### PR TITLE
AGENTS.md: pin gh default repo to the fork after cloning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,17 @@ If work is duplicate/trivial busywork, **do not proceed**. Return a short explan
 
 - **Never use system `python3` or bare `pip`/`pip install`.** All Python commands must go through `uv` and `.venv/bin/python`.
 
+### `gh` repo defaults (fork checkouts)
+
+When this fork (`larkinwc/vllm-gfx908`) is cloned with an `upstream` remote pointing at `vllm-project/vllm`, `gh` cannot disambiguate the two and defaults to upstream. Pin the default once per clone or worktree:
+
+```bash
+gh repo set-default larkinwc/vllm-gfx908
+gh repo set-default --view   # verify: should print larkinwc/vllm-gfx908
+```
+
+After this, `gh pr create`, `gh pr list`, `gh issue ...` target the fork by default. The duplicate-work-check commands in §1 keep their explicit `--repo vllm-project/vllm` so they continue to query upstream regardless of the default.
+
 ### Environment setup
 
 ```bash


### PR DESCRIPTION
## Summary

Fork checkouts with both `origin` (`larkinwc/vllm-gfx908`) and `upstream` (`vllm-project/vllm`) remotes cause `gh` to default to upstream, which silently breaks `gh pr create` / `gh pr list` / `gh issue` from the worktree unless `--repo larkinwc/vllm-gfx908` is passed every time. Hit this opening PR #36 — `gh pr create` failed with a misleading `"no commits between"` GraphQL error because it was trying to open the PR against upstream where neither branch exists.

## Change

Adds a short **`gh` repo defaults (fork checkouts)** subsection under §2 Development Workflow with the one-time setup command:

```bash
gh repo set-default larkinwc/vllm-gfx908
gh repo set-default --view   # verify
```

Notes that the duplicate-work-check commands in §1 keep their explicit `--repo vllm-project/vllm` so they continue to query upstream regardless of the default.

## Stats

```
 AGENTS.md | 11 +++++++++++
 1 file changed, 11 insertions(+)
```

AGENTS.md grows 127 → 138 lines; still under the 200-line budget set by `docs/contributing/editing-agent-instructions.md`.

## Verification against editing-agent-instructions.md checklist

- [x] **Non-obvious?** Yes — the agent (and presumably any new contributor) hits the misleading `"no commits between"` error from `gh pr create` and has no way to know it's a remote-disambiguation issue. The fix (`gh repo set-default`) is undocumented in this repo today.
- [x] **No conflicts?** Searched `AGENTS.md` and `docs/contributing/`; nothing else mentions `gh` repo defaults.
- [x] **Right file?** Project-wide (any agent in any worktree of this fork hits it), so `AGENTS.md` not a domain guide.
- [x] **Offset the addition?** Not strictly required (well under budget). Did not prune to keep the change minimal and reviewable.
- [x] **Under budget?** 138 / 200 lines.
- [x] **No hardcoded paths?** Only command names — `gh repo set-default` is the stable `gh` CLI command, not a file path.
- [x] **Tested?** Verified `gh repo set-default larkinwc/vllm-gfx908` then `gh pr list` returns this fork's PRs (not upstream's). Used exactly this flow to open PR #36 after the initial routing failure.

## Scope

Doc-only PR on the `vllm-gfx908` fork's `mi100-fixes` branch. No code, config, kernel, or test changes. AI assistance was used to draft the wording; human submitter reviews the rendered diff before merge.