### PR TITLE
gfx900 (Vega10/V340) inference support + decode perf (dense 8.2x, MoE 3.2x)

### DIFF
--- a/BENCH_DECODE_PROFILE.md
+++ b/BENCH_DECODE_PROFILE.md
@@ -1,0 +1,67 @@
+# Decode-step profile — gfx900 TP4, FP16 Qwen3.5-9B (issue #56)
+
+torch profiler over a clean 127-step decode-only window (TP4, one socket, eager,
+bs=1). Per-rank GPU kernel time bucketed by class. This **corrects** the earlier
+assumption (carried in older PERF_GFX900 notes) that decode was "RCCL all-reduce +
+GDN kernel" bound.
+
+## Result — where the 152.5 ms/step actually goes
+
+| Component | ms/step | % of wall | % of GPU-busy |
+|---|---:|---:|---:|
+| **GEMM (M=1, rocBLAS `Cijk_..MT64x64x4`, padded)** | **65.9** | **43%** | **88%** |
+| **GPU-idle / launch-dispatch gap** | **77.9** | **51%** | — |
+| RCCL all-reduce (`ncclDevKernel` + `vllm::all_reduce`) | 3.1 | 2% | 4% |
+| elementwise / copy | 1.9 | 1.3% | 2.6% |
+| GDN linear-attn (fused_recurrent + conv + norm) | 0.4 | 0.3% | 0.5% |
+| RMSNorm | 0.2 | 0.1% | 0.3% |
+| Full attention (`unified_attention`) | 0.2 | 0.1% | 0.2% |
+| SiLU/act | 0.1 | 0.1% | 0.2% |
+
+GPU-busy/step = 74.6 ms; wall/step = 152.5 ms → **51% of every decode step the GPU
+is idle**, waiting on host-side per-kernel dispatch (eager mode).
+
+## Two real levers (both different from the old assumption)
+
+### 1. Padded M=1 GEMMs — 43% of wall, running at 20% of the bandwidth roofline
+The decode matmuls go through rocBLAS `Cijk_Alik_Bljk_HHS_BH_MT64x64x4` — a
+**64×64 macrotile** kernel. A 1-row GEMV is padded to 64 rows, so ~63/64 of the
+issued work is waste. Bandwidth floor for the per-GPU weight read (4.83 GB / 365
+GB/s) is **13.2 ms/step**, but we spend **65.9 ms** → only **20% of roofline**, the
+gap being padding overhead, not bandwidth.
+
+This is exactly the failure mode our int4 GEMV (#57) fixed for the MLP by replacing
+`tl.dot` with a real M≤8 vector GEMV. The profile says the same fix applied to the
+**remaining FP16 GEMMs** is the single highest-value kernel work:
+- **lm_head** (#59): vocab 248320×4096, FP16, every token — biggest single GEMM.
+- **attention / linear-attn projections** (#61): q/k/v/o + GDN in/out projections,
+  left in FP16 even under AWQ.
+
+A general **FP16 M≤8 GEMV** (not just int4) would cut into the 43% directly.
+
+### 2. The 51% GPU-idle dispatch gap
+Over half the step is GPU idle between launches. This is host dispatch overhead in
+eager mode. Tension to resolve: HIP CUDA graphs gave **zero** decode speedup in our
+earlier A/B (PERF_GFX900 § graphs) despite this large gap — likely because the
+GDN/FLA Triton kernels can't be captured (mode=NONE forced) so the captured region
+doesn't cover the hot path, or the gap is inter-kernel host latency the partial
+capture didn't remove. Worth a focused re-test: which kernels actually sit inside
+the idle gap, and whether fewer/fused launches (combo kernels, reduced op count)
+shrink it. Lower-risk than it sounds — it's a measurement question first.
+
+## Demoted (do NOT build these)
+- **Full-attention decode kernel (#60)**: 0.2 ms/step (0.1%). Not worth it. Close.
+- **RCCL split / comm tuning (part of #56)**: 3.1 ms/step (2%). Not the bottleneck.
+- **GDN decode kernel**: 0.4 ms/step. Already fine (uses fused_recurrent, 0 tl.dot).
+
+## Re-ranked candidate list (by measured payoff)
+1. **FP16 / int GEMV for lm_head (#59)** — biggest single padded GEMM, certain win.
+2. **GEMV for attn + GDN projections (#61)** — the rest of the 43%.
+3. **Investigate the 51% dispatch gap** — measurement first; potential large win but
+   uncertain (graphs already failed once).
+4. ~~Full-attention kernel (#60)~~ — close, negligible.
+5. ~~RCCL tuning~~ — negligible.
+
+## Repro
+`bench_scripts/prof_decode.py` (writes torch traces to ~/decode_prof),
+`bench_scripts/parse_trace.py` (buckets GPU kernel time by class).

--- a/BENCH_GFX900.md
+++ b/BENCH_GFX900.md
@@ -1,0 +1,89 @@
+# BENCH — FP16 Qwen3.5-9B (gfx900 / Vega10 / Radeon Pro V340)
+
+This document is the gfx900 counterpart to the MI100 (`gfx908`) quant-kernel
+benchmark docs. Because gfx900 (Vega10) has **no MFMA matrix cores**, the
+INT8 (w8a8) and W4A16 quant kernels used in the MI100 grid do not run on this
+arch; this grid therefore benchmarks the **FP16** model. It follows the same
+methodology: `vllm bench serve`, server + `--max-concurrency`, reporting output
+tok/s plus TTFT/TPOT p50/p99.
+
+## Hardware / software manifest
+
+| | |
+|---|---|
+| Host | `tyangpu1`, 8× AMD Radeon Pro V340 (= 16× gfx900, 8 GB VRAM each), dual Xeon E5-2640 v3 |
+| OS | Ubuntu 24.04 |
+| ROCm | 7.2.4 |
+| PyTorch | 2.12.0+rocm7.2 |
+| Triton | 3.7.0 (custom `triton-gfx900` fork: dedicated GFX900 ISA family) |
+| RCCL | custom build `--amdgpu_targets gfx900` |
+| vLLM | 0.1.dev1+g07032c7ba (this fork, `gfx900-support`) |
+| Model | `Qwen/Qwen3.5-9B` (hybrid Gated DeltaNet + full attention, BF16→FP16) |
+| Attention backend | `TRITON_ATTN` (forced on gfx900; no MFMA paged-attn) |
+| All-reduce | `PYNCCL` over custom gfx900 RCCL (XGMI custom-AR disabled — Vega10 has no XGMI) |
+
+## Run configuration (uniform across all cells)
+
+```
+dtype=float16            # gfx900 has no native BF16
+enforce_eager=True       # no CUDA/HIP graphs
+language_model_only=True # skip vision encoder (text-only)
+max_model_len=4096
+gpu_memory_utilization=0.90
+seed=42, request_rate=inf
+num_prompts = 8 * concurrency
+percentile_metrics = ttft,tpot,itl,e2el @ p50,p99
+```
+
+- **synthetic**: `--dataset-name random --random-input-len 1024 --random-output-len 256 --ignore-eos`
+- **coding**: `--dataset-name sharegpt` (ShareGPT V3, conversational; variable output length, EOS honored)
+- **TP=8** uses GPUs 0-7 (a single CPU socket / NUMA node — keeps the tensor-parallel
+  all-reduce off the ~0.26 GB/s cross-socket QPI link).
+- **TP=4** uses GPUs 0-3.
+
+> First-run note: Triton autotunes/JIT-compiles ~290 GDN/FLA kernels on the
+> first server start of each TP shape (the TP=8 set was already warm from a
+> prior run; the TP=4 server cold-compiled its shard shapes, taking ~10 min to
+> become ready). Kernels are disk-cached, so subsequent starts are fast.
+
+## Grid results (8 cells)
+
+Output tok/s is per-stream summed across in-flight requests. TTFT/TPOT are
+per-request p50/p99.
+
+| TP | c | Workload | Out tok/s | Total tok/s | Req/s | TTFT p50 (ms) | TTFT p99 (ms) | TPOT p50 (ms) | TPOT p99 (ms) |
+|---:|--:|----------|----------:|------------:|------:|--------------:|--------------:|--------------:|--------------:|
+| 8 | 1 | synthetic | 7.94 | 39.70 | 0.031 | 823.0 | 1260.8 | 120.41 | 141.44 |
+| 8 | 1 | coding | 6.00 | 8.51 | 0.018 | 231.6 | 633.0 | 175.34 | 184.26 |
+| 8 | 4 | synthetic | 19.54 | 97.72 | 0.076 | 3394.2 | 5133.5 | 194.07 | 208.69 |
+| 8 | 4 | coding | 20.50 | 45.10 | 0.093 | 791.3 | 1778.4 | 190.87 | 214.18 |
+| 4 | 1 | synthetic | 4.58 | 22.90 | 0.018 | 1953.0 | 3295.8 | 198.68 | 292.90 |
+| 4 | 1 | coding | 3.68 | 5.21 | 0.011 | 497.4 | 1392.2 | 273.59 | 275.35 |
+| 4 | 4 | synthetic | 12.23 | 61.13 | 0.048 | 5761.5 | 8850.8 | 309.45 | 343.46 |
+| 4 | 4 | coding | 13.58 | 29.96 | 0.062 | 1445.3 | 3115.0 | 281.92 | 322.00 |
+
+## Observations
+
+- **Concurrency scales throughput**: c=1→c=4 gives ~2.5–3.4× output tok/s
+  (TP8 synthetic 7.94→19.54 = 2.46×; TP8 coding 6.00→20.50 = 3.42×), at the
+  cost of higher TTFT (queueing) — the expected batching trade-off.
+- **TP=8 vs TP=4**: doubling GPUs improves single-stream output tok/s ~1.6–1.7×
+  (synthetic c1 4.58→7.94; coding c1 3.68→6.00) and roughly halves TPOT
+  (synthetic c1 198.7→120.4 ms). Sub-linear because TP adds an all-reduce per
+  layer over PCIe (no XGMI on Vega10) and the GDN recurrence is partly serial.
+- **TPOT is the headline cost of no MFMA**: ~120 ms/token best case (TP8 c1).
+  FP16 GEMMs run on the VALU path instead of matrix cores, so decode is compute-
+  bound. This is the fundamental gfx900 ceiling; the MI100 (gfx908) numbers in
+  the sibling docs are far faster precisely because of MFMA + (there) quant.
+- **coding (ShareGPT) vs synthetic**: lower total tok/s because outputs are
+  shorter / EOS-terminated and prompt lengths vary, but per-request TTFT is
+  lower at c=1 (shorter prompts than the fixed 1024-token synthetic input).
+
+## Reproduce
+
+Harness: `~/gpubench/bench_gfx900/` on `tyangpu1`. Per-cell raw JSON +
+`vllm bench serve` logs are saved alongside. Re-run:
+
+```
+/tmp/gfx900_bench.sh   # starts a TP=8 then TP=4 server, runs the 4 cells each
+```

--- a/BENCH_GFX900.md
+++ b/BENCH_GFX900.md
@@ -87,3 +87,89 @@ Harness: `~/gpubench/bench_gfx900/` on `tyangpu1`. Per-cell raw JSON +
 ```
 /tmp/gfx900_bench.sh   # starts a TP=8 then TP=4 server, runs the 4 cells each
 ```
+
+---
+
+# Pipeline-parallel grid (TP2 × PP{2,4})
+
+Motivation: tensor parallelism issues an all-reduce on *every* layer, so it is
+very sensitive to interconnect bandwidth. **Pipeline parallelism** instead only
+passes the layer activations point-to-point between adjacent stages, so it
+tolerates a slow link far better. On this box the cross-socket QPI link is only
+~0.26 GB/s (a hard Xeon E5 v3 limit), so all cells here are kept **within
+socket0 (GPUs 0-7)** to make a clean apples-to-apples comparison against the TP
+grid above. The two layouts use the same GPU counts as the TP cells:
+
+- **TP2×PP2 = 4 GPUs** (GPUs 0-3) — compare to **TP4**
+- **TP2×PP4 = 8 GPUs** (GPUs 0-7) — compare to **TP8**
+
+Same run config as the TP grid (FP16, enforce_eager, language_model_only,
+max_model_len=4096, gpu_util=0.90, num_prompts=8×c, synthetic=random 1024/256
+`--ignore-eos`, coding=ShareGPT).
+
+> **Required fix for PP on gfx900:** the V1 *async-scheduling* path has the last
+> PP rank broadcast its sampled token IDs back to rank 0 via a raw
+> `torch.distributed.broadcast` (`gpu_model_runner.py:_pp_broadcast_prev_sampled_token_ids`).
+> On our custom gfx900 RCCL this broadcast throws `unhandled cuda error`, killing
+> the engine (`EngineDeadError`) — *only* on the server's async path; the offline
+> `LLM.generate` path worked fine. Running the server with **`--no-async-scheduling`**
+> skips that broadcast and PP runs cleanly. (Offline `LLM(...)` does not need the
+> flag.)
+
+## Results (8 cells)
+
+| Layout | GPUs | c | Workload | Out tok/s | Total tok/s | Req/s | TTFT p50 (ms) | TTFT p99 (ms) | TPOT p50 (ms) | TPOT p99 (ms) |
+|--------|-----:|--:|----------|----------:|------------:|------:|--------------:|--------------:|--------------:|--------------:|
+| TP2xPP4 | 8 | 1 | synthetic | 6.95 | 34.73 | 0.027 | 2180.9 | 4943.8 | 133.70 | 141.11 |
+| TP2xPP4 | 8 | 1 | coding | 7.42 | 10.52 | 0.022 | 267.9 | 1568.5 | 133.74 | 134.12 |
+| TP2xPP4 | 8 | 4 | synthetic | 22.87 | 114.37 | 0.089 | 4638.6 | 7971.0 | 157.96 | 167.02 |
+| TP2xPP4 | 8 | 4 | coding | 25.69 | 54.94 | 0.111 | 1170.0 | 2141.8 | 140.61 | 154.73 |
+| TP2xPP2 | 4 | 1 | synthetic | 6.81 | 34.04 | 0.027 | 2289.1 | 2981.2 | 137.93 | 141.67 |
+| TP2xPP2 | 4 | 1 | coding | 6.99 | 9.91 | 0.021 | 281.2 | 1622.8 | 142.72 | 143.46 |
+| TP2xPP2 | 4 | 4 | synthetic | 18.14 | 90.68 | 0.071 | 6533.2 | 9623.7 | 186.10 | 273.54 |
+| TP2xPP2 | 4 | 4 | coding | 23.69 | 51.72 | 0.106 | 1238.5 | 2566.0 | 156.15 | 198.46 |
+
+## TP vs PP head-to-head (same GPU count, same socket)
+
+Output tok/s:
+
+| GPUs | c | Workload | TP (pure) | TP2×PP | Winner |
+|-----:|--:|----------|----------:|-------:|--------|
+| 4 | 1 | synthetic | 4.58 | 6.81 | **PP +49%** |
+| 4 | 1 | coding | 3.68 | 6.99 | **PP +90%** |
+| 4 | 4 | synthetic | 12.23 | 18.14 | **PP +48%** |
+| 4 | 4 | coding | 13.58 | 23.69 | **PP +74%** |
+| 8 | 1 | synthetic | 7.94 | 6.95 | TP +14% |
+| 8 | 1 | coding | 6.00 | 7.42 | **PP +24%** |
+| 8 | 4 | synthetic | 19.54 | 22.87 | **PP +17%** |
+| 8 | 4 | coding | 20.50 | 25.69 | **PP +25%** |
+
+## Observations
+
+- **At 4 GPUs, TP2×PP2 beats pure TP4 across the board (+48% to +90%).** Pure
+  TP4 splits each GEMM 4 ways, so each gfx900 does a small, inefficient slice of
+  a matrix-core-less FP16 GEMM and then pays a 4-way all-reduce per layer over
+  PCIe. TP2×PP2 keeps GEMMs at a 2-way split (better VALU utilization) and
+  replaces the wide all-reduce with cheap stage-to-stage activation hand-offs.
+- **At 8 GPUs, TP2×PP4 wins on 3 of 4 cells**, losing only single-stream
+  synthetic (where PP's pipeline can't fill at c=1, so its 4 serial stages add
+  latency without a throughput payoff). With any concurrency (c=4) the pipeline
+  fills and PP pulls ahead (+17–25%).
+- **TPOT is markedly steadier under PP**: TP2×PP4 holds ~134–158 ms across all
+  cells, whereas pure TP8 ranged 120–194 ms and pure TP4 198–309 ms. Less
+  per-layer collective traffic means less variance.
+- **TTFT is higher for PP at c≥1 synthetic** (long 1024-token prefill must walk
+  all pipeline stages before the first token), the expected PP latency tax. For
+  the shorter-prompt coding workload TTFT stays low.
+- **Takeaway for this box**: with no XGMI and weak PCIe/QPI, the lowest-TP /
+  higher-PP layout that still fits the model is the throughput sweet spot.
+  TP2×PP4 (8 GPUs, one socket) is the best concurrent-serving config measured,
+  and notably **PP is the layout that makes spanning both sockets viable** since
+  it only needs point-to-point sends across the slow QPI link rather than a
+  bandwidth-hungry all-reduce.
+
+## Reproduce (PP grid)
+
+```
+/tmp/gfx900_bench_pp.sh   # TP2xPP4 then TP2xPP2 server (note --no-async-scheduling), 4 cells each
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
 set(PYTHON_SUPPORTED_VERSIONS "3.10" "3.11" "3.12" "3.13" "3.14")
 
 # Supported AMD GPU architectures.
-set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
+set(HIP_SUPPORTED_ARCHS "gfx900;gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
 
 # ROCm installation prefix. Default to /opt/rocm but allow override via
 # -DROCM_PATH=/your/rocm/path when invoking cmake.

--- a/GFX900_RECOMMENDED.md
+++ b/GFX900_RECOMMENDED.md
@@ -1,0 +1,120 @@
+# Recommended inference setup — gfx900 (V340 / Vega10), Qwen3.5-9B
+
+This is the **prescriptive "how to run"** companion to the deep-dive in
+`PERF_GFX900.md`. It distills everything we measured on this box (8× Radeon Pro
+V340 = 16× gfx900 dies, ~8 GiB each, wave64, no MFMA, ~365 GB/s HBM/die) into the
+single most performant, validated path and the knobs that actually move the needle.
+
+---
+
+## TL;DR — the best path
+
+**For maximum capability per GPU (the recommended default):**
+
+```bash
+# int4 weights (custom gfx900 GEMV) + TurboQuant KV cache, on one socket.
+HIP_VISIBLE_DEVICES=0,1,2,3 VLLM_USE_V1=1 \
+vllm serve QuantTrio/Qwen3.5-9B-AWQ \
+  --tensor-parallel-size 4 \
+  --dtype float16 \
+  --kv-cache-dtype turboquant_k8v4 \
+  --enforce-eager \
+  --gpu-memory-utilization 0.90 \
+  --language-model-only \
+  --max-model-len 16384
+```
+
+This stacks the two gfx900 wins that we built and validated:
+
+| Layer | Mechanism | Win | Issue |
+|---|---|---|---|
+| **Weights** | int4 AWQ via hand-written gfx900 GEMV (sidesteps MFMA-less `tl.dot`) | **~1.5× decode vs FP16 on half the GPUs** | #57 |
+| **KV cache** | TurboQuant `turboquant_k8v4` (FP8 keys + 4-bit values) | **2.34× context/concurrency per VRAM, ~0 decode cost** | #62 |
+
+Both verified active together (coherent output; decode 9.97 tok/s ≈ standalone AWQ
+10.46). They are orthogonal and compose cleanly.
+
+---
+
+## Why these specific choices (each is measured, not assumed)
+
+### 1. `--dtype float16` (never bf16)
+gfx900 has no usable bf16 path for this model. FP16 is mandatory.
+
+### 2. `--enforce-eager` (always)
+HIP CUDA graphs **work** on gfx900 but give **zero decode speedup** — the decode
+floor is per-step all-reduce + GDN-kernel overhead, not launch overhead. Graphs
+also force Inductor (crashes on ROCm). So eager is the correct default, not a
+workaround. (Full A/B in `PERF_GFX900.md` § HIP CUDA-graph investigation.)
+
+### 3. `--kv-cache-dtype turboquant_k8v4` (FP8 keys — NOT a K-quant preset)
+Qwen3 family is **"quirky-K"**: key-side quantization is catastrophic
+(`tq2k` = +150% PPL on qwen3:8b — output destroyed). `k8v4` keeps keys at FP8
+(effectively unquantized) and only compresses values. **Do not** use
+`turboquant_3bit_nc` / other aggressive-K presets on Qwen3.5.
+
+### 4. int4 weights via AWQ (`QuantTrio/Qwen3.5-9B-AWQ`)
+Stock INT4 on gfx900 is *slower* than FP16 because the Triton path dequants then
+runs `tl.dot` through a padded FP32 GEMM (no MFMA). Our hand-written M≤8 GEMV
+(#57) sidesteps `tl.dot` entirely → 2.8–4.0× the MLP matmuls vs FP16, 10–15× vs
+the stock int4 path. It auto-dispatches when `on_gfx900()` and `group_size ∈
+{32,64,128}` and `M≤8`; high-batch falls back to FP16 automatically.
+
+### 5. Layout: TP within one socket
+GPUs 0–7 = socket 0, 8–15 = socket 1. **Cross-socket P2P is 0.26 GB/s** (Xeon
+E5 v3 QPI HW limit) vs ~8 GB/s intra-socket. **Never span sockets in one TP/PP
+group.** Use `HIP_VISIBLE_DEVICES=0,1,2,3` (or 0–7) for socket 0.
+
+---
+
+## Choosing a layout for your workload
+
+Decode does **not** scale with bandwidth here (it sits at ~5–9% of the HBM
+roofline, gated by per-token all-reduce + GDN kernel latency). So:
+
+| Goal | Recommended layout | Why |
+|---|---|---|
+| **Single-stream latency** | TP4 (or TP2) one socket | TP8 only ~1.7× TP4 — diminishing |
+| **Aggregate throughput** | **batch/concurrency** is the only real lever — c1→c4 gives 2.5–3.4× | decode per-step time is ~flat with batch up to ~64–96 |
+| **Decode-optimized serving** | **TP2×PP4** within one socket | PP removes the per-layer all-reduce that dominates decode latency; best aggregate we measured (~26 tok/s, c4 coding) |
+| **Max context per VRAM** | add `turboquant_k8v4` | 2.34× KV capacity |
+
+**Realistic planning numbers** (not the parallel spec): ~24 TFLOPS/socket usable
+prefill; decode in the **tens of tok/s aggregate**. Prefill scales well (~70%
+efficiency, TP-friendly); decode is the bottleneck.
+
+---
+
+## VRAM ceiling — important
+
+Each die is **~8 GiB**. AWQ(TP2) + 16k-token KV **OOMs at batch>1**. The
+compression lets you push context/concurrency further per GiB, but does not remove
+the per-die cap. For long context **and** batching with the AWQ model, use **TP4**
+(more aggregate VRAM) or a shorter `--max-model-len`.
+
+---
+
+## Model facts that drive all of the above (Qwen3.5-9B)
+- 9.65B params (19.3 GB FP16), 32 layers, hidden 4096, vocab 248320, 16 attn / 4 KV heads.
+- **Hybrid attention**: `full_attention_interval=4` → only **8/32 layers** are full
+  attention with a KV cache; the rest are **GDN linear-attn** (no KV cache). So the
+  KV footprint is already small — TurboQuant's 2.34× applies to that 1/4 of layers.
+- GDN **decode** uses `fused_recurrent` (0 `tl.dot`) — already gfx900-appropriate.
+  The `tl.dot`-heavy FLA ops are **prefill-only**.
+- Dense hybrid, **not** MoE. Use `--language-model-only`.
+
+---
+
+## Operational notes
+- **Cold start is slow** (~647s) due to GDN/FLA Triton autotune + TurboQuant
+  centroid init; warm is ~60s. Autotune results cache.
+- `amdgpu.reset_method=2` (mode1) is set so a GPU hang auto-recovers instead of
+  needing a reboot. (`/etc/modprobe.d/amdgpu-reset.conf`; reversible.)
+- Pure-Triton TurboQuant kernels run on wave64 — the wave32 `__shfl_sync` blocker
+  that stops the llama.cpp HIP port does **not** apply to us.
+
+## Repro / benchmarks
+- `bench_scripts/tq_measure.py {auto|turboquant_k8v4}` — KV size + decode tok/s.
+- `bench_scripts/combo_dec.py turboquant_k8v4` — int4 weights + TQ KV together.
+- `bench_scripts/batch_sweep.py` — concurrency scaling.
+- Deep dives: `PERF_GFX900.md`, `BENCH_GFX900.md`, `GFX900_SETUP.md`.

--- a/GFX900_RECOMMENDED.md
+++ b/GFX900_RECOMMENDED.md
@@ -24,11 +24,12 @@ vllm serve QuantTrio/Qwen3.5-9B-AWQ \
   --max-model-len 16384
 ```
 
-This stacks the two gfx900 wins that we built and validated:
+This stacks the gfx900 wins we built and validated (LLMM1 M=1 GEMV is on by default via `VLLM_ROCM_USE_SKINNY_GEMM=1`):
 
 | Layer | Mechanism | Win | Issue |
 |---|---|---|---|
 | **Weights** | int4 AWQ via hand-written gfx900 GEMV (sidesteps MFMA-less `tl.dot`) | **~1.5× decode vs FP16 on half the GPUs** | #57 |
+| **All M=1 FP16 GEMMs** | LLMM1 skinny GEMV (lm_head + qkv/o/gate_up projections) | **2.2× FP16 decode (150→67 ms/step)** | #59 |
 | **KV cache** | TurboQuant `turboquant_k8v4` (FP8 keys + 4-bit values) | **2.34× context/concurrency per VRAM, ~0 decode cost** | #62 |
 
 Both verified active together (coherent output; decode 9.97 tok/s ≈ standalone AWQ

--- a/GFX900_RECOMMENDED.md
+++ b/GFX900_RECOMMENDED.md
@@ -53,6 +53,8 @@ Qwen3 family is **"quirky-K"**: key-side quantization is catastrophic
 (effectively unquantized) and only compresses values. **Do not** use
 `turboquant_3bit_nc` / other aggressive-K presets on Qwen3.5.
 
+**Quality is measured, not assumed.** WikiText-2 reference perplexity (12,264 tokens, 24x512 windows, prefill logprobs), Qwen3.5-9B TP4: FP16 = 9.8885, turboquant_k8v4 = 9.8879 (**-0.006%, lossless within noise**). Safe production default: 2.34x KV capacity at zero measurable quality cost. (PPL measures quantizer reconstruction quality, not long-decode drift.)
+
 ### 4. int4 weights via AWQ (`QuantTrio/Qwen3.5-9B-AWQ`)
 Stock INT4 on gfx900 is *slower* than FP16 because the Triton path dequants then
 runs `tl.dot` through a padded FP32 GEMM (no MFMA). Our hand-written M≤8 GEMV

--- a/GFX900_RECOMMENDED.md
+++ b/GFX900_RECOMMENDED.md
@@ -18,10 +18,13 @@ vllm serve QuantTrio/Qwen3.5-9B-AWQ \
   --tensor-parallel-size 4 \
   --dtype float16 \
   --kv-cache-dtype turboquant_k8v4 \
-  --enforce-eager \
   --gpu-memory-utilization 0.90 \
   --language-model-only \
-  --max-model-len 16384
+  --max-model-len 16384 \
+  --max-num-seqs 32 \
+  --compilation-config '{"mode":0,"cudagraph_mode":[2,0],"cudagraph_capture_sizes":[1]}'
+# NOTE: use CUDA graphs (do NOT pass --enforce-eager) — 3.6x decode on gfx900 (#63).
+# --max-num-seqs must be <= the model's Mamba/GDN cache-block budget or capture fails.
 ```
 
 This stacks the gfx900 wins we built and validated (LLMM1 M=1 GEMV is on by default via `VLLM_ROCM_USE_SKINNY_GEMM=1`):
@@ -30,6 +33,7 @@ This stacks the gfx900 wins we built and validated (LLMM1 M=1 GEMV is on by defa
 |---|---|---|---|
 | **Weights** | int4 AWQ via hand-written gfx900 GEMV (sidesteps MFMA-less `tl.dot`) | **~1.5× decode vs FP16 on half the GPUs** | #57 |
 | **All M=1 FP16 GEMMs** | LLMM1 skinny GEMV (lm_head + qkv/o/gate_up projections) | **2.2× FP16 decode (150→67 ms/step)** | #59 |
+| **Per-step dispatch** | HIP CUDA graphs (FULL_DECODE_ONLY) once GPU-busy is small | **3.6× decode on top of LLMM1** | #63 |
 | **KV cache** | TurboQuant `turboquant_k8v4` (FP8 keys + 4-bit values) | **2.34× context/concurrency per VRAM, ~0 decode cost** | #62 |
 
 Both verified active together (coherent output; decode 9.97 tok/s ≈ standalone AWQ
@@ -42,11 +46,14 @@ Both verified active together (coherent output; decode 9.97 tok/s ≈ standalone
 ### 1. `--dtype float16` (never bf16)
 gfx900 has no usable bf16 path for this model. FP16 is mandatory.
 
-### 2. `--enforce-eager` (always)
-HIP CUDA graphs **work** on gfx900 but give **zero decode speedup** — the decode
-floor is per-step all-reduce + GDN-kernel overhead, not launch overhead. Graphs
-also force Inductor (crashes on ROCm). So eager is the correct default, not a
-workaround. (Full A/B in `PERF_GFX900.md` § HIP CUDA-graph investigation.)
+### 2. CUDA graphs ON (do NOT use `--enforce-eager`) — updated, see #63
+HIP CUDA graphs give a **3.6× decode speedup** on gfx900 (eager 67 → graph 18.4
+ms/tok) once the LLMM1 GEMV (#59) shrinks GPU-busy time so the host dispatch gap
+(59% of the step) dominates. Use `mode=NONE` (Inductor/compile stays off — it
+crashes on ROCm) + `cudagraph_mode=FULL_DECODE_ONLY` + `capture_sizes=[1]`.
+**Constraint:** Qwen3.5 is hybrid (Mamba/GDN); `--max-num-seqs` must be ≤ the
+available Mamba cache blocks or capture fails. (Earlier docs said eager was best —
+that was true before LLMM1; the bottleneck moved. See `PERF_GFX900.md` § #63.)
 
 ### 3. `--kv-cache-dtype turboquant_k8v4` (FP8 keys — NOT a K-quant preset)
 Qwen3 family is **"quirky-K"**: key-side quantization is catastrophic

--- a/GFX900_RECOMMENDED.md
+++ b/GFX900_RECOMMENDED.md
@@ -1,4 +1,7 @@
-# Recommended inference setup — gfx900 (V340 / Vega10), Qwen3.5-9B
+# Recommended inference setup — gfx900 (V340 / Vega10)
+
+Covers two validated models on this box: **Qwen3.5-9B** (dense hybrid) and
+**Qwen3-Coder-Next-AWQ-4bit** (sparse MoE, see section near the end).
 
 This is the **prescriptive "how to run"** companion to the deep-dive in
 `PERF_GFX900.md`. It distills everything we measured on this box (8× Radeon Pro
@@ -122,6 +125,90 @@ the per-die cap. For long context **and** batching with the AWQ model, use **TP4
   needing a reboot. (`/etc/modprobe.d/amdgpu-reset.conf`; reversible.)
 - Pure-Triton TurboQuant kernels run on wave64 — the wave32 `__shfl_sync` blocker
   that stops the llama.cpp HIP port does **not** apply to us.
+
+---
+
+## Second model: Qwen3-Coder-Next (sparse MoE, 80B total / 3B active)
+
+`bullpoint/Qwen3-Coder-Next-AWQ-4bit` runs well on gfx900. It is a **hybrid
+sparse-MoE**: 48 layers of `3×(GatedDeltaNet→MoE) + 1×(GatedAttn→MoE)`, 512
+experts (10 active + 1 shared) at expert-intermediate 512, AWQ 4-bit group_size 32
+(compressed-tensors / pack-quantized). ~45 GB of weights. Gated-attn here is
+head_dim 256, 16 Q / 2 KV heads (different from Qwen3.5-9B).
+
+**Recommended run (TP4×PP2 on one socket, graphs, optional TurboQuant):**
+
+```bash
+# 8 dies, one socket. TP stays at the efficient 4; shallow PP2 holds the ~45 GB.
+HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 VLLM_USE_V1=1 \
+vllm serve bullpoint/Qwen3-Coder-Next-AWQ-4bit \
+  --tensor-parallel-size 4 \
+  --pipeline-parallel-size 2 \
+  --no-async-scheduling \
+  --dtype float16 \
+  --gpu-memory-utilization 0.92 \
+  --max-model-len 32768 \
+  --max-num-seqs 32 \
+  --trust-remote-code \
+  --kv-cache-dtype turboquant_k8v4 \
+  --compilation-config '{"mode":0,"cudagraph_mode":[2,0],"cudagraph_capture_sizes":[1,8,16,32]}'
+# PP needs --no-async-scheduling in server mode.
+# Drop --kv-cache-dtype to use FP16 KV (slightly faster single-stream, half the KV capacity).
+```
+
+### Why TP4×PP2 (not TP8)
+Same finding as the dense model: more than TP4 hurts decode (8-way all-reduce +
+tiny per-rank GEMV slices). The ~45 GB of weights do not fit a single-socket TP4
+(8 GiB/die × 4), so we add **shallow PP2** to span 8 dies while keeping each TP
+group at the efficient width of 4. Both TP groups stay inside socket 0 — never
+cross the QPI link (0.26 GB/s).
+
+### Measured decode (bs=1, TP4×PP2)
+| config | tok/s | note |
+|---|---|---|
+| eager | 8.5 | baseline |
+| + CUDA graphs (#63) | 19.3 | 2.3× |
+| + small-m GEMV fix (#65) | **26.8** | **3.2× total** |
+
+The small-m GEMV fix (`shared_expert_gate` is a `Linear[2048→1]`, m=1, which
+missed LLMM1's `m%4==0` gate and fell to a wasteful 64×64 rocBLAS macrotile)
+routes that scalar projection to a fused multiply-reduce. +39% MoE decode; dense
+Qwen3.5-9B is unaffected (the gate is narrow). The MoE expert path itself
+(`fused_moe_kernel_gptq_awq`, Triton, ~177 µs/call on wave64) is healthy and not
+the bottleneck.
+
+### Throughput scales strongly with concurrency
+| c | FP16 KV tok/s | turboquant_k8v4 tok/s |
+|---|---|---|
+| 1 | 26.7 | 23.8 |
+| 8 | 48.3 | 51.7 |
+| 16 | 79.6 | 88.7 |
+| 32 | **113.7** | **114.0** |
+
+**4.3× aggregate from c=1→32.** Concurrency is the real throughput lever (decode
+per-step time is ~flat with batch), exactly as for the dense model.
+
+### TurboQuant on this MoE: throughput-neutral, 2.5× KV capacity
+TurboQuant is the same lossless quirky-K preset (FP8 keys + 4-bit values) and is
+**throughput-neutral** here (table above). Its payoff is **KV-cache capacity**:
+
+| KV dtype | KV cache tokens | Max concurrency @ 32K ctx |
+|---|---|---|
+| auto (FP16) | 62,100 | 1.90× |
+| **turboquant_k8v4** | **156,483** | **4.78×** |
+
+**2.52× more KV capacity** → 4.78× vs 1.90× concurrent 32K-context streams on the
+same VRAM. Use it whenever long context or high concurrency matters; otherwise
+FP16 KV is marginally faster at single-stream. (No code change was needed — the TQ
+backend already uses the gfx900-safe SDPA prefill fallback, since
+`is_flash_attn_varlen_func_available()` is False on this box.)
+
+### Cold start
+~759 s first run (MoE + GDN + TQ Triton autotune), ~156 s warm (autotune caches).
+
+### Repro
+- `bench_scripts/coder_tput.py {auto|turboquant_k8v4}` — concurrency sweep + KV size.
+- `bench_scripts/coder_smoke.py`, `coder_prof.py` — smoke + decode profile.
 
 ## Repro / benchmarks
 - `bench_scripts/tq_measure.py {auto|turboquant_k8v4}` — KV size + decode tok/s.

--- a/GFX900_RECOMMENDED.md
+++ b/GFX900_RECOMMENDED.md
@@ -156,14 +156,30 @@ vllm serve bullpoint/Qwen3-Coder-Next-AWQ-4bit \
 # Drop --kv-cache-dtype to use FP16 KV (slightly faster single-stream, half the KV capacity).
 ```
 
-### Why TP4×PP2 (not TP8)
-Same finding as the dense model: more than TP4 hurts decode (8-way all-reduce +
-tiny per-rank GEMV slices). The ~45 GB of weights do not fit a single-socket TP4
-(8 GiB/die × 4), so we add **shallow PP2** to span 8 dies while keeping each TP
-group at the efficient width of 4. Both TP groups stay inside socket 0 — never
-cross the QPI link (0.26 GB/s).
+### TP4×PP2 vs TP8 — pick by workload
+The ~45 GB of weights do not fit a single-socket TP4 (8 GiB/die × 4), so the two
+viable 8-die layouts are **TP4×PP2** (shallow PP to span 8 dies, TP stays at the
+efficient width 4) and **TP8**. Both stay inside socket 0 (never cross the
+0.26 GB/s QPI link). Clean A/B (graphs, identical settings):
 
-### Measured decode (bs=1, TP4×PP2)
+| Layout | c=1 | c=8 |
+|---|---|---|
+| **TP8** | **33.2** | 42.3 |
+| **TP4×PP2** | 23.2 | **44.9** |
+
+- **Single-stream / latency:** use **TP8** (+43% at c=1). It is one pipeline stage,
+  so it avoids the PP bubble — at bs=1 the decode profile shows TP4×PP2 spends
+  ~80 ms/step waiting for the other PP stage, which costs more than TP8's heavier
+  8-way all-reduce. (TP8 needs gpu_mem ~0.92 for KV headroom; 0.95 OOMs.)
+- **Throughput / concurrent serving:** use **TP4×PP2** — concurrency fills the PP
+  bubble and TP4's cheaper 4-way all-reduce then wins (c≥8), scaling to 114 tok/s
+  at c=32.
+
+(This inverts the dense-model result where TP4 beat TP8: for the MoE the choice is
+TP8 vs TP4×*PP2*, so it is the 8-way-all-reduce penalty vs the PP-bubble penalty,
+and at bs=1 the bubble is the bigger cost. See issue #65.)
+
+### Measured decode progression (bs=1, TP4×PP2)
 | config | tok/s | note |
 |---|---|---|
 | eager | 8.5 | baseline |

--- a/GFX900_SETUP.md
+++ b/GFX900_SETUP.md
@@ -44,9 +44,32 @@ all MFMA/XGMI kernels to portable Triton + rocBLAS + PCIe paths.
 | vLLM csrc | builds | this branch (`PYTORCH_ROCM_ARCH=gfx900`) |
 | **Triton** | **WORKS** | custom `triton-gfx900` fork (Triton v3.7.0 + gfx900 ISA family). See below. |
 
-## STATUS: vLLM RUNS ON gfx900
+## STATUS: Qwen3.5-9B RUNS ON gfx900 (TP=8)
+
+The original goal is achieved. **Qwen3.5-9B** -- a multimodal hybrid model
+(Gated DeltaNet linear-attention + full attention, 32 layers) -- runs across
+**8x gfx900 GPUs** with tensor parallelism, text-only mode:
+
+```
+GPU KV cache size: 368,208 tokens
+'The capital of France is' => ' Paris.\nThe capital of France is Paris...'
+```
+
+Notably the FLA Gated-DeltaNet Triton kernels (`chunk_gated_delta_rule`,
+`causal_conv1d`, `l2norm_fwd`) -- the most advanced kernels in the stack --
+compiled and ran on Vega10 with **zero additional gfx900 fixes** beyond the
+GFX900 ISA family. First run is slow due to Triton autotuning (~130 kernels
+JIT-compiled + disk-cached); subsequent runs reuse the cache.
+
+Run config: `tensor_parallel_size=8, dtype=float16` (gfx900 has no native BF16,
+so cast BF16->FP16), `enforce_eager=True`, `language_model_only=True`,
+`max_model_len=4096`, GPUs 0-7 (single socket -- keeps TP within one NUMA node).
+
+## STATUS: vLLM RUNS ON gfx900 (smaller models)
 
 Validated end-to-end on a Radeon Pro V340 (gfx900:xnack-):
+opt-125m at TP=1/2/4. Multi-GPU all-reduce uses PYNCCL over our custom gfx900
+RCCL (XGMI custom all-reduce is correctly disabled -- Vega10 has no XGMI).
 
 ```
 [rocm.py] Using TRITON_ATTN backend out of potential backends: ['TRITON_ATTN'].

--- a/GFX900_SETUP.md
+++ b/GFX900_SETUP.md
@@ -42,27 +42,45 @@ all MFMA/XGMI kernels to portable Triton + rocBLAS + PCIe paths.
 | PyTorch | works | `torch==2.12.0+rocm7.2` (ABI-matched to system ROCm 7.2.x) |
 | amdsmi | needed | copy `/opt/rocm/share/amd_smi/amdsmi` into site-packages (vLLM platform detection) |
 | vLLM csrc | builds | this branch (`PYTORCH_ROCM_ARCH=gfx900`) |
-| **Triton** | **BLOCKED** | prebuilt Triton MLIR backend rejects gfx900 (`unsupported target: gfx900` in `ConvertWarpPipeline`). Needs Triton built from source with gfx900 re-enabled. See refs. |
+| **Triton** | **WORKS** | custom `triton-gfx900` fork (Triton v3.7.0 + gfx900 ISA family). See below. |
 
-## Triton gfx900 -- the remaining blocker
+## STATUS: vLLM RUNS ON gfx900
 
-vLLM requires Triton for attention and sampling. The prebuilt Triton 3.7.0
-(bundled with torch rocm wheels) fails on gfx900 even for trivial kernels:
+Validated end-to-end on a Radeon Pro V340 (gfx900:xnack-):
 
 ```
-error: unsupported target: gfx900
-note: Pipeline failed while executing [ConvertWarpPipeline]
-RuntimeError: PassManager::run failed
+[rocm.py] Using TRITON_ATTN backend out of potential backends: ['TRITON_ATTN'].
+'The capital of France is' => ' the capital of the French Republic...'
 ```
 
-The underlying LLVM (22.0.0) DOES support gfx900 codegen -- the rejection is in
-Triton's own AMD MLIR passes. Prior art for first-gen GCN/Vega Triton:
+## Triton gfx900 -- SOLVED (custom fork)
 
-- https://github.com/Said-Akbar/triton-gcn5  (explicitly MI25 = gfx900, Triton 3.1.0)
-- https://github.com/nlzy/triton-gfx906  (newer; "mark gfx906 as CDNA, fix permlanex16 intrinsic")
+vLLM requires Triton for attention and sampling. Stock Triton 3.7.0 rejects
+gfx900 even for trivial kernels (`unsupported target: 'gfx900'` because
+`deduceISAFamily()` returns `Unknown`). The underlying LLVM DOES support gfx900
+codegen -- the rejection was purely in Triton's AMD MLIR backend.
 
-Plan: fork one of these as `triton-gfx900`, version-aligned to vLLM's Triton API,
-add gfx900 to the AMD backend passes + LLVM intrinsic selection.
+Fix: a `triton-gfx900` fork based on **triton v3.7.0** (matches our stack),
+adding a dedicated **GFX900 ISA family** (8 + 6 lines):
+
+- `TargetUtils.h`: add `GFX900` to `ISAFamily` enum.
+- `TargetUtils.cpp` `deduceISAFamily`: map gfx900/gfx902 -> `ISAFamily::GFX900`.
+  A *dedicated* family (NOT gfx906's VEGA20) is essential: gfx906 enables V_DOT
+  and DirectToLds that Vega10 lacks -- reusing it crashes with ILLEGAL_INSTRUCTION
+  (the same reason `HSA_OVERRIDE_GFX_VERSION=9.0.6` spoofing failed).
+- `TargetInfo.cpp` `getWarpSize()`: GFX900 is wave64.
+- `TargetInfo.cpp` `warpReduce()`: bail out for GFX900 so it uses the generic
+  `shuffleXor` (ds_swizzle/ds_bpermute) reduction instead of the DPP-broadcast +
+  `permlanex16` path. `permlanex16` is RDNA-only and is illegal on Vega10 -- this
+  was the second blocker after the "unsupported target" gate.
+
+gfx900 thus routes entirely through portable wave64 `ds_swizzle`/`ds_bpermute`
+paths: no MFMA, no V_DOT, no DPP-broadcast, no permlane. Validated kernels:
+trivial add (PASS), softmax cross-lane reduction (PASS), matmul `tl.dot` FMA (PASS).
+
+Build: `TRITON_BUILD_WITH_CCACHE=true pip wheel --no-build-isolation --no-deps .`
+(LLVM is downloaded prebuilt and already supports gfx900 -- only Triton's C++ is
+recompiled). Prior art: Said-Akbar/triton-gcn5 (MI25=gfx900), nlzy/triton-gfx906.
 
 ## Bandwidth / topology notes (this box)
 

--- a/GFX900_SETUP.md
+++ b/GFX900_SETUP.md
@@ -1,0 +1,74 @@
+# vLLM on AMD gfx900 (Vega10: V340 / MI25) -- Work In Progress
+
+This branch (`gfx900-support`) extends the MI100/gfx908 fork to AMD **gfx900**
+(Vega10) GPUs such as the Radeon Pro V340 and Instinct MI25.
+
+## Hardware context
+
+Validated on: 8x AMD Radeon Pro V340 (= 16x gfx900 GPUs, 8GB VRAM each),
+dual Xeon E5-2640 v3, Ubuntu 24.04, ROCm 7.2.4.
+
+## Why gfx900 is a distinct tier
+
+gfx900 is **gfx908 minus key hardware**:
+
+| Feature        | gfx908 (MI100) | gfx900 (Vega10) |
+|----------------|----------------|-----------------|
+| MFMA matrix cores | yes         | **no**          |
+| Native FP8     | no             | no              |
+| XGMI / Infinity Fabric | yes (some) | **no** (PCIe only) |
+
+The fork's custom paged-attention (`csrc/rocm/attention.cu`, 85 MFMA ops),
+skinny GEMMs, CK flash-attn, and quickreduce all assume MFMA and/or XGMI that
+gfx900 lacks. So gfx900 is modeled as a **separate tier** that routes around
+all MFMA/XGMI kernels to portable Triton + rocBLAS + PCIe paths.
+
+## Changes in this branch
+
+- `vllm/platforms/rocm.py`: add `_ON_GFX900` / `on_gfx900()` (NOT in `_ON_GFX9`,
+  so all `if _ON_GFX9:` MFMA paths are skipped automatically).
+- `vllm/platforms/rocm.py`: gfx900 forces the `TRITON_ATTN` attention backend.
+- `CMakeLists.txt`: add `gfx900` to `HIP_SUPPORTED_ARCHS`. The MFMA kernels are
+  guarded by `__HIP__GFX9__` (gfx908/90a/942/950 only), so they compile-guard
+  out for gfx900 automatically.
+
+## Dependency stack status (ROCm 7.2.4)
+
+| Layer | gfx900 status | Fix |
+|-------|---------------|-----|
+| ROCm runtime | works | stock 7.2.4 |
+| rocBLAS | works | copy `*gfx900*` TensileLibrary from system rocBLAS (incl. `TensileLibrary_lazy_gfx900.dat`) into torch bundle |
+| RCCL | needs rebuild | build RCCL (rocm-7.2.x) with `--amdgpu_targets gfx900`; swap into torch/lib |
+| PyTorch | works | `torch==2.12.0+rocm7.2` (ABI-matched to system ROCm 7.2.x) |
+| amdsmi | needed | copy `/opt/rocm/share/amd_smi/amdsmi` into site-packages (vLLM platform detection) |
+| vLLM csrc | builds | this branch (`PYTORCH_ROCM_ARCH=gfx900`) |
+| **Triton** | **BLOCKED** | prebuilt Triton MLIR backend rejects gfx900 (`unsupported target: gfx900` in `ConvertWarpPipeline`). Needs Triton built from source with gfx900 re-enabled. See refs. |
+
+## Triton gfx900 -- the remaining blocker
+
+vLLM requires Triton for attention and sampling. The prebuilt Triton 3.7.0
+(bundled with torch rocm wheels) fails on gfx900 even for trivial kernels:
+
+```
+error: unsupported target: gfx900
+note: Pipeline failed while executing [ConvertWarpPipeline]
+RuntimeError: PassManager::run failed
+```
+
+The underlying LLVM (22.0.0) DOES support gfx900 codegen -- the rejection is in
+Triton's own AMD MLIR passes. Prior art for first-gen GCN/Vega Triton:
+
+- https://github.com/Said-Akbar/triton-gcn5  (explicitly MI25 = gfx900, Triton 3.1.0)
+- https://github.com/nlzy/triton-gfx906  (newer; "mark gfx906 as CDNA, fix permlanex16 intrinsic")
+
+Plan: fork one of these as `triton-gfx900`, version-aligned to vLLM's Triton API,
+add gfx900 to the AMD backend passes + LLVM intrinsic selection.
+
+## Bandwidth / topology notes (this box)
+
+- All GPUs PCIe 3.0 x16. Large-BAR already enabled (full 8G VRAM BAR).
+- 2 NUMA domains (GPU 0-7 socket0, 8-15 socket1).
+- Intra-socket P2P D2D ~8 GB/s; **cross-socket P2P ~0.26 GB/s** (Xeon E5 v3 QPI
+  hardware limit -- not fixable via IOMMU/BIOS). Keep TP groups within a socket.
+- NUMA-aware host pinned memory restores +66% H2D on socket1 GPUs.
+- Recommended layout for 16 GPUs: **TP=8 within a socket, PP=2 across sockets**.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -553,3 +553,27 @@ TurboQuant centroid init. `enforce_eager=True` as always on gfx900.
 
 Repro: `bench_scripts/tq_measure.py {auto|turboquant_k8v4}` (TP4, 16k ctx; prints
 GPU KV cache size + decode tok/s at B=1/8).
+
+### Composing with the int4 weight GEMV (#57)
+
+TurboQuant (KV-cache quant) and the gfx900 int4 weight GEMV (#57) are orthogonal —
+they live in different parts of the stack (attention-backend KV path vs the
+`triton_w4a16_gemm` weight-matmul path) and share no code. They stack cleanly.
+
+Verified on `QuantTrio/Qwen3.5-9B-AWQ` (int4 MLP weights, exercises the gfx900 GEMV)
+loaded with `--kv-cache-dtype turboquant_k8v4`, TP2, gfx900:
+- Both paths active simultaneously: log shows `quantization=awq_marlin` +
+  `_w4a16_gemv_splitk_kernel` JIT (our GEMV) **and** `Overriding with TURBOQUANT`.
+- Coherent output ("...is Paris").
+- Short-ctx decode B=1: **9.97 tok/s (100.3 ms/tok)** — statistically identical to
+  standalone AWQ int4 (10.46 tok/s / 95.6 ms; ~5% delta is JIT-warmup noise). So
+  **TurboQuant adds its ~2.34x KV-capacity benefit at near-zero decode cost on top
+  of the int4 weight win.**
+
+Caveat — VRAM ceiling: these V340 dies are ~8 GiB each. AWQ(TP2) + 16k-token KV
+exhausts memory at batch>1 (`torch.OutOfMemoryError`, 16 MiB free). For long context
++ batching with the AWQ model, use TP4 (more aggregate VRAM) or a shorter
+max_model_len. The compression itself is what lets you push context further per GiB;
+it doesn't remove the hard per-die cap.
+
+Repro: `bench_scripts/combo_dec.py turboquant_k8v4` (AWQ TP2, short-ctx decode).

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -506,19 +506,6 @@ via `--kv-cache-dtype turboquant_*`.
 ### Why it works on gfx900 (where the llama.cpp HIP port does not)
 The reference llama.cpp-turboquant-hip port **explicitly blocks wave64 hardware
 (Vega/GCN/CDNA)**: its codebook lookup uses `__shfl_sync(width=32)`, which returns
-garbage on 64-wide wavefronts. vLLMs TurboQuant kernels are **pure Triton** — no
-
-## TurboQuant KV-cache quantization on gfx900 (issue #62)
-
-TurboQuant (arXiv 2504.19874; rotation + Lloyd-Max scalar codebook) compresses the
-KV cache to roughly double usable context / concurrency per VRAM. vLLM ships a full
-in-tree implementation (`vllm/model_executor/layers/quantization/turboquant/`,
-`vllm/v1/attention/{backends/turboquant_attn,ops/triton_turboquant_*}`), selected
-via `--kv-cache-dtype turboquant_*`.
-
-### Why it works on gfx900 (where the llama.cpp HIP port does not)
-The reference llama.cpp-turboquant-hip port **explicitly blocks wave64 hardware
-(Vega/GCN/CDNA)**: its codebook lookup uses `__shfl_sync(width=32)`, which returns
 garbage on 64-wide wavefronts. vLLM's TurboQuant kernels are **pure Triton** — no
 `__shfl_sync`, no hand-rolled warp shuffle, no `tl.dot`. Triton handles the
 wavefront width internally, so the wave64 blocker simply does not apply. We only had

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -564,3 +564,9 @@ max_model_len. The compression itself is what lets you push context further per 
 it doesn't remove the hard per-die cap.
 
 Repro: `bench_scripts/combo_dec.py turboquant_k8v4` (AWQ TP2, short-ctx decode).
+
+### Quality: WikiText-2 reference perplexity
+Measured PPL (12,264 tokens, 24x512 windows, prefill logprobs), Qwen3.5-9B TP4:
+FP16 KV = 9.8885; turboquant_k8v4 = 9.8879 (delta -0.006%, lossless within noise).
+Confirms the FP8-key choice avoids the quirky-K catastrophe at zero quality cost.
+Repro: bench_scripts/ppl.py {auto|turboquant_k8v4}.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -1,0 +1,133 @@
+# Aggregate compute / bandwidth + power tuning — gfx900 (V340 / Vega10)
+
+Companion to `BENCH_GFX900.md`. That doc measures end-to-end LLM serving; this
+one measures the **raw hardware ceiling** (FP16 GEMM TFLOPS + HBM2 bandwidth),
+how it **aggregates across the 16 GPUs**, and how it responds to **power-cap
+tuning** — to answer "what do I actually get in aggregate, and what's the
+efficient operating point?"
+
+Microbenchmarks: `/tmp/gpu_peak.py` (matmul TFLOPS + `copy_` bandwidth, one
+process per GPU run concurrently), `/tmp/power_bench.py` + `/tmp/power_scan.sh`
+(sustained load while sweeping the power cap). Harness output in
+`~/gpubench/peak_results/` and `~/gpubench/power_scan/`.
+
+## Theoretical per-GPU ceiling (gfx900, 56 CU @ 1500 MHz)
+
+| Metric | Formula | Peak |
+|--------|---------|-----:|
+| FP32 | 56 CU × 64 lanes × 2 (FMA) × 1.5 GHz | **10.8 TFLOPS** |
+| FP16 (packed) | 2× FP32 via `v_pk_fma_f16` | **21.5 TFLOPS** |
+| HBM2 | 2048-bit × 945 MHz × 2 | **~483 GB/s** |
+| Power cap | (writable via sysfs / rocm-smi) | 110 W |
+
+## Measured per-GPU (n=8192 FP16 matmul, single cold GPU)
+
+| Metric | Measured | % of peak |
+|--------|---------:|----------:|
+| FP16 TFLOPS (cold burst) | ~5.0 | 23% |
+| FP16 TFLOPS (sustained) | **~4.5** | 21% |
+| FP32 TFLOPS | ~4.2 | 39% |
+| HBM bandwidth | **~365 GB/s** | 76% |
+
+**Why FP16 is only ~21% of peak:** Vega10 reaches its 21.5 TFLOPS number only
+with *packed* FP16 (`v_pk_fma_f16`, two FP16 FMAs per lane per clock). The
+rocBLAS kernels selected for this `hgemm` path on gfx900 do **not** emit packed
+math — they run essentially at the FP32 rate (note FP16 ≈ FP32 ≈ 4–5 TFLOPS).
+This is the same root cause as the slow decode TPOT in `BENCH_GFX900.md`: no
+matrix cores (MFMA) and no packed-FP16 GEMM, so FP16 lives on the regular VALU
+at scalar-FP32 throughput. HBM, by contrast, hits a healthy 76% of peak.
+
+## Aggregate (concurrent, one process per GPU)
+
+Each GPU works in its own VRAM, so there is **no interconnect traffic** in this
+test — it measures pure parallel compute/bandwidth headroom (the opposite end
+from the TP all-reduce-bound serving numbers).
+
+| Scope | GPUs | FP16 TFLOPS | HBM GB/s | Scaling |
+|-------|-----:|------------:|---------:|--------:|
+| Single | 1 | 4.5 | 365 | 1.0× |
+| Socket0 | 8 | **38.3** | **2 917** | 7.8× (97%) |
+| Full box | 16 | **76.4** | **5 783** | 16.0× (linear) |
+
+Scaling is essentially linear because the workloads are independent — confirming
+the box has ~**76 TFLOPS FP16** and ~**5.8 TB/s** of aggregate memory bandwidth
+to give, *if* a workload can be partitioned to avoid the slow PCIe/QPI fabric
+(i.e. data/replica parallel, or pipeline parallel — see `BENCH_GFX900.md`, where
+TP2×PP layouts beat pure TP precisely by avoiding per-layer all-reduce).
+
+> Caveat: in real TP serving you will **not** see 76 TFLOPS — that number is the
+> embarrassingly-parallel ceiling. TP shares one model and pays all-reduce every
+> layer over PCIe, so effective utilisation is far lower; PP recovers a chunk of
+> it by trading all-reduce for cheap point-to-point sends.
+
+## Power-cap scan (single GPU, sustained FP16, n=8192)
+
+| Cap (W) | TFLOPS | Mean draw (W) | TFLOPS/W |
+|--------:|-------:|--------------:|---------:|
+| 110 | 4.48 | 85.0 | 0.0527 |
+| 100 | 4.45 | 85.5 | 0.0521 |
+| 90 | 4.44 | 81.5 | 0.0545 |
+| 80 | 4.44 | 80.0 | **0.0555** |
+| 70 | 4.44 | 80.8 | 0.0549 |
+| 60 | 4.25 | 77.2 | 0.0551 |
+| 50 | 3.10 | 60.5 | 0.0513 |
+
+### What this tells us
+
+- **The cards are compute-bound, not power-bound, at stock.** A flat-out FP16
+  GEMM draws only **~85 W** against the 110 W cap. The chip simply can't burn
+  110 W on VALU FP16 (no matrix cores lighting up), so the top 25 W of the cap
+  is never used.
+- **You can cap to 80 W with zero throughput loss** — TFLOPS is identical
+  (4.44) from 110 W down to 70 W. Peak efficiency is at **80 W: 0.0555 TFLOPS/W,
+  ~5% better than stock** while saving 30 W of cap headroom (and the real ~5 W
+  of draw).
+- **The knee is ~70 W.** At 60 W throughput starts to dip (4.25), and 50 W
+  forces a real clock cut (3.10 TFLOPS, −31%). So **70–80 W is the sweet spot.**
+- **Aggregate implication:** capping all 16 GPUs at 80 W trims the box's power
+  budget by 16 × 30 W = **480 W of cap** (and the cards already only pull ~85 W
+  each, so you're mostly removing thermal/PSU headroom risk) for **no perf
+  loss**, and a small efficiency gain.
+
+## ⚠️ The real limiter is COOLING, not power
+
+The V340 is a **passively-cooled** datacenter card (no onboard fan spinning —
+`Fan RPM 0`); it relies entirely on chassis airflow. During back-to-back testing
+one GPU heat-soaked to **junction 89–93 °C**, at which point it **throttled sclk
+to the 300 MHz idle floor → sustained dropped from 4.5 to ~1.0 TFLOPS (−78%)**.
+Idle GPUs sat at 24–33 °C; the hot one took minutes to recover (still 93 °C
+after a minute idle).
+
+**Consequences for inference:**
+
+1. **Thermal throttling, not the power cap, will gate sustained multi-GPU
+   serving.** A long TP/PP run that keeps all GPUs busy will heat-soak the whole
+   tray; expect sustained throughput **below** the cold-burst numbers in
+   `BENCH_GFX900.md` unless chassis airflow is strong.
+2. **Lower power caps directly reduce heat.** Since 80 W costs no throughput but
+   cuts ~5–8 W of draw and (more importantly) reduces the heat the cooling has
+   to remove, **capping at 70–80 W is the single best knob to keep clocks up
+   under sustained load** — i.e. a lower cap can yield *higher* sustained
+   throughput once thermals dominate.
+3. **Watch junction temp, not edge temp.** Throttle triggers off junction
+   (~95–100 °C). Monitor `rocm-smi -t` (junction sensor) during long runs.
+
+## Recommendations for inference on this box
+
+1. **Cap all GPUs at 80 W** (`sudo rocm-smi --setpoweroverdrive 80`): no
+   throughput loss, best TFLOPS/W, less heat → better sustained clocks.
+2. **Prioritise airflow.** These passive cards need aggressive chassis fans;
+   without it, sustained serving will thermally throttle regardless of caps.
+3. **Prefer layouts that avoid the fabric** (DP/PP over wide TP) to actually
+   approach the 76 TFLOPS / 5.8 TB/s aggregate — see the PP wins in
+   `BENCH_GFX900.md`.
+4. **Don't expect FP16 matrix-core throughput.** The honest per-GPU number is
+   ~4.5 TFLOPS FP16 sustained; plan capacity around ~36 TFLOPS/socket, not the
+   21.5×8 theoretical.
+
+## Reproduce
+
+```
+/tmp/run_peak.sh fp16          # single / socket0 / all-16 aggregate
+/tmp/power_scan.sh 1 2         # power-cap efficiency scan on GPU1 (card2)
+```

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -230,3 +230,89 @@ launch + collective latency, not memory bandwidth.
 ```
 python3 bench_scripts/realistic.py   # back-of-envelope from BENCH_GFX900 numbers
 ```
+
+---
+
+# HIP CUDA-graph investigation (the `enforce_eager` question)
+
+`BENCH_GFX900.md` shows decode is **latency-bound**, not bandwidth-bound: it
+realizes only ~5–9% of the HBM roofline, with a ~120 ms/token floor. The leading
+suspect was per-token **kernel-launch overhead** under `enforce_eager` (no
+graphs), so we tried to enable HIP/CUDA graphs to collapse the hundreds of
+per-layer kernel launches into a single graph replay. **Result: graphs are not
+usable on this gfx900 stack.** Details below so nobody burns time (or a GPU)
+re-treading this.
+
+### Layer 1 — `enforce_eager=False` defaults to torch.compile, which crashes
+
+With graphs left on (default), vLLM picks `mode=VLLM_COMPILE` (Inductor) +
+`cudagraph_mode=FULL_AND_PIECEWISE`. Inductor immediately fails on ROCm:
+
+```
+RuntimeError: torch.* op returned non-Tensor bool
+  target: torch.cuda.is_current_stream_capturing
+```
+
+This is the same reason the gfx908/MI100 path force-sets `mode=NONE`: Inductor
+fusions aren't available/working on ROCm here. **torch.compile is a dead end on
+gfx900.**
+
+### Layer 2 — pure HIP graphs (no Inductor) hard-hang the GPU
+
+The correct config to isolate graphs from compile is
+`mode=NONE` + `cudagraph_mode=FULL_DECODE_ONLY`. The model loads, but during the
+graph-capture warmup at **TP=8** the hardware hung and the driver's recovery
+**failed**:
+
+```
+amdgpu 0000:25:00.0: KCQ enable failed
+resume of IP block <gfx_v9_0> failed -110
+GPU reset end with ret = -22          ← reset FAILED, not recovered
+VRAM is lost due to GPU reset!
+[powerplay] No response from smu / fw load failed
+[powerplay] firmware(0x1) doesn't match SMU9_DRIVER_IF_VERSION(0xe)
+```
+
+`rocm-smi` then enumerated only **15/16 GPUs** — the hung GPU's SMU (power
+microcontroller) was wedged and **only a full host reboot brought it back**.
+The stale SMU firmware (`0x1` vs expected `0xe`) means the in-driver GPU-reset
+path cannot recover a Vega10 hang on this box, so a graph-capture hang escalates
+to a dead GPU until reboot.
+
+### Layer 3 — even the safest settings never finish (infinite autotune)
+
+After rebooting (all 16 GPUs healthy again), we retried with the most
+conservative settings possible: **TP=4, single socket, `cudagraph_capture_sizes=[1]`,
+`max_num_batched_tokens=2048`, 600 s hard timeout.** This time **no GPU hang**
+(dmesg clean), but init **never completed** — the worker sat in
+`triton/backends/amd/compiler.py make_amdgcn` → `autotuner do_bench`,
+re-JIT-compiling kernels for the capture shapes without ever converging
+(`~/.triton/cache` `.hsaco` count frozen at 426 for >8 min). It hit the 600 s
+timeout still in warmup. The graph-capture code path re-triggers Triton
+autotuning for the GDN/FLA kernels in a way that does not terminate in
+reasonable time on gfx900.
+
+### Conclusion
+
+**`enforce_eager=True` is correct and required on gfx900 for this stack.** HIP
+CUDA graphs are not viable here:
+
+1. torch.compile (Inductor) is broken on ROCm → `mode=NONE` mandatory;
+2. full graph capture can hard-hang the GPU, and the SMU-firmware mismatch makes
+   the driver reset path fail → **a hang = a dead GPU until reboot** (risky);
+3. even the minimal-footprint capture never escapes Triton autotune.
+
+So the ~120 ms/token decode floor is **not** simply removable launch overhead —
+on this hardware the eager path is the only stable one, and the per-token cost
+is intrinsic (no MFMA, no packed-FP16, per-layer PCIe all-reduce). The
+realistic levers remain the ones already validated in `BENCH_GFX900.md`:
+**pipeline parallelism over wide TP** (removes per-layer all-reduce) and
+**batching/concurrency** (amortizes fixed per-step latency). A future ROCm with
+working ROCm-Inductor and updated Vega10 SMU firmware would be the prerequisite
+to revisit graphs.
+
+### Repro / guardrails
+
+If anyone retries graphs on gfx900: use a **hard `timeout`**, watch
+`dmesg | grep amdgpu` for `KCQ enable failed` / `GPU reset`, and be ready to
+**reboot** — do not run it unattended across all 16 GPUs.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -326,3 +326,110 @@ on this hot path.)
   pre-warm the Triton cache so init is ~1 min instead of ~11 min.
 - The decode floor is a **hardware** property (no MFMA/packed-FP16 + PCIe TP
   all-reduce), not a software/launch artifact. Optimize via PP + batching.
+
+---
+
+# Decode performance: where the gains are (and aren't) on gfx900
+
+Starting point: single-stream (bs=1) decode of Qwen3.5-9B TP4 FP16 is ~150
+ms/token (6.8 tok/s). HIP graphs gave 0 speedup (see above), proving the floor
+is **fixed per-STEP overhead** (RCCL all-reduce + GDN linear-attn Triton
+kernels), not kernel-launch overhead and not HBM bandwidth.
+
+Roofline check (per GPU, TP4): each GPU reads 1/4 of weights = 4.83 GB at the
+measured ~365 GB/s HBM = **~13 ms/step floor**. We measure ~150 ms/step → we are
+**~10x above the bandwidth roofline**. So at bs=1 we use only ~9% of HBM
+bandwidth. The headroom is real; the question is how to convert idle bandwidth
+into throughput.
+
+## Lever 1 — batching/concurrency (the big, free win) — issue #53
+
+A decode *step* costs ~150 ms regardless of how many sequences are in the batch
+(it reads the weights once, then does B sequences' worth of cheap per-token
+work). So running B concurrent sequences yields ~B tokens per step → throughput
+scales nearly linearly until something saturates.
+
+`bench_scripts/batch_sweep.py`, TP4 FP16, gen=96:
+
+| Batch | agg tok/s | scaling | ms/step |
+|-------|-----------|---------|---------|
+| 1 | 6.80 | 1.0x | 147 |
+| 2 | 12.82 | 1.9x | 156 |
+| 4 | 25.36 | 3.7x | 158 |
+| 8 | 49.37 | 7.3x | 162 |
+| 16 | 83.91 | 12.3x | 191 |
+| 32 | 225–231 | 33x | 138–142 |
+| 48 | 289 | 42x | 166 |
+| 64 | 293 | 43x | 219 |
+| 96 | ~498 | ~70x | 193 |
+| 128 | 321 (regress) | — | 398 |
+
+**Decode goes from 6.8 tok/s (bs=1) to ~300–500 tok/s aggregate (50–70x) purely
+via concurrency.** Peak sits around B=64–96; B=128 regresses (KV-cache pressure /
+scheduler recompute). The curve is approximate (wall time includes prefill of B
+prompts, which grows with batch), but the regime is unambiguous: **decode is
+latency/overhead-bound, and concurrency is the primary throughput lever.** Even
+at B=96 per-step time (~190 ms) is still ~10x above the bandwidth roofline, so we
+never actually become bandwidth-bound — the per-step overhead (RCCL + GDN
+kernels) is the true ceiling.
+
+**Takeaway:** serve with high concurrency. For latency-sensitive bs=1 use, the
+floor is hardware-intrinsic; for throughput, batch hard.
+
+## Lever 2 — INT4 weight quantization — issue #54 — TESTED, DOES NOT HELP
+
+Hypothesis: shrink weights with INT4 so the model fits on fewer GPUs (cutting the
+all-reduce floor) and reduce bytes/step. Tested `QuantTrio/Qwen3.5-9B-AWQ` (AWQ
+4-bit, group_size 128; only MLP weights quantized — attn/linear_attn stay FP16;
+12.4 GB → fits TP2).
+
+**It loads and runs correctly on gfx900.** vLLM auto-selects
+`TritonW4A16LinearKernel` for `AWQMarlinLinearMethod` (Marlin MoE is disabled on
+ROCm; the dense Triton W4A16 dequant path is used — the right path for gfx900,
+which has no MFMA/Marlin). Correct output, TP2.
+
+`bench_scripts/awq_sweep.py`, AWQ INT4 TP2, gen=96:
+
+| Batch | agg tok/s | ms/step |
+|-------|-----------|---------|
+| 1 | 4.98 | 200.6 |
+| 8 | 27.28 | 293 |
+| 32 | 54.88 | 583 |
+| 64 | 56.12 | 1140 |
+| 96 | 52.50 | 1829 |
+
+**AWQ INT4 is SLOWER than FP16 on both latency and throughput:**
+- bs=1: 200 ms/tok (AWQ TP2) vs 147 ms/tok (FP16 TP4) — **36% slower**.
+- peak throughput: ~56 tok/s (plateaus at B=32) vs ~300–500 tok/s (FP16) — **~6–9x worse**.
+
+**Why (the key lesson):**
+1. gfx900 has **no native INT4/dequant hardware**, so `TritonW4A16` must
+   dequantize INT4→FP16 in software every forward, then do the FP16 matmul. That
+   dequant is **pure added compute**, not hidden behind anything.
+2. Quantization only helps when you are **bandwidth-bound** (trade compute for
+   fewer bytes). gfx900 decode is **overhead/latency-bound**, not bandwidth-bound
+   (Lever 1 proved we never hit the HBM roofline). So fewer bytes buys nothing
+   while the dequant adds cost.
+3. At scale the Triton dequant kernel becomes the bottleneck: per-step time
+   explodes (583→1829 ms) and throughput plateaus at B=32, where FP16 kept
+   scaling to B=96.
+
+**Takeaway:** INT4 quantization is the **wrong** lever for gfx900 decode, *because*
+decode is not bandwidth-bound here. Quant would only pay off on a bandwidth-bound
+GPU with native INT4/INT8 units (MI300, etc.). On Vega10 it adds software-dequant
+overhead with no benefit. (Quant may still be worth it purely to *fit a larger
+model* in limited VRAM — but not for speed.)
+
+## Where the remaining decode gains actually are
+
+Since both batching headroom and the all-reduce floor dominate, the productive
+directions are:
+- **#55 PP-over-TP under concurrency** — pipeline parallel swaps per-layer
+  all-reduce for point-to-point sends; should cut the per-step overhead that
+  caps the batch-sweep ceiling.
+- **#56 profile the 150 ms step** — split RCCL all-reduce vs GDN/FLA Triton
+  kernel time; tells us whether to attack comms (PP, fewer ranks) or kernels
+  (tune the GDN linear-attention Triton ops for wave64/gfx900).
+
+Both target the real bottleneck (fixed per-step overhead), unlike quantization
+which targets bandwidth we aren't actually limited by.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -433,3 +433,64 @@ directions are:
 
 Both target the real bottleneck (fixed per-step overhead), unlike quantization
 which targets bandwidth we aren't actually limited by.
+
+---
+
+# Redeeming INT4 on gfx900: a hand-written decode GEMV — issue #57
+
+`#54` found stock AWQ INT4 is *slower* than FP16 on gfx900 because the W4A16
+path uses `tl.dot` even at M=1, and gfx900 has no MFMA → `tl.dot` becomes a
+padded FP32 GEMM (one real token padded to BLOCK_M=16/32). The fix is not better
+dequant (that was already register-level) — it's the **wrong primitive**. Decode
+is M=1, so the right primitive is a **GEMV**: purely HBM-bandwidth-bound, no
+matrix units needed, and int4 weights move 4× fewer bytes than FP16.
+
+## The kernel (`vllm/.../mixed_precision/gfx900_w4a16_gemv.py`)
+
+M=1..8 int4 GEMV: register-level unpack (GPTQ-sequential packing, shift =
+`(j%8)*4`, matching the generic `triton_w4a16` kernel), group scales/zeros loaded
+**once per group** (not per K-row), and **split-K** to parallelize long-K /
+small-N shapes across gfx900's 56 CUs. Per-shape tuned configs
+(`_GFX900_GEMV_CONFIGS`). `tl.sum` reduction over K instead of `tl.dot`.
+
+Dispatch: `triton_w4a16_gemm` routes `on_gfx900() and group_size in {32,64,128}
+and M<=8` to this GEMV; prefill (M>8) still uses the generic `tl.dot` path.
+
+## Microbench (real Qwen3.5-9B MLP shapes, M=1, correctness rel err ≤ 0.001)
+
+| shape | FP16 GEMV | int4 GEMV | vs FP16 | vs stock tl.dot (the path it replaces) |
+|-------|-----------|-----------|---------|------------------------------------------|
+| gate/up K=4096 N=24576 | 0.726 ms | 0.257 ms | **2.82×** | 2.86 ms → 0.282 ms = **10.1×** |
+| down K=12288 N=4096    | 0.576 ms | 0.143 ms | **4.02×** | 2.21 ms → 0.141 ms = **15.6×** |
+
+The 10–15× vs stock is because the gfx900 `tl.dot` int4 path is pathologically
+bad (~2–3 ms for one token). ~54% of the 365 GB/s HBM roofline; correct across
+M=1/4/8 vs the existing kernel.
+
+## End-to-end (Qwen3.5-9B-AWQ, TP2, enforce_eager, bs=1 decode)
+
+| Config | GPUs | bs=1 ms/tok | bs=1 tok/s |
+|--------|------|-------------|------------|
+| FP16 (baseline) | TP4 | 147 | 6.80 |
+| AWQ INT4, stock `tl.dot` | TP2 | 200 | 4.98 |
+| **AWQ INT4, gfx900 GEMV** | **TP2** | **95.6** | **10.46** |
+
+Output verified correct. The kernel flips INT4 from the *worst* decode option to
+the **best**: **2.1× faster than stock AWQ**, **1.54× faster than FP16 at bs=1**,
+and on **half the GPUs** (TP2 vs TP4) — freeing 2 GPUs per replica.
+
+**When to use it:** latency-sensitive / low-to-moderate concurrency decode, or
+when VRAM/GPU count is the constraint. At very high batch, FP16 still wins on
+aggregate throughput (decode there is step-overhead-bound, not weight-bandwidth-
+bound, so fewer weight bytes stops helping — consistent with the batch-sweep
+finding). The GEMV gate is M<=8, so high-batch prefill/decode automatically falls
+back to the generic path.
+
+## Why this matters (the general lesson)
+
+Quantization only helps where you're **bandwidth-bound**. gfx900 bs=1 decode
+*is* weight-bandwidth-bound (each token re-reads all weights), so int4's 4×-fewer
+bytes is a real win — but only once you stop forcing the work through MFMA-less
+`tl.dot`. A GEMV that reads int4 and accumulates in vector ALU is the right shape
+for this hardware. Same principle would apply to any matmul-light, M=1 path on a
+no-MFMA GPU.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -131,3 +131,102 @@ after a minute idle).
 /tmp/run_peak.sh fp16          # single / socket0 / all-16 aggregate
 /tmp/power_scan.sh 1 2         # power-cap efficiency scan on GPU1 (card2)
 ```
+
+---
+
+# Realistic scaling under LLM inference (TP / PP) — not the linear ceiling
+
+The 76 TFLOPS / 5.8 TB/s aggregate above is the **embarrassingly-parallel**
+ceiling: 16 independent jobs, each in its own VRAM, zero communication. Real
+single-model LLM serving never reaches it. Below we back out the **effective**
+realized compute and bandwidth from the actual serving runs in
+`BENCH_GFX900.md` (Qwen3.5-9B, 9.65 B params, 19.3 GB FP16).
+
+LLM inference has two regimes that scale very differently:
+
+- **Prefill** (processing the prompt) is **compute-bound** — a big GEMM over all
+  prompt tokens. From TTFT we recover effective **TFLOPS**.
+- **Decode** (generating tokens) is **bandwidth-bound** — every step must stream
+  all weights from HBM to emit (batch) tokens. From output tok/s we recover
+  effective **GB/s**.
+
+Formulas: prefill FLOPs ≈ `2 · P · prompt_tokens · batch` over the TTFT window;
+decode bytes ≈ `2 · P` (FP16 weights) streamed per forward step, `steps/s =
+out_tok_s / batch`.
+
+## Prefill: effective TFLOPS vs the parallel ceiling
+
+| Layout | GPUs | c | TTFT p50 | Eff TFLOPS | % of agg ceiling |
+|--------|-----:|--:|---------:|-----------:|-----------------:|
+| TP8 | 8 | 1 | 0.82 s | 24.0 | **67%** |
+| TP8 | 8 | 4 | 3.39 s | 23.3 | 65% |
+| TP4 | 4 | 4 | 5.76 s | 13.7 | 76% |
+| TP4 | 4 | 1 | 1.95 s | 10.1 | 56% |
+| TP2×PP2 | 4 | 4 | 6.53 s | 12.1 | 67% |
+| TP2×PP4 | 8 | 4 | 4.64 s | 17.1 | 47% |
+| TP2×PP4 | 8 | 1 | 2.18 s | 9.1 | 25% |
+
+**Prefill realizes 50–76% of the parallel-compute ceiling.** It is the regime
+that actually uses the GPUs' arithmetic, so wide **TP wins here** (TP8 hits the
+best single-stream 24 TFLOPS effective). PP is weaker for single-stream prefill
+because the prompt must walk all pipeline stages before the first token (the
+25% outlier), but it recovers with concurrency as the pipeline fills.
+
+## Decode: effective GB/s vs the bandwidth ceiling
+
+| Layout | GPUs | c | out tok/s | Eff GB/s | % of agg HBM | % of bw-roofline |
+|--------|-----:|--:|----------:|---------:|-------------:|-----------------:|
+| TP2×PP2 | 4 | 1 | 6.81 | 131 | 9.0% | **9.0%** |
+| TP4 | 4 | 1 | 4.58 | 88 | 6.1% | 6.1% |
+| TP8 | 8 | 1 | 7.94 | 153 | 5.2% | 5.2% |
+| TP2×PP4 | 8 | 1 | 6.95 | 134 | 4.6% | 4.6% |
+| TP8 | 8 | 4 | 19.54 | 94/step | 3.2% | 3.2% |
+
+A 19.3 GB model over ~2.9 TB/s of aggregate HBM gives a **bandwidth roofline of
+~151 tok/s** (8 GPU, batch 1) if decode were purely memory-bound. We measure
+**~5–9% of that.** Decode on this box is **NOT actually bandwidth-bound** — it
+is **latency/overhead-bound**:
+
+- No matrix cores + no packed-FP16, so each tiny per-token GEMM is slow on the
+  VALU and **enforce_eager** (no HIP graphs — required for stability here) adds
+  full kernel-launch overhead on every one of the ~hundreds of ops per layer.
+- TP adds an all-reduce *per layer* over PCIe (no XGMI); at batch 1 this is pure
+  serial latency the HBM never gets to hide.
+- The hybrid Gated-DeltaNet recurrence is partly sequential.
+
+So the HBM is **>90% idle during decode** — the bottleneck is per-token kernel
+launch + collective latency, not memory bandwidth.
+
+## Bottom line: what you realistically get
+
+| Quantity | Parallel ceiling | **Realistic (this model, serving)** |
+|----------|-----------------:|------------------------------------:|
+| Prefill compute (8 GPU) | 36 TFLOPS | **~24 TFLOPS (≈67%)** |
+| Prefill compute (4 GPU) | 18 TFLOPS | **~13 TFLOPS (≈70%)** |
+| Decode bandwidth (8 GPU) | 2.9 TB/s | **~0.15 TB/s used (≈5%)** |
+| Decode speed, best single-stream | — | **~8 tok/s (TP8)** |
+| Decode speed, best aggregate | — | **~26 tok/s (TP2×PP4, c4 coding)** |
+
+**Takeaways**
+
+1. **Prefill scales well (~70% efficiency)** and is TP-friendly — that is the
+   part of the box that behaves like the aggregate spec.
+2. **Decode is the bottleneck and does *not* scale with bandwidth** — it is
+   gated by per-token kernel-launch + all-reduce latency, so it sits at ~5–9% of
+   the HBM roofline. Throwing more GPUs at one stream barely helps (TP8 only
+   ~1.7× TP4); **batching/concurrency is the only real decode lever** (c1→c4
+   gives 2.5–3.4×).
+3. **PP > TP for decode at equal GPUs** because it removes the per-layer
+   all-reduce that dominates decode latency — exactly the TP2×PP wins in
+   `BENCH_GFX900.md`.
+4. **Realistic planning number:** count on **~24 TFLOPS/socket of usable prefill
+   compute** and **decode throughput in the tens of tok/s aggregate**, *not* the
+   76 TFLOPS / 5.8 TB/s parallel figure. The two regimes want opposite layouts
+   (TP for prefill, PP/low-TP for decode), so the best serving config is a
+   compromise — here TP2×PP4 within one socket.
+
+## Reproduce
+
+```
+python3 bench_scripts/realistic.py   # back-of-envelope from BENCH_GFX900 numbers
+```

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -670,3 +670,74 @@ The remaining decode levers are batching/concurrency (TP4 scales to ~220 tok/s a
 c=32) and the int4 + TurboQuant stack.
 
 Repro: `bench_scripts/pp_bench.py {tp4|tp2pp2} {graph|eager} <num_gpus>`.
+
+# Multi-GPU topology review: TP4 vs TP8 vs TP16 vs cross-socket PP (issue #55 follow-up)
+
+This box is 8x AMD Radeon Pro V340 = **16 gfx900 dies**, split across two CPU sockets:
+GPUs 0-7 on socket 0, GPUs 8-15 on socket 1. Intra-socket P2P is ~8 GB/s; **the
+cross-socket link is the Xeon E5 v3 QPI path at ~0.26 GB/s** (a hardware ceiling, not
+tunable). Every layout decision is dominated by that 30x cross-socket bandwidth cliff.
+
+All runs below use the recommended decode stack: LLMM1 skinny GEMV (#59) + FULL_DECODE_ONLY
+CUDA graphs (#63), Qwen3.5-9B FP16, `max_num_seqs=32`, offline `LLM.generate`, out tok/s.
+
+## Results
+| Layout | GPUs | Socket(s) | c=1 | c=8 | c=32 | Outcome |
+|---|---:|---|---:|---:|---:|---|
+| **TP4** | 4 | one (0-3) | **52.3** | 48.9 | **220.0** | **best** |
+| TP8 | 8 | one (0-7) | 14.7 | 12.7 | 61.8 | ~3.5x worse than TP4 |
+| TP16 | 16 | both (0-15) | stall | - | - | catastrophic, killed |
+| TP8xPP2 | 16 | both | (inconclusive) | - | - | needs clean revisit |
+
+## TP8 (one socket) is much WORSE than TP4 — more TP hurts here
+TP8 c=1 = 14.7 tok/s, *worse than TP4 running eager* (14.9). Doubling TP from 4 to 8:
+- doubles the per-layer all-reduce participant count (8-way collective over PCIe), and
+- halves each die's GEMV slice. With LLMM1 the decode matmul is already a skinny GEMV;
+  splitting an M=1 GEMV 8 ways makes each slice too small to amortize launch overhead,
+  so the all-reduce cost dominates and throughput collapses.
+- Cold init also scaled with GPU count: TP8 took ~662s (vs ~67s for TP4) for GDN/FLA
+  Triton autotune + graph capture.
+**Takeaway: TP4 is the sweet spot. Going past TP4 on this box is a net loss for decode.**
+
+## TP16 (cross-socket TP) is catastrophic
+Init completed but the first decode step stalled 20+ min and never returned. py-spy
+showed every worker blocked in `all_gather_into_tensor` inside
+`logits_processor._gather_logits` -- the lm_head logits all-gather (vocab=248320)
+across all 16 TP ranks, which **must traverse the 0.26 GB/s QPI link**. Pure TP issues
+a collective on every layer plus this giant logits gather; routing all of that over QPI
+makes a single decode step effectively never finish. Killed; GPUs recovered via
+reset_method=2. **Cross-socket pure TP is unusable -- do not span sockets with TP.**
+
+## TP8xPP2 (cross-socket PP) -- inconclusive, flagged for clean revisit
+The theoretically-correct way to use all 16 GPUs: TP8 *within* each socket (intra-socket
+all-reduce only) with the PP stage boundary crossing QPI as cheap point-to-point sends.
+It initialized and started decoding (8 active requests reached the decode loop), then
+hit a collective `TimeoutError` mid-decode. **But the host was simultaneously overloaded
+(load avg ~30-50) and SSH was timing out, so this is not a clean measurement.** Worse,
+the cross-socket teardown left two socket-1 dies (GPUs 14/15) with a non-responsive SMU
+(`amdgpu: Failed to send message ... ret 0xffffffff` looping) and ~57 kernel ttm workers
+stuck in uninterruptible D-state; those two dies then fell off the PCIe bus and a warm
+reboot did not recover them (needs a cold power cycle). **Verdict: TP8xPP2 is worth a
+proper, isolated retry on a quiet box, NOT a recorded negative result.** See "Revisit"
+below.
+
+## Conclusion / recommendation
+- **Use TP4 on one socket for decode.** It wins single-stream (52.3 tok/s) and peak
+  throughput (220 tok/s at c=32), and avoids every cross-socket pitfall.
+- More TP than 4 hurts (TP8 ~3.5x worse); cross-socket TP (TP16) is unusable.
+- The QPI link (0.26 GB/s) is the hard wall for any 16-GPU layout. The only layout that
+  could plausibly use both sockets is cross-socket PP (point-to-point, not all-reduce),
+  which remains an open question pending a clean retry.
+- For multi-tenant serving, run **independent TP4 (or TP8) engines per socket** rather
+  than one model spanning sockets.
+
+## Revisit later: TP8xPP2 on a quiet box
+Retry `bench_scripts/run_topo.sh tp8pp2 eager 16` (and `graph 16`) only when (a) all 16
+GPUs are healthy after a cold power cycle, (b) the host is idle, and (c) consider raising
+the distributed collective timeout (`--distributed-timeout` / `TORCH_NCCL_*` env) so the
+QPI activation hand-off doesn't trip the default timeout. The question to answer: can PP
+keep the per-layer all-reduce inside each socket and only pay QPI at the single stage
+boundary, and is the resulting tok/s competitive with two independent TP4 engines?
+
+Scripts: `bench_scripts/topo_bench.py {tp4|tp8|tp16|tp8pp2} {graph|eager}` via
+`bench_scripts/run_topo.sh <layout> <mode> <num_gpus>`.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -570,3 +570,51 @@ Measured PPL (12,264 tokens, 24x512 windows, prefill logprobs), Qwen3.5-9B TP4:
 FP16 KV = 9.8885; turboquant_k8v4 = 9.8879 (delta -0.006%, lossless within noise).
 Confirms the FP8-key choice avoids the quirky-K catastrophe at zero quality cost.
 Repro: bench_scripts/ppl.py {auto|turboquant_k8v4}.
+
+# UPDATE: HIP CUDA graphs now give 3.6x decode (revisit after LLMM1) — issue #63
+
+The "HIP CUDA-graph investigation — RESOLVED" section above concluded graphs give
+**zero** decode speedup and that enforce_eager should stay the default. **That
+conclusion is now obsolete.** It was correct for its data (GPU-busy 74.6 ms/step, so
+the host dispatch gap was a small slice), but the LLMM1 win (#59) cut GPU-busy to
+27.9 ms/step, making the GPU-idle dispatch gap **59% of the step**. Graphs remove
+exactly that gap.
+
+## Re-test (Qwen3.5-9B TP4, FP16, bs=1 decode, best of 3 x 160 tok)
+| Mode | ms/tok | tok/s |
+|---|---:|---:|
+| Eager (LLMM1) | 67.0 | 14.93 |
+| **Graph + LLMM1** | **18.4** | **54.41** |
+
+3.6x, reproduced twice (18.4 / 18.5 ms), coherent identical output. Config:
+`mode=NONE` + `cudagraph_mode=FULL_DECODE_ONLY` + `capture_sizes=[1]` (Inductor/
+compile stays OFF — only HIP graph capture; Inductor still crashes on ROCm).
+
+## Full decode progression (Qwen3.5-9B, bs=1)
+| Config | tok/s | vs original |
+|---|---:|---:|
+| FP16 TP4 eager (original) | 6.65 | 1.0x |
+| + LLMM1 GEMV (#59) | 14.85 | 2.2x |
+| + CUDA graphs (#63) | **54.4** | **8.2x** |
+
+Full stack (AWQ int4 + TurboQuant KV + LLMM1 + graphs), TP2 on half the GPUs:
+14.12 -> **37.71 tok/s**, coherent.
+
+## Gotcha: hybrid (Mamba/GDN) graph capture needs max_num_seqs <= Mamba cache blocks
+Qwen3.5 is hybrid; each decode sequence needs one Mamba/GDN state cache block. Graph
+capture fails if `max_num_seqs` exceeds the available blocks:
+`max_num_seqs (256) exceeds available Mamba cache blocks (N) ... CUDA graph capture
+cannot proceed`. Fix: set `--max-num-seqs <= N` (N depends on
+gpu_memory_utilization and model; was 42 for AWQ TP2 on 8 GiB dies — use 32).
+
+## New guidance
+**Use CUDA graphs for gfx900 decode** (do NOT pass `enforce_eager`). Set
+`compilation_config(mode=NONE, cudagraph_mode=FULL_DECODE_ONLY, capture_sizes=[1])`
+and `max_num_seqs` within the Mamba-block budget. Cold start still pays the
+GDN/FLA Triton autotune + a 1-2s capture; both cache.
+
+Lesson: a perf conclusion is only valid for the bottleneck profile under which it was
+measured. After a structural change (here LLMM1 halving GPU-busy), revisit prior
+negatives — the cheap A/B flipped from 0% to 3.6x.
+
+Repro: `bench_scripts/graph_ab.py {eager|graph}`, `bench_scripts/graph_combo.py graph turboquant_k8v4`.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -494,3 +494,62 @@ bytes is a real win — but only once you stop forcing the work through MFMA-les
 `tl.dot`. A GEMV that reads int4 and accumulates in vector ALU is the right shape
 for this hardware. Same principle would apply to any matmul-light, M=1 path on a
 no-MFMA GPU.
+
+## TurboQuant KV-cache quantization on gfx900 (issue #62)
+
+TurboQuant (arXiv 2504.19874; rotation + Lloyd-Max scalar codebook) compresses the
+KV cache to roughly double usable context / concurrency per VRAM. vLLM ships a full
+in-tree implementation (`vllm/model_executor/layers/quantization/turboquant/`,
+`vllm/v1/attention/{backends/turboquant_attn,ops/triton_turboquant_*}`), selected
+via `--kv-cache-dtype turboquant_*`.
+
+### Why it works on gfx900 (where the llama.cpp HIP port does not)
+The reference llama.cpp-turboquant-hip port **explicitly blocks wave64 hardware
+(Vega/GCN/CDNA)**: its codebook lookup uses `__shfl_sync(width=32)`, which returns
+garbage on 64-wide wavefronts. vLLMs TurboQuant kernels are **pure Triton** — no
+
+## TurboQuant KV-cache quantization on gfx900 (issue #62)
+
+TurboQuant (arXiv 2504.19874; rotation + Lloyd-Max scalar codebook) compresses the
+KV cache to roughly double usable context / concurrency per VRAM. vLLM ships a full
+in-tree implementation (`vllm/model_executor/layers/quantization/turboquant/`,
+`vllm/v1/attention/{backends/turboquant_attn,ops/triton_turboquant_*}`), selected
+via `--kv-cache-dtype turboquant_*`.
+
+### Why it works on gfx900 (where the llama.cpp HIP port does not)
+The reference llama.cpp-turboquant-hip port **explicitly blocks wave64 hardware
+(Vega/GCN/CDNA)**: its codebook lookup uses `__shfl_sync(width=32)`, which returns
+garbage on 64-wide wavefronts. vLLM's TurboQuant kernels are **pure Triton** — no
+`__shfl_sync`, no hand-rolled warp shuffle, no `tl.dot`. Triton handles the
+wavefront width internally, so the wave64 blocker simply does not apply. We only had
+to add `TURBOQUANT` to the gfx900 attention-backend list in `rocm.py` (opt-in; the
+default stays TRITON_ATTN unless `--kv-cache-dtype turboquant_*` is passed). No
+kernel changes were needed. Prefill uses the `F.scaled_dot_product_attention`
+fallback since gfx900 has no flash-attn.
+
+### Preset choice: Qwen3.5 is "quirky-K"
+Per the ollama#15051 sweep, the Qwen3 family is extremely sensitive to *key*-side
+quantization (tq2k = +150% PPL on qwen3:8b — output destroyed), while tolerant of
+value quantization. So on Qwen3.5-9B use **`turboquant_k8v4`** (FP8 keys + 4-bit
+values) — it leaves keys effectively unquantized and only compresses values. V-heavy
+presets are mandatory here; aggressive K presets (`turboquant_3bit_nc`) are unsafe.
+
+### Measured — Qwen3.5-9B, TP=4 gfx900, fp16 weights, max_model_len=16384
+| Metric | FP16 KV (`auto`) | `turboquant_k8v4` | Δ |
+|---|---|---|---|
+| GPU KV cache size | 194,267 tokens | **454,382 tokens** | **2.34×** |
+| Max concurrency @16k ctx | 11.86× | **27.73×** | **2.34×** |
+| Decode tok/s, B=1 (~8k prefill) | 4.75 | 5.10 | +7% |
+| Decode tok/s, B=8 | 12.20 | 13.78 | +13% |
+
+Output stays coherent ("The capital of France is Paris"; correct photosynthesis
+explanation). **2.34× more context/concurrency per VRAM, plus a small decode speedup**
+(fewer KV bytes read per step). Note Qwen3.5 is hybrid — only 8/32 layers are full
+attention with a KV cache (rest are GDN linear-attn), so the cache footprint is
+already small; the 2.34× multiplier applies to that KV-cached portion.
+
+Cold start pays the usual GDN/FLA Triton autotune (~647s cold, ~60s warm) plus the
+TurboQuant centroid init. `enforce_eager=True` as always on gfx900.
+
+Repro: `bench_scripts/tq_measure.py {auto|turboquant_k8v4}` (TP4, 16k ctx; prints
+GPU KV cache size + decode tok/s at B=1/8).

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -233,86 +233,96 @@ python3 bench_scripts/realistic.py   # back-of-envelope from BENCH_GFX900 number
 
 ---
 
-# HIP CUDA-graph investigation (the `enforce_eager` question)
 
-`BENCH_GFX900.md` shows decode is **latency-bound**, not bandwidth-bound: it
-realizes only ~5–9% of the HBM roofline, with a ~120 ms/token floor. The leading
-suspect was per-token **kernel-launch overhead** under `enforce_eager` (no
-graphs), so we tried to enable HIP/CUDA graphs to collapse the hundreds of
-per-layer kernel launches into a single graph replay. **Result: graphs are not
-usable on this gfx900 stack.** Details below so nobody burns time (or a GPU)
-re-treading this.
+---
 
-### Layer 1 — `enforce_eager=False` defaults to torch.compile, which crashes
+# HIP CUDA-graph investigation (the `enforce_eager` question) — RESOLVED
 
-With graphs left on (default), vLLM picks `mode=VLLM_COMPILE` (Inductor) +
-`cudagraph_mode=FULL_AND_PIECEWISE`. Inductor immediately fails on ROCm:
+**Question:** decode on gfx900 has a ~150 ms/token floor and realizes only
+~5–9% of the HBM roofline (see `BENCH_GFX900.md`). Is that floor just
+per-token **kernel-launch overhead** from running eager (no CUDA graphs)? If so,
+capturing HIP/CUDA graphs should collapse the hundreds of per-layer launches
+into one replay and remove the floor.
+
+**Answer: No. Graphs work on gfx900, but they give ZERO decode speedup.** The
+floor is real per-token compute/comm cost, not launch overhead. Measured A/B
+below. `enforce_eager=True` remains the right default — not because graphs are
+broken, but because they don't help and cost a long one-time autotune.
+
+## The A/B result (TP4, Qwen3.5-9B, FP16, bs=1 single-stream decode, 128 tok)
+
+| Mode | Config | tok/s | ms/token |
+|------|--------|-------|----------|
+| Eager | `enforce_eager=True` | 6.69 | 149.4 |
+| Graph | `mode=NONE` + `FULL_DECODE_ONLY`, capture_sizes=[1] | 6.55–6.64 | 150.7–152.6 |
+
+Three independent graph runs all landed at 150–153 ms/tok — within noise of
+eager (often *slightly* slower). Graph capture was confirmed active in the logs:
+`Capturing CUDA graphs (decode, FULL): 100%|████| 1/1` →
+`Graph capturing finished in 1 secs`. So the captured graph genuinely replaced
+the eager decode launches and produced identical, correct output — and the
+per-token time did not move.
+
+**Conclusion:** the ~150 ms/token decode cost is intrinsic to this hardware:
+no MFMA (matmuls run at FP32 rate), no packed-FP16 from rocBLAS, per-layer PCIe
+all-reduce under TP, plus the GDN linear-attention Triton kernels themselves.
+Removing launch overhead changes nothing because launch overhead was never the
+bottleneck. The real levers stay **PP-over-TP** (removes per-layer all-reduce)
+and **batching/concurrency** (amortizes the fixed per-step cost) — both
+validated in `BENCH_GFX900.md`.
+
+## What it took to get graphs working (three real blockers)
+
+### Blocker A — torch.compile/Inductor is the wrong target (don't bother)
+With graphs left fully on, vLLM defaults to `mode=VLLM_COMPILE` (Inductor) +
+`FULL_AND_PIECEWISE`. Inductor crashes on ROCm:
+`torch.* op returned non-Tensor bool, target: is_current_stream_capturing`. This
+is also why the gfx908/MI100 path force-sets `mode=NONE`. **Fixing Inductor is
+pointless here** — the MI100 path proves disabling it is correct, and our A/B
+shows pure HIP graphs (no Inductor) already give no speedup. The correct config
+is `mode=NONE` (compile off) + `cudagraph_mode=FULL_DECODE_ONLY` (HIP graphs on).
+
+### Blocker B — graph-capture hang + the REAL fix (`reset_method`, not firmware)
+An early TP8 capture hung **two** GPUs at once (PCI 22:00.0 and 25:00.0, both
+socket0). The driver's auto reset chose **BACO** (`reset_method=-1` → BACO),
+which "succeeded" but **lost VRAM** and left one GPU's SMU wedged
+(`No response from smu`, the bogus `firmware 0x1 vs 0xe` line is a *symptom* of
+the half-dead GPU, **not** stale firmware — a clean boot shows the SMU loading
+fine with no mismatch). `rocm-smi` then saw only 15/16 GPUs; **only a reboot
+recovered it.**
+
+The fix is **not** flashing firmware. It is forcing a reliable reset method:
 
 ```
-RuntimeError: torch.* op returned non-Tensor bool
-  target: torch.cuda.is_current_stream_capturing
+# /etc/modprobe.d/amdgpu-reset.conf   (reversible: delete file + reboot)
+options amdgpu reset_method=2          # 2 = mode1 (PSP-assisted whole-chip)
 ```
 
-This is the same reason the gfx908/MI100 path force-sets `mode=NONE`: Inductor
-fusions aren't available/working on ROCm here. **torch.compile is a dead end on
-gfx900.**
+`sudo update-initramfs -u && reboot`, then verify
+`cat /sys/module/amdgpu/parameters/reset_method` → `2`. **mode1 (value 2)** is
+the robust path for Vega10. Do **not** use mode2 (value 3) — that's an
+SMU/Arcturus(gfx908)-only reset and is not implemented for Vega10. With mode1 in
+place, subsequent capture experiments never lost a GPU again (driver can
+actually recover instead of corrupting VRAM via BACO).
 
-### Layer 2 — pure HIP graphs (no Inductor) hard-hang the GPU
+### Blocker C — one-time Triton autotune during capture warmup is very slow
+`mode=NONE + FULL_DECODE_ONLY` triggers `_warmup_prefill_kernels`
+(`qwen_gdn_linear_attn.py:1152`) → `recompute_w_u_fwd` (`wy_fast.py:156`) →
+`chunk_gated_delta_rule_fwd`, which `@triton.autotune`s the GDN/FLA kernels.
+Each config is a full `make_amdgcn`/`make_hsaco` compile, and gfx900 compiles
+slowly, so the GDN warmup grinds for ~10 min on a **cold** Triton cache
+(`INIT_DONE in 647s`). It is slow, not infinite. The autotune result **persists
+across runs**, so a **warm** start is `INIT_DONE in 63s` and graph capture
+itself is only **1 second**. (The FLA configs are gfx900-valid — num_warps 2/4/8;
+the one `num_warps=32` config in `l2norm.py:23` is invalid on wave64 but isn't
+on this hot path.)
 
-The correct config to isolate graphs from compile is
-`mode=NONE` + `cudagraph_mode=FULL_DECODE_ONLY`. The model loads, but during the
-graph-capture warmup at **TP=8** the hardware hung and the driver's recovery
-**failed**:
-
-```
-amdgpu 0000:25:00.0: KCQ enable failed
-resume of IP block <gfx_v9_0> failed -110
-GPU reset end with ret = -22          ← reset FAILED, not recovered
-VRAM is lost due to GPU reset!
-[powerplay] No response from smu / fw load failed
-[powerplay] firmware(0x1) doesn't match SMU9_DRIVER_IF_VERSION(0xe)
-```
-
-`rocm-smi` then enumerated only **15/16 GPUs** — the hung GPU's SMU (power
-microcontroller) was wedged and **only a full host reboot brought it back**.
-The stale SMU firmware (`0x1` vs expected `0xe`) means the in-driver GPU-reset
-path cannot recover a Vega10 hang on this box, so a graph-capture hang escalates
-to a dead GPU until reboot.
-
-### Layer 3 — even the safest settings never finish (infinite autotune)
-
-After rebooting (all 16 GPUs healthy again), we retried with the most
-conservative settings possible: **TP=4, single socket, `cudagraph_capture_sizes=[1]`,
-`max_num_batched_tokens=2048`, 600 s hard timeout.** This time **no GPU hang**
-(dmesg clean), but init **never completed** — the worker sat in
-`triton/backends/amd/compiler.py make_amdgcn` → `autotuner do_bench`,
-re-JIT-compiling kernels for the capture shapes without ever converging
-(`~/.triton/cache` `.hsaco` count frozen at 426 for >8 min). It hit the 600 s
-timeout still in warmup. The graph-capture code path re-triggers Triton
-autotuning for the GDN/FLA kernels in a way that does not terminate in
-reasonable time on gfx900.
-
-### Conclusion
-
-**`enforce_eager=True` is correct and required on gfx900 for this stack.** HIP
-CUDA graphs are not viable here:
-
-1. torch.compile (Inductor) is broken on ROCm → `mode=NONE` mandatory;
-2. full graph capture can hard-hang the GPU, and the SMU-firmware mismatch makes
-   the driver reset path fail → **a hang = a dead GPU until reboot** (risky);
-3. even the minimal-footprint capture never escapes Triton autotune.
-
-So the ~120 ms/token decode floor is **not** simply removable launch overhead —
-on this hardware the eager path is the only stable one, and the per-token cost
-is intrinsic (no MFMA, no packed-FP16, per-layer PCIe all-reduce). The
-realistic levers remain the ones already validated in `BENCH_GFX900.md`:
-**pipeline parallelism over wide TP** (removes per-layer all-reduce) and
-**batching/concurrency** (amortizes fixed per-step latency). A future ROCm with
-working ROCm-Inductor and updated Vega10 SMU firmware would be the prerequisite
-to revisit graphs.
-
-### Repro / guardrails
-
-If anyone retries graphs on gfx900: use a **hard `timeout`**, watch
-`dmesg | grep amdgpu` for `KCQ enable failed` / `GPU reset`, and be ready to
-**reboot** — do not run it unattended across all 16 GPUs.
+## Bottom line / guidance
+- Keep **`enforce_eager=True`** for serving on gfx900 — graphs add a long cold
+  autotune and buy nothing.
+- If you must experiment with graphs: set `amdgpu.reset_method=2` first (mode1),
+  use `mode=NONE` + `FULL_DECODE_ONLY` + small `cudagraph_capture_sizes`, run
+  with a hard `timeout`, watch `dmesg | grep -E "GPU reset|amdgpu.*fail"`, and
+  pre-warm the Triton cache so init is ~1 min instead of ~11 min.
+- The decode floor is a **hardware** property (no MFMA/packed-FP16 + PCIe TP
+  all-reduce), not a software/launch artifact. Optimize via PP + batching.

--- a/PERF_GFX900.md
+++ b/PERF_GFX900.md
@@ -618,3 +618,55 @@ measured. After a structural change (here LLMM1 halving GPU-busy), revisit prior
 negatives — the cheap A/B flipped from 0% to 3.6x.
 
 Repro: `bench_scripts/graph_ab.py {eager|graph}`, `bench_scripts/graph_combo.py graph turboquant_k8v4`.
+
+# PP-over-TP revisited after LLMM1 + CUDA graphs (issue #55) — the advantage inverted
+
+BENCH_GFX900.md (eager, pre-LLMM1) found pipeline parallel beat tensor parallel at
+equal GPU count by +48-90%, for two reasons: (1) PP swaps the per-layer all-reduce
+for cheap point-to-point sends, and (2) pure TP makes each gfx900 do a small,
+inefficient slice of a matrix-core-less FP16 GEMM. **Both reasons were undermined by
+later work**, so we re-measured.
+
+## What changed since the original PP benchmark
+- **#56 profile**: RCCL all-reduce is only ~2% of the decode step, not the dominant
+  cost the PP motivation assumed.
+- **#59 LLMM1**: decode GEMMs are now real GEMVs, not padded macrotile matmuls. A
+  GEMV is not "inefficiently sliced" by a 4-way TP split -> reason (2) is gone.
+- **#63 CUDA graphs**: the host dispatch gap that PP's pipelining used to hide is
+  now removed for everyone.
+
+## Head-to-head, 4 GPUs, one socket, LLMM1 + CUDA graphs, Qwen3.5-9B
+Offline `LLM.generate`, decode out tok/s (aggregate), max_num_seqs=32.
+
+| concurrency | TP4 | TP2xPP2 | winner |
+|---|---:|---:|---|
+| c=1 (single-stream) | **52.3** | 32.5 | **TP4 +61%** |
+| c=8 | 48.9 | **54.8** | PP +12% |
+| c=32 (peak throughput) | **220.0** | 176.4 | **TP4 +25%** |
+
+Contrast with the old eager numbers (PP won every cell, +48-90%). With LLMM1 +
+graphs, **TP4 now wins single-stream and peak throughput**; PP only edges ahead in a
+narrow mid-concurrency band (c~8) where its pipeline fills but TP hasn't yet reached
+its batched sweet spot.
+
+### Why TP flipped to winning
+- TP4 c=1 went from ~4.6 tok/s (old eager) to **52.3** (LLMM1 + graphs) = ~11x. The
+  things that made TP slow (padded GEMM slices, per-step dispatch) are exactly what
+  LLMM1 + graphs fixed, so TP no longer needs PP to hide them.
+- PP's structural latency tax (c=1 must walk all pipeline stages) is now a net
+  negative because there's no longer a big per-layer overhead for it to amortize.
+
+## 8-GPU PP not usable here (offline)
+TP2xPP4 (8 GPUs) crashes during init on the offline `LLM.generate` path in this build
+— `hipErrorLaunchFailure` across all PP ranks, in **both** eager and graph modes
+(GPUs recover via reset_method=2). The old TP2xPP4 numbers came from server mode with
+`--no-async-scheduling`; the offline PP4 path regressed since. Not pursued further —
+the 4-GPU result already answers the question, and TP4 is the better config anyway.
+
+## Recommendation (updated)
+**Use TP (TP4 within one socket), not PP, for gfx900 decode now that LLMM1 + CUDA
+graphs are in.** PP was the right call in the eager/padded-GEMM era; it is no longer.
+The remaining decode levers are batching/concurrency (TP4 scales to ~220 tok/s at
+c=32) and the int4 + TurboQuant stack.
+
+Repro: `bench_scripts/pp_bench.py {tp4|tp2pp2} {graph|eager} <num_gpus>`.

--- a/PERF_LMHEAD_GFX900.md
+++ b/PERF_LMHEAD_GFX900.md
@@ -1,0 +1,58 @@
+
+# The biggest decode win: enable LLMM1 skinny GEMV for gfx900 (issue #59)
+
+The decode profile (#56, BENCH_DECODE_PROFILE.md) showed M=1 GEMMs were 43% of decode
+wall time, running at only 20% of the bandwidth roofline because rocBLAS pads a 1-row
+GEMV to a 64x64 macrotile (`Cijk_..MT64x64x4`). Root cause found:
+
+**gfx900 is excluded from `on_gfx9()`** (which only lists gfx908/gfx90a/gfx942/gfx950).
+vLLM already ships hand-written skinny GEMV ops (`LLMM1`, `wvSplitK`) gated on
+`on_gfx9() or on_gfx1x()`, so on gfx900 they were never used and every M=1 decode
+matmul fell through to the padded rocBLAS path.
+
+## Microbench (lm_head shape, M=1, k=4096, single gfx900)
+| vocab shard | rocBLAS | LLMM1 | speedup | rel err |
+|---|---:|---:|---:|---:|
+| 62080 (TP4) | 5.33 ms | **1.46 ms** | **3.66x** | 5.5e-4 |
+| 124160 (TP2) | 10.14 ms | 2.92 ms | 3.47x | 5.4e-4 |
+| 248320 (TP1) | 20.21 ms | 5.83 ms | 3.46x | 5.0e-4 |
+
+`LLMM1` is correct on wave64 and ~3.5x faster. **`wvSplitK` (the n>1 branch) hits a
+device-side assertion and crashes the GPU on gfx900** (recovered cleanly thanks to
+reset_method=2). So we enable only the `LLMM1` branch: n==1, m%4==0, k<=8192, bias=None.
+
+## The fix
+A narrow gfx900 block in `rocm_unquantized_gemm_impl` (vllm/model_executor/layers/utils.py)
+that routes M=1 unquantized FP16 GEMMs through `LLMM1`. This covers **lm_head AND the
+M=1 FP16 projections** (qkv / o / gate_up where k<=8192, m%4==0). down_proj (k=12288)
+and any m not %4 stay on rocBLAS.
+
+## End-to-end (Qwen3.5-9B, TP4, enforce_eager, bs=1 decode)
+| | tok/s | ms/step |
+|---|---:|---:|
+| FP16, before | 6.65 | ~150 |
+| **FP16, LLMM1** | **14.85** | **67.3** |
+
+**2.2x decode speedup**, coherent output. Re-profile confirms the mechanism: GEMM time
+**65.9 -> 6.5 ms/step (10x)** (5.46 ms LLMM1 + 1.0 ms remaining rocBLAS for down_proj /
+gate_up). The padded-macrotile waste is gone.
+
+## Compounding with the other gfx900 wins
+lm_head stays FP16 even under AWQ, so LLMM1 also speeds up the int4 + TurboQuant stack:
+
+| Config | decode tok/s |
+|---|---:|
+| AWQ int4 + TQ KV (before LLMM1) | 9.97 |
+| **AWQ int4 + TQ KV + LLMM1** | **14.12** |
+
+All three optimizations active and coherent (TP2, half the GPUs).
+
+Repro: `bench_scripts/skinny_bench.py` (microbench), `bench_scripts/lmhead_e2e.py` (e2e).
+
+## General lesson
+Hardware that is "GFX9 ISA but no MFMA" (gfx900/Vega10) often falls outside vendor
+fast-path gates written for MFMA-capable CDNA. Several of those fast paths
+(`LLMM1` here) are pure ALU GEMVs that work fine on wave64 — they just need the device
+let into the gate. Always check the existing skinny/GEMV ops before writing a new
+kernel; here the win was a 1-condition gate, not new code. (Verify each op: `wvSplitK`
+from the same family crashes — never enable a whole gate blind.)

--- a/bench_scripts/ab_decode.py
+++ b/bench_scripts/ab_decode.py
@@ -1,0 +1,28 @@
+import os, time, sys
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CompilationMode, CUDAGraphMode
+
+def main():
+    MODE = sys.argv[1]
+    common = dict(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+                  gpu_memory_utilization=0.85, max_model_len=2048,
+                  max_num_batched_tokens=2048, **{"language_model_only": True})
+    if MODE=="eager":
+        llm = LLM(enforce_eager=True, **common)
+    else:
+        cc = CompilationConfig(mode=CompilationMode.NONE,
+                               cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+                               cudagraph_capture_sizes=[1])
+        llm = LLM(compilation_config=cc, **common)
+    sp = SamplingParams(max_tokens=128, temperature=0, ignore_eos=True)
+    llm.generate(["warmup prompt here"], sp)
+    prompt = "Write a detailed explanation of how transformers work in machine learning."
+    N=3; tot=0.0; toks=0
+    for i in range(N):
+        t0=time.time(); o=llm.generate([prompt], sp); dt=time.time()-t0
+        n=len(o[0].outputs[0].token_ids); tot+=dt; toks+=n
+    print(f"MODE={MODE} avg_total={tot/N:.3f}s tokens={toks//N} tok_s={toks/tot:.2f} ms_per_tok={1000*tot/toks:.1f}", flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/awq_e2e.py
+++ b/bench_scripts/awq_e2e.py
@@ -1,0 +1,19 @@
+import os, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    llm = LLM(model="QuantTrio/Qwen3.5-9B-AWQ", tensor_parallel_size=2, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=4096,
+              max_num_seqs=64, **{"language_model_only": True})
+    # correctness
+    o=llm.generate(["The capital of France is"], SamplingParams(max_tokens=24,temperature=0))
+    print("CORRECT:", repr(o[0].outputs[0].text), flush=True)
+    # decode latency bs=1
+    prompt="Write a long detailed essay about the history of computing."
+    sp=SamplingParams(max_tokens=128,temperature=0,ignore_eos=True)
+    llm.generate([prompt], SamplingParams(max_tokens=8,temperature=0,ignore_eos=True))
+    for B in [1,8,32]:
+        t0=time.time(); oo=llm.generate([prompt]*B, sp); dt=time.time()-t0
+        ot=sum(len(x.outputs[0].token_ids) for x in oo)
+        print("B=%2d agg_tok_s=%.2f ms_per_tok=%.1f"%(B, ot/dt, 1000*dt/128), flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/awq_sweep.py
+++ b/bench_scripts/awq_sweep.py
@@ -1,0 +1,18 @@
+import os, time, sys
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    TP=int(sys.argv[1])
+    llm = LLM(model="QuantTrio/Qwen3.5-9B-AWQ", tensor_parallel_size=TP, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=4096,
+              max_num_seqs=160, **{"language_model_only": True})
+    prompt="Write a long detailed essay about the history of computing."
+    GEN=96
+    llm.generate([prompt], SamplingParams(max_tokens=8,temperature=0,ignore_eos=True))
+    print("== AWQ INT4 decode sweep (TP%d, gen=%d) =="%(TP,GEN), flush=True)
+    for B in [1,8,32,64,96]:
+        sp=SamplingParams(max_tokens=GEN,temperature=0,ignore_eos=True)
+        t0=time.time(); o=llm.generate([prompt]*B, sp); dt=time.time()-t0
+        ot=sum(len(x.outputs[0].token_ids) for x in o)
+        print("B=%3d out=%5d wall=%6.2fs agg_tok_s=%7.2f per_step_ms=%6.1f"%(B,ot,dt,ot/dt,1000*dt/GEN), flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/awq_test.py
+++ b/bench_scripts/awq_test.py
@@ -1,0 +1,16 @@
+import os, time, sys
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    TP=int(sys.argv[1]) if len(sys.argv)>1 else 2
+    t0=time.time()
+    llm = LLM(model="QuantTrio/Qwen3.5-9B-AWQ", tensor_parallel_size=TP,
+              dtype="float16", enforce_eager=True,
+              gpu_memory_utilization=0.90, max_model_len=4096,
+              max_num_seqs=64, **{"language_model_only": True})
+    print("AWQ_INIT TP=%d in %.1fs"%(TP,time.time()-t0), flush=True)
+    sp=SamplingParams(max_tokens=32, temperature=0)
+    o=llm.generate(["The capital of France is"], sp)
+    print("RESULT:", repr(o[0].outputs[0].text), flush=True)
+    print("ALL_DONE", flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/batch_sweep.py
+++ b/bench_scripts/batch_sweep.py
@@ -1,0 +1,21 @@
+import os, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    llm = LLM(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=4096,
+              max_num_seqs=160, **{"language_model_only": True})
+    prompt = "Write a long detailed essay about the history of computing."
+    GEN=96
+    # warmup
+    llm.generate([prompt], SamplingParams(max_tokens=8, temperature=0, ignore_eos=True))
+    print("== decode batch sweep (TP4, FP16, gen=%d tok) =="%GEN, flush=True)
+    for B in [32,48,64,96,128]:
+        sp = SamplingParams(max_tokens=GEN, temperature=0, ignore_eos=True)
+        prompts=[prompt]*B
+        t0=time.time(); o=llm.generate(prompts, sp); dt=time.time()-t0
+        outtok=sum(len(x.outputs[0].token_ids) for x in o)
+        # subtract approx prefill by measuring step rate: total decode tok / wall
+        print("B=%2d  out_tok=%4d  wall=%6.2fs  agg_tok_s=%6.2f  per_step_ms=%6.1f"%(
+              B, outtok, dt, outtok/dt, 1000*dt/GEN), flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/coder_prof.py
+++ b/bench_scripts/coder_prof.py
@@ -1,0 +1,27 @@
+import os, time, glob
+os.environ.setdefault("VLLM_USE_V1", "1")
+PROF = "/home/larkinwc/coder_prof"
+os.makedirs(PROF, exist_ok=True)
+from vllm import LLM, SamplingParams
+from vllm.config.profiler import ProfilerConfig
+
+
+def main():
+    llm = LLM(model="bullpoint/Qwen3-Coder-Next-AWQ-4bit",
+              tensor_parallel_size=4, pipeline_parallel_size=2, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.92, max_model_len=32768,
+              max_num_seqs=16, trust_remote_code=True,
+              profiler_config=ProfilerConfig(profiler="torch", torch_profiler_dir=PROF,
+                                             torch_profiler_with_stack=False))
+    sp = SamplingParams(max_tokens=64, temperature=0, ignore_eos=True)
+    llm.generate(["The capital of France is"], sp)  # warm steady state
+    llm.start_profile()
+    llm.generate(["Tell me a story."], SamplingParams(max_tokens=64, temperature=0, ignore_eos=True))
+    llm.stop_profile()
+    time.sleep(3)
+    print("TRACES:", sorted(glob.glob(PROF + "/*")), flush=True)
+    print("PROF_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/coder_smoke.py
+++ b/bench_scripts/coder_smoke.py
@@ -1,0 +1,46 @@
+"""Qwen3-Coder-Next-AWQ-4bit bring-up smoke test on gfx900.
+Usage: coder_smoke.py <layout> <graph|eager>   layout in {tp4pp2, tp8, tp4}
+Issue #65. TP4xPP2 on one socket (GPUs 0-7).
+"""
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1", "1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+
+MODEL = "bullpoint/Qwen3-Coder-Next-AWQ-4bit"
+
+
+def main():
+    layout = sys.argv[1] if len(sys.argv) > 1 else "tp4pp2"
+    graphs = (len(sys.argv) > 2 and sys.argv[2] == "graph")
+    tp, pp = dict(tp4pp2=(4, 2), tp8=(8, 1), tp4=(4, 1))[layout]
+    kw = dict(model=MODEL, tensor_parallel_size=tp, pipeline_parallel_size=pp,
+              dtype="float16", gpu_memory_utilization=0.92, max_model_len=32768,
+              max_num_seqs=16, trust_remote_code=True)
+    if graphs:
+        kw["enforce_eager"] = False
+        kw["compilation_config"] = CompilationConfig(
+            mode=CompilationMode.NONE,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+            cudagraph_capture_sizes=[1])
+    else:
+        kw["enforce_eager"] = True
+    t0 = time.time()
+    llm = LLM(**kw)
+    print("INIT[%s g=%s tp=%d pp=%d] %.0fs" % (layout, graphs, tp, pp, time.time() - t0), flush=True)
+    sp = SamplingParams(max_tokens=64, temperature=0)
+    prompt = "Write a Python function that returns the nth Fibonacci number.\n"
+    o = llm.generate([prompt], sp)
+    print("=== OUTPUT ===", flush=True)
+    print(o[0].outputs[0].text, flush=True)
+    # quick decode tok/s, bs=1
+    sp2 = SamplingParams(max_tokens=96, temperature=0, ignore_eos=True)
+    llm.generate([prompt], SamplingParams(max_tokens=4, temperature=0, ignore_eos=True))
+    t0 = time.time(); o = llm.generate([prompt], sp2); dt = time.time() - t0
+    tot = len(o[0].outputs[0].token_ids)
+    print("DECODE bs=1: %.1f tok/s (%.1f ms/tok)" % (tot / dt, 1000 * dt / tot), flush=True)
+    print("CODER_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/coder_tput.py
+++ b/bench_scripts/coder_tput.py
@@ -1,0 +1,41 @@
+"""Qwen3-Coder-Next MoE throughput sweep on gfx900 (TP4xPP2, graphs).
+Usage: coder_tput.py [kv_dtype]   kv_dtype in {auto, turboquant_k8v4}
+Sweeps concurrency c in {1,8,16,32}, reports aggregate + per-stream tok/s.
+Issue #65 option B."""
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1", "1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+
+MODEL = "bullpoint/Qwen3-Coder-Next-AWQ-4bit"
+
+
+def main():
+    kv = sys.argv[1] if len(sys.argv) > 1 else "auto"
+    kw = dict(model=MODEL, tensor_parallel_size=4, pipeline_parallel_size=2,
+              dtype="float16", gpu_memory_utilization=0.92, max_model_len=32768,
+              max_num_seqs=32, trust_remote_code=True, enforce_eager=False,
+              compilation_config=CompilationConfig(mode=CompilationMode.NONE,
+                  cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+                  cudagraph_capture_sizes=[1, 8, 16, 32]))
+    if kv != "auto":
+        kw["kv_cache_dtype"] = kv
+    t0 = time.time()
+    llm = LLM(**kw)
+    print("INIT[tput kv=%s] %.0fs" % (kv, time.time() - t0), flush=True)
+    base = "Write a short note about topic number "
+    for c in [1, 8, 16, 32]:
+        prompts = [base + str(i) for i in range(c)]
+        sp = SamplingParams(max_tokens=96, temperature=0, ignore_eos=True)
+        llm.generate(prompts[:1], SamplingParams(max_tokens=4, temperature=0, ignore_eos=True))
+        t0 = time.time()
+        o = llm.generate(prompts, sp)
+        dt = time.time() - t0
+        tot = sum(len(x.outputs[0].token_ids) for x in o)
+        print("[kv=%s] c=%2d  agg_tok/s=%.1f  per-stream=%.2f  tpot_ms=%.1f"
+              % (kv, c, tot / dt, tot / dt / c, 1000 * dt / 96), flush=True)
+    print("TPUT_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/combo_dec.py
+++ b/bench_scripts/combo_dec.py
@@ -1,0 +1,19 @@
+import os, time, sys
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    preset = sys.argv[1]
+    kw = dict(model="QuantTrio/Qwen3.5-9B-AWQ", tensor_parallel_size=2, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.85, max_model_len=4096,
+              **{"language_model_only": True})
+    if preset!="auto": kw["kv_cache_dtype"]=preset
+    llm=LLM(**kw)
+    sp=SamplingParams(max_tokens=128, temperature=0, ignore_eos=True)
+    p=["The capital of France is"]
+    llm.generate(p, SamplingParams(max_tokens=8,temperature=0,ignore_eos=True))  # warm
+    t0=time.time(); o=llm.generate(p, sp); dt=time.time()-t0
+    n=len(o[0].outputs[0].token_ids)
+    print("DECODE[%s] short-ctx B=1: %.2f tok/s  %.1f ms/tok (n=%d)"%(preset,n/dt,1000*dt/n,n), flush=True)
+    print("SAMPLE:", repr(o[0].outputs[0].text[:80]), flush=True)
+    print("DONE_%s"%preset, flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/gate_bench.py
+++ b/bench_scripts/gate_bench.py
@@ -1,0 +1,54 @@
+"""Microbench the shared_expert_gate GEMV [n=1,k=2048] @ [m,2048]^T -> [1,m]
+for m in {1}, the decode shape that falls to padded rocBLAS MT64x64x8.
+Compare: rocBLAS (F.linear), mul+sum, LLMM1-with-pad-to-4, tiny.
+Correctness vs torch ref (rel-err), then ms over many iters. Issue #65 option A.
+Single GPU (cuda:0)."""
+import torch, time
+import vllm._custom_ops as ops
+
+dev = "cuda:0"
+torch.manual_seed(0)
+K = 2048
+iters = 2000
+
+
+def bench(fn, ref, name):
+    # correctness
+    out = fn()
+    rel = (out.float() - ref.float()).abs().max().item() / (ref.float().abs().max().item() + 1e-9)
+    torch.cuda.synchronize()
+    # time
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    us = (time.perf_counter() - t0) / iters * 1e6
+    print("  %-22s rel_err=%.2e  %.1f us/call" % (name, rel, us), flush=True)
+    return us
+
+
+for m in [1, 2]:
+    print("=== m=%d k=%d (n=1) ===" % (m, K), flush=True)
+    x = torch.randn(1, K, device=dev, dtype=torch.float16)
+    w = torch.randn(m, K, device=dev, dtype=torch.float16)
+    ref = torch.nn.functional.linear(x.float(), w.float())  # fp32 ref
+
+    bench(lambda: torch.nn.functional.linear(x, w), ref, "F.linear (rocBLAS)")
+    bench(lambda: (x * w).sum(dim=-1, keepdim=True).t() if m > 1 else (x * w).sum(dim=-1, keepdim=True), ref, "mul+sum")
+    # matmul variant
+    bench(lambda: x @ w.t(), ref, "x @ w.t()")
+
+    # LLMM1 with weight padded to multiple of 4 rows
+    mp = ((m + 3) // 4) * 4
+    wpad = torch.zeros(mp, K, device=dev, dtype=torch.float16)
+    wpad[:m] = w
+
+    def llmm1_pad():
+        o = ops.LLMM1(wpad, x, 4)
+        return o[:, :m]
+    try:
+        bench(llmm1_pad, ref, "LLMM1(pad m->%d)" % mp)
+    except Exception as e:
+        print("  LLMM1 pad FAILED:", str(e)[:60], flush=True)
+
+print("GATE_BENCH_DONE", flush=True)

--- a/bench_scripts/gemv_bench.py
+++ b/bench_scripts/gemv_bench.py
@@ -115,7 +115,7 @@ def awq_gemv_splitk_kernel(
     tl.atomic_add(c_ptr + offs_n, acc, mask=mask_n)
 
 
-def awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=64, num_warps=4, split_k=4):
+def awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=64, num_warps=4, split_k=4, num_stages=2):
     K = a.shape[-1]; N = scales.shape[1]
     c = torch.zeros((N,), dtype=torch.float32, device=a.device)
     n_groups = K // G
@@ -123,7 +123,7 @@ def awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=64, num_warps=4, split_k=4):
     grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(n_groups, gpp))
     awq_gemv_splitk_kernel[grid](a, qw, scales, qz, c, K, N,
                                  G=G, BLOCK_N=BLOCK_N, GROUPS_PER_PID=gpp,
-                                 num_warps=num_warps)
+                                 num_warps=num_warps, num_stages=num_stages)
     return c.to(a.dtype)
 
 
@@ -199,21 +199,23 @@ def main():
                     pass
         t, BN, nw = best
         print(f"   int4 GEMV*: {t:.3f} ms  ({gb_i4/(t/1e3):.0f} GB/s)  [BLOCK_N={BN} warps={nw}]  speedup {t_fp16/t:.2f}x")
-        # split-K variant
+        # split-K variant (wider sweep)
         bestk = None
-        for BN in [32, 64, 128]:
+        n_groups = K // G
+        for BN in [32, 64, 128, 256]:
             for nw in [1, 2, 4]:
-                for sk in [2, 4, 8, 16]:
-                    try:
-                        c2 = awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw, split_k=sk)
-                        if (c_ref.float() - c2.float()).abs().max().item() > 0.5: continue
-                        tt = bench(lambda: awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw, split_k=sk))
-                        if bestk is None or tt < bestk[0]: bestk = (tt, BN, nw, sk)
-                    except Exception:
-                        pass
+                for sk in [4, 8, 16, 32, 48, n_groups]:
+                    for ns in [1, 2, 3]:
+                        try:
+                            c2 = awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw, split_k=sk, num_stages=ns)
+                            if (c_ref.float() - c2.float()).abs().max().item() > 0.5: continue
+                            tt = bench(lambda: awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw, split_k=sk, num_stages=ns))
+                            if bestk is None or tt < bestk[0]: bestk = (tt, BN, nw, sk, ns)
+                        except Exception:
+                            pass
         if bestk:
-            tt, BN, nw, sk = bestk
-            print(f"   int4 splitK: {tt:.3f} ms  ({gb_i4/(tt/1e3):.0f} GB/s)  [BLOCK_N={BN} warps={nw} splitK={sk}]  speedup {t_fp16/tt:.2f}x")
+            tt, BN, nw, sk, ns = bestk
+            print(f"   int4 splitK: {tt:.3f} ms  ({gb_i4/(tt/1e3):.0f} GB/s)  [BLOCK_N={BN} warps={nw} splitK={sk} stages={ns}]  speedup {t_fp16/tt:.2f}x")
 
 
 if __name__ == "__main__":

--- a/bench_scripts/gemv_bench.py
+++ b/bench_scripts/gemv_bench.py
@@ -1,0 +1,220 @@
+"""Microbenchmark: hand-written int4 AWQ GEMV (M=1) for gfx900 vs FP16 and vs
+the existing padded tl.dot W4A16 path. Issue #57.
+
+AWQ layout:
+  qweight [K, N//8] int32  (8 int4 packed per int32 along N, reverse-AWQ order)
+  scales  [K//G, N] fp16
+  qzeros  [K//G, N//8] int32 (same packing as qweight)
+reverse-AWQ order = [0,4,1,5,2,6,3,7]; shift = order*4.
+"""
+import torch, time
+import triton
+import triton.language as tl
+
+DEV = "cuda"
+
+
+# ----------------------- int4 AWQ GEMV (M=1) -----------------------
+@triton.jit
+def awq_gemv_kernel(
+    a_ptr,        # [K] fp16   (single token activation vector)
+    qw_ptr,       # [K, N//8] int32
+    scales_ptr,   # [K//G, N] fp16
+    qz_ptr,       # [K//G, N//8] int32
+    c_ptr,        # [N] fp16
+    K, N,
+    G: tl.constexpr,
+    BLOCK_N: tl.constexpr,   # output cols per program (multiple of 8)
+):
+    # One program owns BLOCK_N output columns and loops over all K.
+    # Scales/zeros are loaded ONCE PER GROUP (not per K-row) -> tiny.
+    pid_n = tl.program_id(0)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)   # [BN] output cols
+    mask_n = offs_n < N
+    offs_n8 = pid_n * (BLOCK_N // 8) + tl.arange(0, BLOCK_N // 8)
+    mask_n8 = offs_n8 < (N // 8)
+
+    # reverse-AWQ shifts: order[j]=(j%2)*4+(j//2); shift=order*4
+    j = tl.arange(0, BLOCK_N) % 8
+    shifts = ((j % 2) * 4 + (j // 2)) * 4              # [BN]
+    j8 = tl.arange(0, BLOCK_N // 8)                    # unused but documents packing
+
+    acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    shifts2d = shifts[None, :]                          # [1,BN]
+
+    # BLOCK_K rows per step; BLOCK_K <= G so each tile is within ONE group.
+    n_groups = K // G
+    for g in range(0, n_groups):
+        # group scales/zeros loaded ONCE per group as [BN]
+        s_ptrs = scales_ptr + g * N + offs_n
+        scales = tl.load(s_ptrs, mask=mask_n, other=0.0).to(tl.float32)   # [BN]
+        qz_ptrs = qz_ptr + g * (N // 8) + offs_n8
+        qzv = tl.load(qz_ptrs, mask=mask_n8, other=0)                     # [BN//8]
+        ze = tl.interleave(qzv, qzv); ze = tl.interleave(ze, ze); ze = tl.interleave(ze, ze)
+        zf = ((ze >> shifts) & 0xF).to(tl.float32)                        # [BN]
+
+        # one 2D tile of G rows: [G, BN]
+        offs_k = g * G + tl.arange(0, G)                                  # [G]
+        a = tl.load(a_ptr + offs_k).to(tl.float32)                        # [G]
+        qw_ptrs = qw_ptr + offs_k[:, None] * (N // 8) + offs_n8[None, :]   # [G, BN//8]
+        m_w = (offs_k[:, None] < K) & mask_n8[None, :]
+        qwt = tl.load(qw_ptrs, mask=m_w, other=0)                         # [G, BN//8]
+        bt = tl.interleave(qwt, qwt); bt = tl.interleave(bt, bt); bt = tl.interleave(bt, bt)  # [G,BN]
+        bt = (bt >> shifts2d) & 0xF
+        wt = (bt.to(tl.float32) - zf[None, :]) * scales[None, :]          # [G, BN]
+        acc += tl.sum(a[:, None] * wt, axis=0)                            # [BN]
+
+    c = acc.to(c_ptr.type.element_ty)
+    tl.store(c_ptr + offs_n, c, mask=mask_n)
+
+
+def awq_gemv(a, qw, scales, qz, G, BLOCK_N=64, num_warps=4):
+    K = a.shape[-1]
+    N = scales.shape[1]
+    c = torch.empty((N,), dtype=a.dtype, device=a.device)
+    grid = (triton.cdiv(N, BLOCK_N),)
+    awq_gemv_kernel[grid](a, qw, scales, qz, c, K, N, G,
+                          BLOCK_N=BLOCK_N, num_warps=num_warps)
+    return c
+
+
+@triton.jit
+def awq_gemv_splitk_kernel(
+    a_ptr, qw_ptr, scales_ptr, qz_ptr, c_ptr,
+    K, N,
+    G: tl.constexpr, BLOCK_N: tl.constexpr, GROUPS_PER_PID: tl.constexpr,
+):
+    pid_n = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N
+    offs_n8 = pid_n * (BLOCK_N // 8) + tl.arange(0, BLOCK_N // 8)
+    mask_n8 = offs_n8 < (N // 8)
+    j = tl.arange(0, BLOCK_N) % 8
+    shifts = ((j % 2) * 4 + (j // 2)) * 4
+    shifts2d = shifts[None, :]
+    acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    g0 = pid_k * GROUPS_PER_PID
+    for gi in range(0, GROUPS_PER_PID):
+        g = g0 + gi
+        s_ptrs = scales_ptr + g * N + offs_n
+        scales = tl.load(s_ptrs, mask=mask_n, other=0.0).to(tl.float32)
+        qz_ptrs = qz_ptr + g * (N // 8) + offs_n8
+        qzv = tl.load(qz_ptrs, mask=mask_n8, other=0)
+        ze = tl.interleave(qzv, qzv); ze = tl.interleave(ze, ze); ze = tl.interleave(ze, ze)
+        zf = ((ze >> shifts) & 0xF).to(tl.float32)
+        offs_k = g * G + tl.arange(0, G)
+        a = tl.load(a_ptr + offs_k).to(tl.float32)
+        qw_ptrs = qw_ptr + offs_k[:, None] * (N // 8) + offs_n8[None, :]
+        m_w = (offs_k[:, None] < K) & mask_n8[None, :]
+        qwt = tl.load(qw_ptrs, mask=m_w, other=0)
+        bt = tl.interleave(qwt, qwt); bt = tl.interleave(bt, bt); bt = tl.interleave(bt, bt)
+        bt = (bt >> shifts2d) & 0xF
+        wt = (bt.to(tl.float32) - zf[None, :]) * scales[None, :]
+        acc += tl.sum(a[:, None] * wt, axis=0)
+    tl.atomic_add(c_ptr + offs_n, acc, mask=mask_n)
+
+
+def awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=64, num_warps=4, split_k=4):
+    K = a.shape[-1]; N = scales.shape[1]
+    c = torch.zeros((N,), dtype=torch.float32, device=a.device)
+    n_groups = K // G
+    gpp = triton.cdiv(n_groups, split_k)
+    grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(n_groups, gpp))
+    awq_gemv_splitk_kernel[grid](a, qw, scales, qz, c, K, N,
+                                 G=G, BLOCK_N=BLOCK_N, GROUPS_PER_PID=gpp,
+                                 num_warps=num_warps)
+    return c.to(a.dtype)
+
+
+# reference dequant in torch (for correctness)
+def awq_dequant_ref(qw, scales, qz, G):
+    K, N8 = qw.shape
+    N = N8 * 8
+    shifts = torch.tensor([(((j % 8) % 2) * 4 + ((j % 8) // 2)) * 4 for j in range(N)],
+                          device=qw.device, dtype=torch.int32)
+    gk = (torch.arange(K, device=qw.device) // G)
+    # weights packed per-K: [K,N8]->[K,N]
+    b = qw.repeat_interleave(8, dim=1)            # [K, N]
+    b = (b >> shifts[None, :]) & 0xF
+    # zeros packed per-group: [K//G,N8]->[K//G,N]->index by gk ->[K,N]
+    zg = qz.repeat_interleave(8, dim=1)           # [K//G, N]
+    zg = (zg >> shifts[None, :]) & 0xF
+    z = zg[gk]                                     # [K, N]
+    s = scales[gk]                                 # [K, N]
+    w = (b.to(torch.float32) - z.to(torch.float32)) * s.to(torch.float32)
+    return w                                        # [K, N] fp32
+
+
+def bench(fn, *a, iters=50, warm=10):
+    for _ in range(warm): fn(*a)
+    torch.cuda.synchronize()
+    t0 = time.time()
+    for _ in range(iters): fn(*a)
+    torch.cuda.synchronize()
+    return (time.time() - t0) / iters * 1e3  # ms
+
+
+def make_awq(K, N, G):
+    N8 = N // 8
+    qw = torch.randint(0, 2**31, (K, N8), dtype=torch.int32, device=DEV)
+    qz = torch.randint(0, 2**31, (K // G, N8), dtype=torch.int32, device=DEV)
+    scales = (torch.randn(K // G, N, device=DEV) * 0.01).to(torch.float16)
+    return qw, scales, qz
+
+
+def main():
+    torch.manual_seed(0)
+    G = 128
+    shapes = [
+        ("gate/up", 4096, 12288 * 2),
+        ("down",    12288, 4096),
+    ]
+    for name, K, N in shapes:
+        a = (torch.randn(K, device=DEV) * 0.1).to(torch.float16)
+        qw, scales, qz = make_awq(K, N, G)
+        # correctness vs ref (dequant @ a)
+        w_ref = awq_dequant_ref(qw, scales, qz, G)        # [K,N] fp32
+        c_ref = (a.to(torch.float32) @ w_ref).to(torch.float16)
+        c_gemv = awq_gemv(a, qw, scales, qz, G)
+        err = (c_ref.float() - c_gemv.float()).abs().max().item()
+        rel = err / (c_ref.float().abs().max().item() + 1e-6)
+        # FP16 baseline GEMV (full dense weight)
+        w16 = w_ref.to(torch.float16)
+        def fp16_gemv(): return (a @ w16)
+        t_fp16 = bench(fp16_gemv)
+        gb_i4 = K * N * 0.5 / 1e9
+        gb_16 = K * N * 2 / 1e9
+        print(f"[{name}] K={K} N={N}  maxabs_err={err:.4f} rel={rel:.4f}")
+        print(f"   fp16 GEMV : {t_fp16:.3f} ms  ({gb_16/(t_fp16/1e3):.0f} GB/s)")
+        best = None
+        for BN in [32, 64, 128, 256]:
+            for nw in [1, 2, 4, 8]:
+                try:
+                    c2 = awq_gemv(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw)
+                    if (c_ref.float() - c2.float()).abs().max().item() > 0.5: continue
+                    t = bench(lambda: awq_gemv(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw))
+                    if best is None or t < best[0]: best = (t, BN, nw)
+                except Exception:
+                    pass
+        t, BN, nw = best
+        print(f"   int4 GEMV*: {t:.3f} ms  ({gb_i4/(t/1e3):.0f} GB/s)  [BLOCK_N={BN} warps={nw}]  speedup {t_fp16/t:.2f}x")
+        # split-K variant
+        bestk = None
+        for BN in [32, 64, 128]:
+            for nw in [1, 2, 4]:
+                for sk in [2, 4, 8, 16]:
+                    try:
+                        c2 = awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw, split_k=sk)
+                        if (c_ref.float() - c2.float()).abs().max().item() > 0.5: continue
+                        tt = bench(lambda: awq_gemv_splitk(a, qw, scales, qz, G, BLOCK_N=BN, num_warps=nw, split_k=sk))
+                        if bestk is None or tt < bestk[0]: bestk = (tt, BN, nw, sk)
+                    except Exception:
+                        pass
+        if bestk:
+            tt, BN, nw, sk = bestk
+            print(f"   int4 splitK: {tt:.3f} ms  ({gb_i4/(tt/1e3):.0f} GB/s)  [BLOCK_N={BN} warps={nw} splitK={sk}]  speedup {t_fp16/tt:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/gpu_peak.py
+++ b/bench_scripts/gpu_peak.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Per-GPU FP16 TFLOPS + HBM bandwidth microbenchmark.
+Run with HIP_VISIBLE_DEVICES=<i> so the target GPU is always cuda:0.
+Launch one process per physical GPU concurrently to measure the aggregate
+under real power/thermal/memory contention. Prints a single JSON line."""
+import argparse, json, os, time
+import torch
+
+def time_loop(fn, iters):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return time.perf_counter() - t0
+
+def bench_flops(dtype, n, warmup, iters):
+    a = torch.randn(n, n, device="cuda", dtype=dtype)
+    b = torch.randn(n, n, device="cuda", dtype=dtype)
+    c = torch.empty(n, n, device="cuda", dtype=dtype)
+    f = lambda: torch.matmul(a, b, out=c)
+    time_loop(f, warmup)
+    dt = time_loop(f, iters)
+    flops = 2.0 * n * n * n * iters
+    return flops / dt / 1e12  # TFLOPS
+
+def bench_bw(dtype, mb, warmup, iters):
+    # copy_ reads src + writes dst => 2 * nbytes moved per iteration
+    nelem = (mb * 1024 * 1024) // torch.tensor([], dtype=dtype).element_size()
+    src = torch.randn(nelem, device="cuda", dtype=dtype)
+    dst = torch.empty(nelem, device="cuda", dtype=dtype)
+    f = lambda: dst.copy_(src)
+    time_loop(f, warmup)
+    dt = time_loop(f, iters)
+    bytes_moved = 2.0 * src.numel() * src.element_size() * iters
+    return bytes_moved / dt / 1e9  # GB/s
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--dtype", default="fp16", choices=["fp16", "fp32"])
+    p.add_argument("--n", type=int, default=8192)         # matmul dim
+    p.add_argument("--mb", type=int, default=1024)        # bw buffer MB
+    p.add_argument("--flops-iters", type=int, default=50)
+    p.add_argument("--bw-iters", type=int, default=200)
+    p.add_argument("--warmup", type=int, default=10)
+    p.add_argument("--label", default="")
+    a = p.parse_args()
+    dt = torch.float16 if a.dtype == "fp16" else torch.float32
+    name = torch.cuda.get_device_name(0)
+    tflops = bench_flops(dt, a.n, a.warmup, a.flops_iters)
+    bw = bench_bw(dt, a.mb, a.warmup, a.bw_iters)
+    print(json.dumps({
+        "label": a.label,
+        "hip_visible": os.environ.get("HIP_VISIBLE_DEVICES", "?"),
+        "device": name,
+        "dtype": a.dtype,
+        "matmul_n": a.n,
+        "tflops": round(tflops, 2),
+        "bw_gbps": round(bw, 1),
+    }))
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/graph_ab.py
+++ b/bench_scripts/graph_ab.py
@@ -1,0 +1,26 @@
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+def main():
+    mode=sys.argv[1]  # eager | graph
+    kw=dict(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+            gpu_memory_utilization=0.90, max_model_len=2048, language_model_only=True)
+    if mode=="eager":
+        kw["enforce_eager"]=True
+    else:
+        kw["enforce_eager"]=False
+        kw["compilation_config"]=CompilationConfig(mode=CompilationMode.NONE,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY, cudagraph_capture_sizes=[1])
+    llm=LLM(**kw)
+    sp=SamplingParams(max_tokens=160, temperature=0, ignore_eos=True)
+    p=["The capital of France is"]
+    llm.generate(p, SamplingParams(max_tokens=8,temperature=0,ignore_eos=True))
+    best=1e9
+    for _ in range(3):
+        t0=time.time(); o=llm.generate(p, sp); dt=time.time()-t0
+        n=len(o[0].outputs[0].token_ids); best=min(best, 1000*dt/n)
+    print("MODE=%s  best %.1f ms/tok  (%.2f tok/s)"%(mode, best, 1000/best), flush=True)
+    print("SAMPLE:", repr(o[0].outputs[0].text[:60]), flush=True)
+    print("AB_DONE", flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/graph_combo.py
+++ b/bench_scripts/graph_combo.py
@@ -1,0 +1,27 @@
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+def main():
+    mode=sys.argv[1]; preset=sys.argv[2] if len(sys.argv)>2 else "turboquant_k8v4"
+    kw=dict(model="QuantTrio/Qwen3.5-9B-AWQ", tensor_parallel_size=2, dtype="float16",
+            gpu_memory_utilization=0.85, max_model_len=4096, language_model_only=True, max_num_seqs=32,
+            kv_cache_dtype=preset)
+    if mode=="eager":
+        kw["enforce_eager"]=True
+    else:
+        kw["enforce_eager"]=False
+        kw["compilation_config"]=CompilationConfig(mode=CompilationMode.NONE,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY, cudagraph_capture_sizes=[1])
+    llm=LLM(**kw)
+    sp=SamplingParams(max_tokens=160, temperature=0, ignore_eos=True)
+    p=["The capital of France is"]
+    llm.generate(p, SamplingParams(max_tokens=8,temperature=0,ignore_eos=True))
+    best=1e9
+    for _ in range(3):
+        t0=time.time(); o=llm.generate(p, sp); dt=time.time()-t0
+        n=len(o[0].outputs[0].token_ids); best=min(best,1000*dt/n)
+    print("COMBO MODE=%s preset=%s best %.1f ms/tok (%.2f tok/s)"%(mode,preset,best,1000/best),flush=True)
+    print("SAMPLE:", repr(o[0].outputs[0].text[:60]),flush=True)
+    print("CB_DONE",flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/graph_safe.py
+++ b/bench_scripts/graph_safe.py
@@ -1,0 +1,24 @@
+import os, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CompilationMode, CUDAGraphMode
+def main():
+    cc = CompilationConfig(
+        mode=CompilationMode.NONE,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        cudagraph_capture_sizes=[1],
+    )
+    t0=time.time()
+    llm = LLM(model="Qwen/Qwen3.5-9B",
+              tensor_parallel_size=4,
+              dtype="float16",
+              gpu_memory_utilization=0.85, max_model_len=2048,
+              max_num_batched_tokens=2048,
+              compilation_config=cc,
+              **{"language_model_only": True})
+    print("INIT_DONE in %.1fs"%(time.time()-t0), flush=True)
+    out = llm.generate(["The capital of France is"], SamplingParams(max_tokens=16, temperature=0))
+    for o in out: print("RESULT:", repr(o.outputs[0].text), flush=True)
+    print("ALL_DONE", flush=True)
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/lmhead_e2e.py
+++ b/bench_scripts/lmhead_e2e.py
@@ -1,0 +1,16 @@
+import os, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    llm=LLM(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+            enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=2048,
+            language_model_only=True)
+    sp=SamplingParams(max_tokens=128, temperature=0, ignore_eos=True)
+    p=["The capital of France is"]
+    llm.generate(p, SamplingParams(max_tokens=8,temperature=0,ignore_eos=True))
+    t0=time.time(); o=llm.generate(p, sp); dt=time.time()-t0
+    n=len(o[0].outputs[0].token_ids)
+    print("DECODE B=1: %.2f tok/s  %.1f ms/tok (n=%d)"%(n/dt,1000*dt/n,n), flush=True)
+    print("SAMPLE:", repr(o[0].outputs[0].text[:70]), flush=True)
+    print("E2E_DONE", flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/moe_topo.py
+++ b/bench_scripts/moe_topo.py
@@ -1,0 +1,25 @@
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+MODEL="bullpoint/Qwen3-Coder-Next-AWQ-4bit"
+def run(tp, pp, label):
+    t0=time.time()
+    llm=LLM(model=MODEL, tensor_parallel_size=tp, pipeline_parallel_size=pp, dtype="float16",
+            gpu_memory_utilization=0.92, max_model_len=4096, max_num_seqs=8,
+            trust_remote_code=True, enforce_eager=False,
+            compilation_config=CompilationConfig(mode=CompilationMode.NONE,
+                cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+                cudagraph_capture_sizes=[1,8]))
+    print("INIT[%s] %.0fs"%(label, time.time()-t0), flush=True)
+    base="Write a short note about topic number "
+    for c in [1,8]:
+        prompts=[base+str(i) for i in range(c)]
+        sp=SamplingParams(max_tokens=64, temperature=0, ignore_eos=True)
+        llm.generate(prompts[:1], SamplingParams(max_tokens=4,temperature=0,ignore_eos=True))
+        t0=time.time(); o=llm.generate(prompts, sp); dt=time.time()-t0
+        tot=sum(len(x.outputs[0].token_ids) for x in o)
+        print("[%s] c=%2d agg=%.1f per-stream=%.2f"%(label,c,tot/dt,tot/dt/c), flush=True)
+    print("DONE[%s]"%label, flush=True)
+if __name__=="__main__":
+    run(8,1,"TP8") if sys.argv[1]=="tp8" else run(4,2,"TP4xPP2")

--- a/bench_scripts/parse_trace.py
+++ b/bench_scripts/parse_trace.py
@@ -1,0 +1,27 @@
+import gzip, json, glob, re
+from collections import defaultdict
+f=sorted(glob.glob("/home/larkinwc/decode_prof/rank0.*.pt.trace.json.gz"))[0]
+d=json.load(gzip.open(f))
+ev=d["traceEvents"]
+# GPU kernel events: have "cat":"kernel" and dur, on a device stream
+cat=defaultdict(float); cnt=defaultdict(int); tot=0.0
+def bucket(n):
+    if n.startswith("Cijk_") or "gemm" in n.lower(): return "GEMM (rocBLAS hgemm, M=1 padded)"
+    if "nccl" in n.lower() or "all_reduce" in n.lower() or "AllReduce" in n: return "RCCL all-reduce/comm"
+    if "gated_delta" in n or "gdn" in n.lower() or "causal_conv" in n or "ChunkGated" in n or "reduce_segments" in n or "layer_norm_fwd" in n: return "GDN linear-attn"
+    if "unified_attention" in n or "kernel_unified" in n or "paged" in n or "flash" in n: return "Full attention"
+    if "rms_norm" in n: return "RMSNorm"
+    if "act_and_mul" in n or "silu" in n: return "SiLU/act"
+    if "elementwise" in n or "reduce_kernel" in n or "vectorized" in n or "copy" in n.lower() or "fill" in n or "Copy" in n: return "elementwise/copy"
+    if "mrope" in n or "rope" in n.lower(): return "RoPE"
+    if "reshape_and_cache" in n or "kv_cache" in n: return "KV cache write"
+    if "argmax" in n or "embedding" in n.lower() or "index" in n: return "sampling/embed/index"
+    return "other:"+n[:30]
+for e in ev:
+    if e.get("cat")=="kernel" and "dur" in e:
+        n=e.get("name","")
+        b=bucket(n); cat[b]+=e["dur"]; cnt[b]+=1; tot+=e["dur"]
+print("Total GPU kernel time in window: %.1f ms (rank0)"%(tot/1000))
+print("%-42s %10s %8s %8s"%("category","ms","%","calls"))
+for k in sorted(cat,key=lambda x:-cat[x]):
+    print("%-42s %10.1f %7.1f%% %8d"%(k, cat[k]/1000, 100*cat[k]/tot, cnt[k]))

--- a/bench_scripts/power_bench.py
+++ b/bench_scripts/power_bench.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Sustained FP16 matmul load on cuda:0 while sampling power draw.
+Run with HIP_VISIBLE_DEVICES=<i>. Reports TFLOPS sustained over the window
+plus mean/peak power (read via rocm-smi for the same GPU index passed in)."""
+import argparse, json, subprocess, threading, time, os
+import torch
+
+def read_power_w(power_path):
+    try:
+        with open(power_path) as f:
+            return int(f.read().strip()) / 1e6  # uW -> W
+    except Exception:
+        return None
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--n", type=int, default=8192)
+    p.add_argument("--iters", type=int, default=60)
+    p.add_argument("--smi-idx", type=int, default=-1, help="(unused, kept for compat)")
+    p.add_argument("--power-path", required=True, help="sysfs power1_input/average path for this GPU")
+    p.add_argument("--label", default="")
+    a = p.parse_args()
+
+    dt = torch.float16
+    A = torch.randn(a.n, a.n, device="cuda", dtype=dt)
+    B = torch.randn(a.n, a.n, device="cuda", dtype=dt)
+    C = torch.empty(a.n, a.n, device="cuda", dtype=dt)
+    # warmup
+    for _ in range(10):
+        torch.matmul(A, B, out=C)
+    torch.cuda.synchronize()
+
+    # Run in chunks: time each chunk with a sync (full throughput within the
+    # chunk), then take one quick power sample between chunks. sysfs read is
+    # ~microseconds so it barely dents the duty cycle.
+    samples = []
+    chunk = 10
+    nchunks = max(1, a.iters // chunk)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(nchunks):
+        for _ in range(chunk):
+            torch.matmul(A, B, out=C)
+        torch.cuda.synchronize()
+        w = read_power_w(a.power_path)
+        if w:
+            samples.append(w)
+    dt_s = time.perf_counter() - t0
+    done = nchunks * chunk
+
+    if len(samples) > 4:
+        samples = samples[2:]              # drop clock-ramp samples
+    tflops = (2.0 * a.n**3 * done) / dt_s / 1e12
+    mean_w = sum(samples)/len(samples) if samples else None
+    peak_w = max(samples) if samples else None
+    print(json.dumps({
+        "label": a.label,
+        "tflops": round(tflops, 2),
+        "mean_w": round(mean_w, 1) if mean_w else None,
+        "peak_w": round(peak_w, 1) if peak_w else None,
+        "tflops_per_w": round(tflops/mean_w, 4) if mean_w else None,
+        "n_samples": len(samples),
+    }))
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/power_scan.sh
+++ b/bench_scripts/power_scan.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Power-cap efficiency scan on ONE cold GPU.
+# For each cap: set it, run sustained FP16 matmul, record TFLOPS + draw + TFLOPS/W.
+# Usage: power_scan.sh <gpu_idx> <card_num>
+set -u
+cd ~/gpubench && source venv/bin/activate
+GPU="${1:-1}"
+CARD="${2:-2}"
+PWR=$(ls /sys/class/drm/card${CARD}/device/hwmon/hwmon*/power1_input 2>/dev/null | head -1)
+OUT=~/gpubench/power_scan
+mkdir -p "$OUT"
+echo "GPU=$GPU card=$CARD power=$PWR"
+echo "cap_W  TFLOPS  mean_W  peak_W  TFLOPS/W"
+for CAP in 110 100 90 80 70 60 50; do
+  sudo -n rocm-smi -d $GPU --setpoweroverdrive $CAP >/dev/null 2>&1
+  sleep 2
+  HIP_VISIBLE_DEVICES=$GPU python /tmp/power_bench.py \
+    --power-path "$PWR" --iters 60 --label "cap${CAP}" \
+    > "$OUT/cap${CAP}.json" 2>"$OUT/cap${CAP}.err"
+  python - "$OUT/cap${CAP}.json" "$CAP" <<'PYEOF'
+import json,sys
+d=json.load(open(sys.argv[1]));cap=sys.argv[2]
+print(f"{cap:>5}  {d['tflops']:6.2f}  {str(d['mean_w']):>6}  {str(d['peak_w']):>6}  {d['tflops_per_w']}")
+PYEOF
+  sleep 3   # brief cool between caps
+done
+# restore default
+sudo -n rocm-smi -d $GPU --setpoweroverdrive 110 >/dev/null 2>&1
+echo "restored $GPU to 110W"

--- a/bench_scripts/pp_bench.py
+++ b/bench_scripts/pp_bench.py
@@ -1,0 +1,30 @@
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+def main():
+    layout=sys.argv[1]   # tp4 | tp2pp2 | tp8 | tp2pp4
+    graphs=(sys.argv[2]=="graph") if len(sys.argv)>2 else True
+    cfg=dict(tp4=(4,1), tp2pp2=(2,2), tp8=(8,1), tp2pp4=(2,4))[layout]
+    tp,pp=cfg
+    kw=dict(model="Qwen/Qwen3.5-9B", tensor_parallel_size=tp, pipeline_parallel_size=pp,
+            dtype="float16", gpu_memory_utilization=0.90, max_model_len=2048,
+            language_model_only=True, max_num_seqs=32)
+    if graphs:
+        kw["enforce_eager"]=False
+        kw["compilation_config"]=CompilationConfig(mode=CompilationMode.NONE,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY, cudagraph_capture_sizes=[1])
+    else:
+        kw["enforce_eager"]=True
+    t0=time.time(); llm=LLM(**kw); print("INIT[%s graphs=%s] %.0fs"%(layout,graphs,time.time()-t0),flush=True)
+    # decode sweep at several concurrencies
+    base="The history of computing began long ago and "
+    for c in [1, 8, 32]:
+        prompts=[base+str(i) for i in range(c)]
+        sp=SamplingParams(max_tokens=96, temperature=0, ignore_eos=True)
+        llm.generate(prompts[:1], SamplingParams(max_tokens=4,temperature=0,ignore_eos=True))
+        t0=time.time(); o=llm.generate(prompts, sp); dt=time.time()-t0
+        tot=sum(len(x.outputs[0].token_ids) for x in o)
+        print("[%s g=%s] c=%2d  out_tok/s=%.1f  per-stream=%.2f  tpot_ms=%.1f"%(layout,graphs,c,tot/dt,tot/dt/c,1000*dt/96),flush=True)
+    print("PP_DONE_%s"%layout,flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/ppl.py
+++ b/bench_scripts/ppl.py
@@ -1,0 +1,34 @@
+import os, sys, math
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams, TokensPrompt
+def main():
+    preset=sys.argv[1]
+    import pandas as pd
+    ds=pd.read_parquet("/home/larkinwc/wikitext2_test.parquet")
+    text="\n\n".join(t for t in ds["text"].tolist() if t.strip())
+    kw=dict(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+            enforce_eager=True, gpu_memory_utilization=0.70, max_model_len=4096,
+            language_model_only=True)
+    if preset!="auto": kw["kv_cache_dtype"]=preset
+    llm=LLM(**kw)
+    tok=llm.get_tokenizer()
+    ids=tok(text, add_special_tokens=False)["input_ids"]
+    W=512; stride=512; N=24  # 20 windows of 2048 = ~40k tokens evaluated
+    prompts=[]
+    for i in range(N):
+        s=i*stride
+        if s+W>len(ids): break
+        prompts.append(TokensPrompt(prompt_token_ids=ids[s:s+W]))
+    sp=SamplingParams(max_tokens=1, temperature=0, prompt_logprobs=0)
+    nll=0.0; ntok=0
+    for pr in prompts:
+        out=llm.generate([pr], sampling_params=sp)
+        o=out[0]
+        pl=o.prompt_logprobs
+        for d in pl[1:]:
+            lp=next(iter(d.values())).logprob
+            nll+=-lp; ntok+=1
+    ppl=math.exp(nll/ntok)
+    print("PPL[%s] = %.4f  (tokens=%d, windows=%d)"%(preset, ppl, ntok, len(prompts)), flush=True)
+    print("PPL_DONE_%s"%preset, flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/prof_decode.py
+++ b/bench_scripts/prof_decode.py
@@ -1,0 +1,23 @@
+import os, time, glob
+os.environ.setdefault("VLLM_USE_V1","1")
+PROF="/home/larkinwc/decode_prof"
+os.makedirs(PROF, exist_ok=True)
+from vllm import LLM, SamplingParams
+from vllm.config.profiler import ProfilerConfig
+def main():
+    llm = LLM(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=2048,
+              language_model_only=True,
+              profiler_config=ProfilerConfig(profiler="torch", torch_profiler_dir=PROF,
+                                             torch_profiler_with_stack=False))
+    # warm up the GDN/FLA autotune + steady state
+    sp=SamplingParams(max_tokens=64, temperature=0, ignore_eos=True)
+    llm.generate(["The capital of France is"], sp)
+    # profile a clean decode-only window: short prompt, many decode steps
+    llm.start_profile()
+    o=llm.generate(["Tell me a story."], SamplingParams(max_tokens=64,temperature=0,ignore_eos=True))
+    llm.stop_profile()
+    time.sleep(3)
+    print("TRACES:", sorted(glob.glob(PROF+"/*")), flush=True)
+    print("PROF_DONE", flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/realistic.py
+++ b/bench_scripts/realistic.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Convert measured serving throughput -> effective realized TFLOPS / GB/s,
+# and compare to the parallel-aggregate ceiling.
+PARAMS = 9.653e9
+BYTES  = PARAMS * 2          # fp16 weights actually streamed per decode step
+# parallel-aggregate ceilings measured in PERF_GFX900.md
+AGG_TFLOPS = {4: 4.5*4, 8: 4.5*8}      # ~per-GPU 4.5 * N
+AGG_BW     = {4: 365*4,  8: 365*8}     # GB/s
+
+def prefill_tflops(prompt_tok, ttft_s, batch=1):
+    # FLOPs ~ 2 * params * tokens (whole batch's prompt processed in the TTFT window)
+    flops = 2 * PARAMS * prompt_tok * batch
+    return flops / ttft_s / 1e12
+
+def decode_bw(out_tok_s, batch):
+    # one forward step streams all weights once and emits `batch` tokens
+    steps_s = out_tok_s / batch
+    return steps_s * BYTES / 1e9     # GB/s realized
+
+print("=== DECODE (bandwidth-bound): effective aggregate GB/s ===")
+print(f"{'layout':<12}{'GPUs':>5}{'c':>3}{'out tok/s':>11}{'eff GB/s':>10}{'vs agg':>9}{'vs/GPU peak':>12}")
+# (layout, gpus, c, out_tok_s)
+decode = [
+ ("TP8",      8,1, 7.94),("TP8",     8,4,19.54),
+ ("TP4",      4,1, 4.58),("TP4",     4,4,12.23),
+ ("TP2xPP4",  8,1, 6.95),("TP2xPP4", 8,4,22.87),
+ ("TP2xPP2",  4,1, 6.81),("TP2xPP2", 4,4,18.14),
+ ("TP2xPP4-coding", 8,4,25.69),
+]
+for name,g,c,o in decode:
+    bw = decode_bw(o,c)
+    agg = AGG_BW[g]
+    print(f"{name:<12}{g:>5}{c:>3}{o:>11.2f}{bw:>10.1f}{100*bw/agg:>8.1f}%{100*bw/(365*g):>11.1f}%")
+
+print("\n=== PREFILL (compute-bound): effective aggregate TFLOPS ===")
+print(f"{'layout':<12}{'GPUs':>5}{'c':>3}{'TTFT p50 s':>11}{'eff TFLOPS':>12}{'vs agg':>9}")
+# (layout, gpus, c, ttft_ms, prompt_tok, batch_in_flight)
+prefill = [
+ ("TP8",     8,1, 823, 1024,1),("TP8",    8,4,3394,1024,4),
+ ("TP4",     4,1,1953, 1024,1),("TP4",    4,4,5762,1024,4),
+ ("TP2xPP4", 8,1,2181, 1024,1),("TP2xPP4",8,4,4639,1024,4),
+ ("TP2xPP2", 4,1,2289, 1024,1),("TP2xPP2",4,4,6533,1024,4),
+]
+for name,g,c,ttft,ptok,b in prefill:
+    tf = prefill_tflops(ptok, ttft/1000.0, batch=b)
+    agg = AGG_TFLOPS[g]
+    print(f"{name:<12}{g:>5}{c:>3}{ttft/1000:>11.3f}{tf:>12.2f}{100*tf/agg:>8.1f}%")

--- a/bench_scripts/run_peak.sh
+++ b/bench_scripts/run_peak.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Aggregate FP16 TFLOPS + HBM bandwidth across gfx900 GPUs.
+# Phase 1: single GPU (GPU0) alone -> uncontended peak.
+# Phase 2: all GPUs in a socket concurrently -> realistic aggregate.
+# Phase 3: all 16 GPUs concurrently -> full-box aggregate.
+set -u
+cd ~/gpubench && source venv/bin/activate
+PY=/tmp/gpu_peak.py
+OUT=~/gpubench/peak_results
+mkdir -p "$OUT"
+DTYPE="${1:-fp16}"
+
+run_set () {
+  local label="$1"; shift
+  local gpus=("$@")
+  echo "===== $label : GPUs ${gpus[*]} ====="
+  pids=()
+  for g in "${gpus[@]}"; do
+    HIP_VISIBLE_DEVICES=$g python "$PY" --dtype "$DTYPE" --label "$label" \
+      > "$OUT/${label}_gpu${g}.json" 2>"$OUT/${label}_gpu${g}.err" &
+    pids+=($!)
+  done
+  for pid in "${pids[@]}"; do wait "$pid"; done
+  # aggregate
+  python - "$OUT" "$label" "${gpus[@]}" <<'PYEOF'
+import json, sys
+out, label = sys.argv[1], sys.argv[2]
+gpus = sys.argv[3:]
+tf=bw=0.0; rows=[]
+for g in gpus:
+    try:
+        d=json.load(open(f"{out}/{label}_gpu{g}.json"))
+        tf+=d["tflops"]; bw+=d["bw_gbps"]; rows.append((g,d["tflops"],d["bw_gbps"]))
+    except Exception as e:
+        print(f"  GPU{g}: FAILED ({e})")
+for g,t,b in rows:
+    print(f"  GPU{g:>2}: {t:7.2f} TFLOPS  {b:7.1f} GB/s")
+print(f"  AGG  : {tf:7.2f} TFLOPS  {bw:7.1f} GB/s  (n={len(rows)})")
+PYEOF
+  echo
+}
+
+echo "### dtype=$DTYPE  $(date) ###"
+run_set single 0
+run_set socket0 0 1 2 3 4 5 6 7
+run_set allgpu $(seq 0 15)
+echo "### done $(date) ###"

--- a/bench_scripts/run_topo.sh
+++ b/bench_scripts/run_topo.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Driver for topo_bench.py: $1=layout $2=graph|eager $3=num_gpus
+# Sets HIP_VISIBLE_DEVICES to 0..num_gpus-1 and a hard timeout. Issue #55 topology review.
+cd ~/gpubench && source venv/bin/activate
+export VLLM_USE_V1=1 PYTHONUNBUFFERED=1
+NG=$3; export HIP_VISIBLE_DEVICES=$(seq -s, 0 $((NG-1)))
+timeout 1100 python -u ~/vllm-gfx908/bench_scripts/topo_bench.py "$1" "$2" 2>&1 \
+  | grep -iE "INIT\[|out_tok/s=|TOPO_DONE|Graph capturing|Error|Traceback \(most|EngineDead|launch failure|RuntimeError|Mamba cache|TimeoutError"
+echo "### EXIT $? ###"

--- a/bench_scripts/skinny_bench.py
+++ b/bench_scripts/skinny_bench.py
@@ -1,0 +1,30 @@
+import torch, time
+import vllm._custom_ops as ops
+from vllm.model_executor.layers.utils import num_compute_units
+torch.manual_seed(0)
+dev="cuda"
+# lm_head shapes: vocab shard per TP rank. Full vocab 248320, TP4 -> 62080. Also test TP1 full.
+H=4096
+cu=num_compute_units()
+print("CUs=",cu)
+def bench(fn,*a,iters=50):
+    for _ in range(5): fn(*a)
+    torch.cuda.synchronize(); t=time.time()
+    for _ in range(iters): r=fn(*a)
+    torch.cuda.synchronize(); return (time.time()-t)/iters*1000, r
+for V in [62080, 124160, 248320]:   # m = vocab shard (TP4, TP2, TP1)
+    # ensure m%4==0 for LLMM1, n==1
+    w=torch.randn(V,H,device=dev,dtype=torch.float16)*0.02
+    x=torch.randn(1,H,device=dev,dtype=torch.float16)*0.02
+    ref=torch.nn.functional.linear(x,w)
+    # rocBLAS baseline
+    tb,_=bench(lambda x,w: torch.nn.functional.linear(x,w), x,w)
+    # LLMM1: signature ops.LLMM1(weight, x_view, rows_per_block=4)
+    try:
+        tl,rl=bench(lambda w,x: ops.LLMM1(w, x, 4), w, x)
+        err=(rl.reshape(ref.shape)-ref).abs().max().item()/ (ref.abs().max().item()+1e-6)
+        okl="OK" if err<2e-2 else "BAD"
+    except Exception as e:
+        tl,err,okl=-1,-1,"ERR:"+str(e)[:40]
+    print("V=%6d  rocBLAS=%.3fms  LLMM1=%.3fms (%.2fx) relerr=%.1e %s"%(V,tb,tl,(tb/tl if tl>0 else 0),err,okl), flush=True)
+print("DONE")

--- a/bench_scripts/test_gfx900_gemv.py
+++ b/bench_scripts/test_gfx900_gemv.py
@@ -1,0 +1,41 @@
+"""Validate gfx900_w4a16_gemv against the existing triton_w4a16_gemm (same
+GPTQ-sequential packing) for correctness across M, and time M=1 decode."""
+import torch, time, sys
+sys.path.insert(0, "/home/larkinwc/vllm-gfx908")
+from vllm.model_executor.kernels.linear.mixed_precision.triton_w4a16 import triton_w4a16_gemm
+from vllm.model_executor.kernels.linear.mixed_precision.gfx900_w4a16_gemv import w4a16_gemv_gfx900
+
+DEV = "cuda"
+
+def make(K, N, G):
+    qw = torch.randint(0, 2**31, (K, N // 8), dtype=torch.int32, device=DEV)
+    qz = torch.randint(0, 2**31, (K // G, N // 8), dtype=torch.int32, device=DEV)
+    scales = (torch.randn(K // G, N, device=DEV) * 0.01).to(torch.float16)
+    return qw, scales, qz
+
+def bench(fn, it=50, wm=10):
+    for _ in range(wm): fn()
+    torch.cuda.synchronize(); t0 = time.time()
+    for _ in range(it): fn()
+    torch.cuda.synchronize(); return (time.time()-t0)/it*1e3
+
+def main():
+    G = 128
+    for name, K, N in [("gate/up",4096,24576),("down",12288,4096)]:
+        qw, scales, qz = make(K, N, G)
+        for M in [1, 4, 8]:
+            a = (torch.randn(M, K, device=DEV)*0.1).to(torch.float16).contiguous()
+            ref = triton_w4a16_gemm(a=a, b_q=qw, scales=scales, qzeros=qz, group_size=G, zp_bias=0)
+            got = w4a16_gemv_gfx900(a, qw, scales, qz, G, zp_bias=0)
+            err = (ref.float()-got.float()).abs().max().item()
+            rel = err/(ref.float().abs().max().item()+1e-6)
+            tag = "OK" if rel < 0.02 else "FAIL"
+            print(f"[{name}] M={M} K={K} N={N}  rel_err={rel:.4f}  {tag}")
+        # M=1 timing
+        a = (torch.randn(1, K, device=DEV)*0.1).to(torch.float16).contiguous()
+        t_ref = bench(lambda: triton_w4a16_gemm(a=a, b_q=qw, scales=scales, qzeros=qz, group_size=G, zp_bias=0))
+        t_gemv = bench(lambda: w4a16_gemv_gfx900(a, qw, scales, qz, G, zp_bias=0))
+        print(f"   M=1: stock tl.dot {t_ref:.3f}ms  gemv {t_gemv:.3f}ms  speedup {t_ref/t_gemv:.2f}x")
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/topo_bench.py
+++ b/bench_scripts/topo_bench.py
@@ -1,0 +1,50 @@
+"""Topology sweep for gfx900: TP4/TP8/TP16/TP8xPP2 decode benchmark.
+
+Usage: topo_bench.py <layout> <graph|eager>
+  layout in {tp4, tp8, tp16, tp8pp2, tp2pp2}
+Driver run_topo.sh sets HIP_VISIBLE_DEVICES to the right GPU count and a hard timeout.
+All runs use LLMM1 (default skinny-GEMM) and the FULL_DECODE_ONLY CUDA-graph config.
+Issue #55 / topology review.
+"""
+import os, sys, time
+os.environ.setdefault("VLLM_USE_V1", "1")
+from vllm import LLM, SamplingParams
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode, CompilationMode
+
+
+def main():
+    layout = sys.argv[1]
+    graphs = (sys.argv[2] == "graph") if len(sys.argv) > 2 else True
+    tp, pp = dict(tp4=(4, 1), tp8=(8, 1), tp16=(16, 1),
+                  tp8pp2=(8, 2), tp2pp2=(2, 2))[layout]
+    kw = dict(model="Qwen/Qwen3.5-9B", tensor_parallel_size=tp,
+              pipeline_parallel_size=pp, dtype="float16",
+              gpu_memory_utilization=0.90, max_model_len=2048,
+              language_model_only=True, max_num_seqs=32)
+    if graphs:
+        kw["enforce_eager"] = False
+        kw["compilation_config"] = CompilationConfig(
+            mode=CompilationMode.NONE,
+            cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+            cudagraph_capture_sizes=[1])
+    else:
+        kw["enforce_eager"] = True
+    t0 = time.time()
+    llm = LLM(**kw)
+    print("INIT[%s g=%s tp=%d pp=%d] %.0fs" % (layout, graphs, tp, pp, time.time() - t0), flush=True)
+    base = "The history of computing began long ago and "
+    for c in [1, 8, 32]:
+        prompts = [base + str(i) for i in range(c)]
+        sp = SamplingParams(max_tokens=96, temperature=0, ignore_eos=True)
+        llm.generate(prompts[:1], SamplingParams(max_tokens=4, temperature=0, ignore_eos=True))
+        t0 = time.time()
+        o = llm.generate(prompts, sp)
+        dt = time.time() - t0
+        tot = sum(len(x.outputs[0].token_ids) for x in o)
+        print("[%s g=%s] c=%2d  out_tok/s=%.1f  per-stream=%.2f  tpot_ms=%.1f"
+              % (layout, graphs, c, tot / dt, tot / dt / c, 1000 * dt / 96), flush=True)
+    print("TOPO_DONE_%s" % layout, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/tq_measure.py
+++ b/bench_scripts/tq_measure.py
@@ -1,0 +1,28 @@
+import os, time, sys
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    preset = sys.argv[1]   # "auto" (fp16) or turboquant_*
+    kw = dict(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=16384,
+              **{"language_model_only": True})
+    if preset != "auto":
+        kw["kv_cache_dtype"] = preset
+    llm = LLM(**kw)
+    # report KV cache blocks available (proxy for KV mem efficiency)
+    try:
+        nb = llm.llm_engine.cache_config.num_gpu_blocks
+        bs = llm.llm_engine.cache_config.block_size
+        print("KV_BLOCKS[%s] num_gpu_blocks=%s block_size=%s -> tokens=%s"%(preset, nb, bs, (nb*bs if nb else "?")), flush=True)
+    except Exception as e:
+        print("kvinfo err", e, flush=True)
+    # long-context decode: prefill ~8k, decode 64
+    longp = "The history of computing began long ago. " * 400  # ~ a few k tokens
+    sp=SamplingParams(max_tokens=64, temperature=0, ignore_eos=True)
+    llm.generate([longp], SamplingParams(max_tokens=4,temperature=0,ignore_eos=True))
+    for B in [1, 8]:
+        t0=time.time(); o=llm.generate([longp]*B, sp); dt=time.time()-t0
+        ot=sum(len(x.outputs[0].token_ids) for x in o)
+        print("[%s] B=%d decode_tok_s=%.2f ms_per_tok=%.1f"%(preset, B, ot/dt, 1000*dt/64), flush=True)
+    print("DONE_%s"%preset, flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/tq_smoke.py
+++ b/bench_scripts/tq_smoke.py
@@ -1,0 +1,16 @@
+import os, time, sys
+os.environ.setdefault("VLLM_USE_V1","1")
+from vllm import LLM, SamplingParams
+def main():
+    preset = sys.argv[1] if len(sys.argv)>1 else "turboquant_k8v4"
+    t0=time.time()
+    llm = LLM(model="Qwen/Qwen3.5-9B", tensor_parallel_size=4, dtype="float16",
+              enforce_eager=True, gpu_memory_utilization=0.90, max_model_len=4096,
+              kv_cache_dtype=preset, **{"language_model_only": True})
+    print("TQ_INIT[%s] in %.1fs"%(preset, time.time()-t0), flush=True)
+    sp=SamplingParams(max_tokens=48, temperature=0)
+    for p in ["The capital of France is", "Explain photosynthesis in one sentence:"]:
+        o=llm.generate([p], sp)
+        print("Q:", p, "\nA:", repr(o[0].outputs[0].text), flush=True)
+    print("ALL_DONE", flush=True)
+if __name__=="__main__": main()

--- a/bench_scripts/trace_mm.py
+++ b/bench_scripts/trace_mm.py
@@ -1,0 +1,32 @@
+"""Find the parent CPU op that launches aten::mm, via a stack sweep (O(n log n))."""
+import gzip, json, sys, collections
+
+path = sys.argv[1]
+with gzip.open(path) as f:
+    data = json.load(f)
+ev = data["traceEvents"]
+cpu = [e for e in ev if e.get("cat") in ("cpu_op", "user_annotation") and "dur" in e and "ts" in e]
+by_tid = collections.defaultdict(list)
+for e in cpu:
+    by_tid[e["tid"]].append(e)
+
+targets = {"aten::mm", "aten::matmul", "aten::bmm", "aten::addmm", "aten::linear"}
+parents = {t: collections.Counter() for t in targets}
+
+for tid, lst in by_tid.items():
+    # sort by ts asc, then by dur desc so parents open before children
+    lst.sort(key=lambda e: (e["ts"], -e["dur"]))
+    stack = []  # (end_ts, name)
+    for e in lst:
+        ts, end = e["ts"], e["ts"] + e["dur"]
+        while stack and stack[-1][0] <= ts:
+            stack.pop()
+        if e["name"] in targets:
+            parents[e["name"]][stack[-1][1] if stack else "<root>"] += 1
+        stack.append((end, e["name"]))
+
+for t in targets:
+    if parents[t]:
+        print("== parents of %s ==" % t)
+        for name, c in parents[t].most_common(8):
+            print("  %6d  <- %s" % (c, name))

--- a/gfx900_bench_pp.sh
+++ b/gfx900_bench_pp.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# gfx900 Qwen3.5-9B PIPELINE-PARALLEL grid: TP2xPP{2,4} x concurrency{1,4} x {synthetic,coding}
+# Stays within socket0 (GPUs 0-7) to avoid the slow cross-socket QPI link.
+# PP2 -> 4 GPUs (0-3), PP4 -> 8 GPUs (0-7). Comparable to the TP4 / TP8 grids.
+set -u
+cd ~/gpubench && source venv/bin/activate
+MODEL="Qwen/Qwen3.5-9B"
+SHAREGPT=~/gpubench/sharegpt.json
+OUTDIR=~/gpubench/bench_gfx900
+mkdir -p "$OUTDIR"
+PORT=8120
+
+run_pp () {
+  local PP=$1
+  local DEVS=$2
+  local NGPU=$3
+  echo "############ Starting server TP2xPP=$PP ($NGPU GPUs: $DEVS) ############"
+  HIP_VISIBLE_DEVICES=$DEVS VLLM_USE_V1=1 nohup vllm serve "$MODEL" \
+    --tensor-parallel-size 2 \
+    --pipeline-parallel-size $PP \
+    --dtype float16 \
+    --enforce-eager \
+    --language-model-only \
+    --max-model-len 4096 \
+    --gpu-memory-utilization 0.90 \
+    --no-async-scheduling \
+    --port $PORT > "$OUTDIR/server_tp2pp${PP}.log" 2>&1 &
+  SERVER_PID=$!
+  echo "server PID=$SERVER_PID, waiting for ready..."
+  for i in $(seq 1 180); do
+    if curl -s "http://127.0.0.1:$PORT/v1/models" 2>/dev/null | grep -q "$MODEL"; then
+      echo "server READY after ${i}0s"; break
+    fi
+    sleep 10
+  done
+
+  for C in 1 4; do
+    echo "=== CELL TP2PP=$PP c=$C synthetic ==="
+    vllm bench serve \
+      --model "$MODEL" --backend vllm --host 127.0.0.1 --port $PORT \
+      --dataset-name random --random-input-len 1024 --random-output-len 256 \
+      --num-prompts $((C*8)) --max-concurrency $C --ignore-eos \
+      --request-rate inf --seed 42 \
+      --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,99 \
+      --save-result --result-filename "$OUTDIR/tp2pp${PP}_c${C}_synthetic.json" \
+      > "$OUTDIR/cell_tp2pp${PP}_c${C}_synthetic.log" 2>&1
+    echo "--- result ---"; grep -iE "Output token throughput|Total Token|Request throughput|Median TTFT|P99 TTFT|Median TPOT|P99 TPOT" "$OUTDIR/cell_tp2pp${PP}_c${C}_synthetic.log"
+
+    echo "=== CELL TP2PP=$PP c=$C coding ==="
+    vllm bench serve \
+      --model "$MODEL" --backend vllm --host 127.0.0.1 --port $PORT \
+      --dataset-name sharegpt --dataset-path "$SHAREGPT" \
+      --num-prompts $((C*8)) --max-concurrency $C \
+      --request-rate inf --seed 42 \
+      --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,99 \
+      --save-result --result-filename "$OUTDIR/tp2pp${PP}_c${C}_coding.json" \
+      > "$OUTDIR/cell_tp2pp${PP}_c${C}_coding.log" 2>&1
+    echo "--- result ---"; grep -iE "Output token throughput|Total Token|Request throughput|Median TTFT|P99 TTFT|Median TPOT|P99 TPOT" "$OUTDIR/cell_tp2pp${PP}_c${C}_coding.log"
+  done
+
+  echo "############ Stopping server TP2xPP=$PP ############"
+  kill $SERVER_PID 2>/dev/null
+  sleep 15
+  pkill -f "vllm serve" 2>/dev/null
+  sleep 10
+}
+
+echo "===== PP BENCH START $(date) ====="
+run_pp 4 "0,1,2,3,4,5,6,7" 8
+run_pp 2 "0,1,2,3" 4
+echo "===== PP BENCH END $(date) ====="

--- a/vllm/model_executor/kernels/linear/mixed_precision/gfx900_w4a16_gemv.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/gfx900_w4a16_gemv.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""gfx900 (Vega10) int4 W4A16 decode GEMV.
+
+gfx900 has NO MFMA units, so the generic W4A16 path (which uses ``tl.dot`` even
+at M=1) runs a padded FP32 GEMM and is *slower* than FP16. For the decode hot
+path (small M) a GEMV is the right primitive: it is purely HBM-bandwidth-bound,
+needs no matrix units, and int4 weights move 4x fewer bytes than FP16.
+
+Microbench (Qwen3.5-9B MLP shapes, M=1, vs FP16 GEMV):
+    gate/up K=4096  N=24576 : 2.82x
+    down    K=12288 N=4096  : 4.02x
+
+Packing matches the generic ``triton_w4a16`` kernel: GPTQ-sequential, i.e. column
+``j`` of an unpacked int32 uses nibble shift ``(j % 8) * 4``. ``b_q`` is
+``[K, N//8] int32``; ``scales`` ``[K//G, N]``; ``qzeros`` ``[K//G, N//8] int32``
+or ``None`` for symmetric (uses ``zp_bias``).
+"""
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _w4a16_gemv_splitk_kernel(
+    a_ptr,            # [M, K] fp16/bf16
+    qw_ptr,           # [K, N//8] int32
+    scales_ptr,       # [K//G, N]
+    qz_ptr,           # [K//G, N//8] int32 (unused if HAS_ZP=0)
+    c_ptr,            # [M, N] fp32 accumulator (atomic)
+    M, K, N,
+    ZP_BIAS,
+    G: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    GROUPS_PER_PID: tl.constexpr,
+    HAS_ZP: tl.constexpr,
+):
+    pid_n = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N
+    offs_n8 = pid_n * (BLOCK_N // 8) + tl.arange(0, BLOCK_N // 8)
+    mask_n8 = offs_n8 < (N // 8)
+
+    # GPTQ-sequential shifts: column j -> (j % 8) * 4
+    j = tl.arange(0, BLOCK_N) % 8
+    shifts = j * 4
+    shifts2d = shifts[None, :]
+
+    g0 = pid_k * GROUPS_PER_PID
+    for gi in range(0, GROUPS_PER_PID):
+        g = g0 + gi
+        in_range = g < (K // G)
+        s_ptrs = scales_ptr + g * N + offs_n
+        scales = tl.load(s_ptrs, mask=mask_n & in_range, other=0.0).to(tl.float32)
+        if HAS_ZP:
+            qz_ptrs = qz_ptr + g * (N // 8) + offs_n8
+            qzv = tl.load(qz_ptrs, mask=mask_n8 & in_range, other=0)
+            ze = tl.interleave(qzv, qzv); ze = tl.interleave(ze, ze); ze = tl.interleave(ze, ze)
+            zf = ((ze >> shifts) & 0xF).to(tl.float32)
+        else:
+            zf = tl.full((BLOCK_N,), ZP_BIAS, dtype=tl.float32)
+
+        offs_k = g * G + tl.arange(0, G)
+        mask_k = offs_k < K
+        qw_ptrs = qw_ptr + offs_k[:, None] * (N // 8) + offs_n8[None, :]
+        m_w = (mask_k[:, None] & in_range) & mask_n8[None, :]
+        qwt = tl.load(qw_ptrs, mask=m_w, other=0)
+        bt = tl.interleave(qwt, qwt); bt = tl.interleave(bt, bt); bt = tl.interleave(bt, bt)
+        bt = (bt >> shifts2d) & 0xF
+        wt = (bt.to(tl.float32) - zf[None, :]) * scales[None, :]   # [G, BLOCK_N]
+
+        # M rows (decode: M is tiny, 1..8). Unrolled small loop.
+        for m in range(0, M):
+            a = tl.load(a_ptr + m * K + offs_k, mask=mask_k, other=0.0).to(tl.float32)
+            acc = tl.sum(a[:, None] * wt, axis=0)                  # [BLOCK_N]
+            tl.atomic_add(c_ptr + m * N + offs_n, acc, mask=mask_n)
+
+
+# Tuned per-shape configs for gfx900 (from bench_scripts/gemv_bench.py sweeps).
+# Key: (N) -> (BLOCK_N, num_warps, split_k, num_stages). split_k=0 => full (n_groups).
+_GFX900_GEMV_CONFIGS = {
+    24576: (256, 2, 32, 2),   # gate/up
+    4096: (128, 1, 0, 3),     # down  (split_k=full)
+}
+_DEFAULT_CFG = (128, 2, 16, 2)
+
+
+def w4a16_gemv_gfx900(
+    a: torch.Tensor,          # [M, K]
+    b_q: torch.Tensor,        # [K, N//8] int32
+    scales: torch.Tensor,     # [K//G, N]
+    qzeros: torch.Tensor | None,
+    group_size: int,
+    zp_bias: int = 0,
+) -> torch.Tensor:
+    M, K = a.shape
+    N = b_q.shape[1] * 8
+    n_groups = K // group_size
+    BLOCK_N, num_warps, split_k, num_stages = _GFX900_GEMV_CONFIGS.get(N, _DEFAULT_CFG)
+    if split_k == 0 or split_k > n_groups:
+        split_k = n_groups
+    gpp = triton.cdiv(n_groups, split_k)
+    c = torch.zeros((M, N), dtype=torch.float32, device=a.device)
+    grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(n_groups, gpp))
+    _w4a16_gemv_splitk_kernel[grid](
+        a, b_q, scales, qzeros if qzeros is not None else b_q, c,
+        M, K, N, float(zp_bias),
+        G=group_size, BLOCK_N=BLOCK_N, GROUPS_PER_PID=gpp,
+        HAS_ZP=(qzeros is not None),
+        num_warps=num_warps, num_stages=num_stages,
+    )
+    return c.to(a.dtype)

--- a/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
@@ -221,7 +221,18 @@ def triton_w4a16_gemm(
     # The dispatch is intentionally narrow: any unsupported group-size or
     # disabled-via-env case falls back to the generic Triton path below.
     if current_platform.is_rocm() and not _mi100_w4a16_disabled():
-        from vllm.platforms.rocm import on_mi100
+        from vllm.platforms.rocm import on_gfx900, on_mi100
+        # gfx900 (Vega10) has no MFMA -> tl.dot is a padded FP32 GEMM and is
+        # *slower* than FP16 at small M. For the decode hot path (M<=8) route to
+        # the dedicated bandwidth-bound int4 GEMV (10-15x vs the tl.dot path).
+        if on_gfx900() and group_size in (32, 64, 128) and M <= 8:
+            from vllm.model_executor.kernels.linear.mixed_precision.gfx900_w4a16_gemv import (
+                w4a16_gemv_gfx900 as _gfx900_gemv,
+            )
+            return _gfx900_gemv(
+                a=a, b_q=b_q, scales=scales,
+                qzeros=qzeros, group_size=group_size, zp_bias=zp_bias,
+            )
         if on_mi100() and group_size in (32, 128):
             from vllm.model_executor.kernels.linear.scaled_mm.mi100_w4a16 import (
                 mi100_w4a16_gemm as _mi100_w4a16_gemm,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -122,7 +122,7 @@ def use_aiter_triton_gemm(n, m, k, dtype):
 def rocm_unquantized_gemm_impl(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:
-    from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx950
+    from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx900, on_gfx950
 
     n = x.numel() // x.size(-1)
     m = weight.shape[0]
@@ -168,6 +168,24 @@ def rocm_unquantized_gemm_impl(
         from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
 
         return gemm_a16w16(x, weight, bias)
+
+    # gfx900 (Vega10): excluded from on_gfx9() because it lacks MFMA, but its
+    # LLMM1 skinny GEMV still works on wave64 and is ~3.5x faster than the
+    # padded rocBLAS macrotile path for the M=1 decode case (e.g. lm_head).
+    # wvSplitK device-asserts on gfx900, so only the n==1 LLMM1 branch is enabled.
+    if (
+        envs.VLLM_ROCM_USE_SKINNY_GEMM
+        and on_gfx900()
+        and x.dtype in [torch.float16, torch.bfloat16]
+        and k % 8 == 0
+        and m % 4 == 0
+        and n == 1
+        and k <= 8192
+        and bias is None
+    ):
+        x_view = x.reshape(-1, x.size(-1))
+        out = ops.LLMM1(weight, x_view, 4)
+        return out.reshape(*x.shape[:-1], weight.shape[0])
 
     use_skinny = (
         envs.VLLM_ROCM_USE_SKINNY_GEMM

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -173,6 +173,25 @@ def rocm_unquantized_gemm_impl(
     # LLMM1 skinny GEMV still works on wave64 and is ~3.5x faster than the
     # padded rocBLAS macrotile path for the M=1 decode case (e.g. lm_head).
     # wvSplitK device-asserts on gfx900, so only the n==1 LLMM1 branch is enabled.
+    # gfx900: tiny-output M=1 GEMVs (e.g. Qwen3-Next shared_expert_gate,
+    # [hidden -> 1]) have m not divisible by 4, so they fail the LLMM1 gate
+    # below and fall to padded rocBLAS, which computes a wasteful 64x64
+    # macrotile for a 1-row output (~300 us vs ~20 us). For these few-row
+    # cases a fused multiply-reduce is correct and ~14x faster.
+    if (
+        envs.VLLM_ROCM_USE_SKINNY_GEMM
+        and on_gfx900()
+        and x.dtype in [torch.float16, torch.bfloat16]
+        and n == 1
+        and m <= 8
+        and m % 4 != 0
+        and bias is None
+    ):
+        # weight is [m, k]; broadcast x [1, k] over rows and reduce over K -> [m]
+        x_view = x.reshape(-1, x.size(-1))
+        out = (x_view * weight).sum(dim=-1)
+        return out.reshape(*x.shape[:-1], m)
+
     if (
         envs.VLLM_ROCM_USE_SKINNY_GEMM
         and on_gfx900()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -405,6 +405,10 @@ def _get_backend_priorities(
     # kernel cannot run. Prefer the portable Triton attention backend.
     if _ON_GFX900:
         backends.append(AttentionBackendEnum.TRITON_ATTN)
+        # TurboQuant KV-cache quant: kernels are pure Triton (no wave32 shuffle),
+        # so they run on wave64 gfx900. Only selected when the user opts in via
+        # --kv-cache-dtype turboquant_*; otherwise TRITON_ATTN above is used.
+        backends.append(AttentionBackendEnum.TURBOQUANT)
         return backends
     # ROCM_ATTN uses (2, num_blocks, ...) KV cache layout which is
     # incompatible with KV connectors that require blocks-first layout.

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -200,6 +200,10 @@ _ON_GFX90A = "gfx90a" in _GCN_ARCH
 _ON_GFX942 = "gfx942" in _GCN_ARCH
 _ON_GFX950 = "gfx950" in _GCN_ARCH
 _ON_MI100 = "gfx908" in _GCN_ARCH
+# gfx900 (Vega10, e.g. V340/MI25): GFX9 ISA but NO MFMA matrix cores,
+# no native FP8, no XGMI. Treated as a separate tier that routes around
+# all MFMA/XGMI kernels to portable Triton + rocBLAS paths.
+_ON_GFX900 = "gfx900" in _GCN_ARCH
 
 
 def _capability_from_gcn_arch(gcn_arch: str) -> tuple[int, int] | None:
@@ -302,6 +306,12 @@ def on_mi100() -> bool:
     return _ON_MI100
 
 
+def on_gfx900() -> bool:
+    """Detect gfx900 (Vega10): GFX9 ISA but lacks MFMA, FP8, and XGMI.
+    Must route around MFMA paged-attn/skinny-GEMM and XGMI custom all-reduce."""
+    return _ON_GFX900
+
+
 def on_gfx950() -> bool:
     return _ON_GFX950
 
@@ -391,6 +401,11 @@ def _get_backend_priorities(
             ]
 
     backends = []
+    # gfx900 (Vega10) has no MFMA: the ROCM_ATTN custom paged-attention
+    # kernel cannot run. Prefer the portable Triton attention backend.
+    if _ON_GFX900:
+        backends.append(AttentionBackendEnum.TRITON_ATTN)
+        return backends
     # ROCM_ATTN uses (2, num_blocks, ...) KV cache layout which is
     # incompatible with KV connectors that require blocks-first layout.
     if not use_kv_connector:


### PR DESCRIPTION
## gfx900 (Vega10 / Radeon Pro V340) inference support + decode perf

Adds a gfx900 support tier to this ROCm vLLM fork and brings up fast LLM inference on an 8× V340 (16 die) box. Validated end-to-end on two models: dense **Qwen3.5-9B** and sparse-MoE **Qwen3-Coder-Next-AWQ-4bit**.

### Headline results
- **Dense Qwen3.5-9B decode (bs=1): 6.65 → 54.4 tok/s (8.2×)** — FP16 TP4 + LLMM1 skinny GEMV + HIP CUDA graphs.
- **MoE Qwen3-Coder-Next decode (bs=1): 8.5 → 26.8 tok/s (3.2×)**; throughput **114 tok/s @ c=32 (4.3×)**.

### What's in the platform/kernel changes
- `vllm/platforms/rocm.py`: `on_gfx900()` detection + capability `(9,0)`, gfx900-appropriate attention backend selection (Triton/TurboQuant), 56 CUs / wave64 / no-MFMA characterization.
- `vllm/model_executor/layers/utils.py`:
  - **LLMM1 skinny GEMV** for M=1 FP16 decode (lm_head/projections) — narrow gfx900 gate (#59).
  - **Small-m M=1 GEMV** fast path (`shared_expert_gate`, n==1, m≤8, m%4≠0) that fails the LLMM1 `m%4==0` gate and otherwise falls into a wasteful rocBLAS macrotile — +39% MoE decode (#65).
- `gfx900_w4a16_gemv.py`: int4 AWQ weight GEMV decode kernel (split-K tuned) (#57).
- HIP **CUDA graphs** enabled for decode (`FULL_DECODE_ONLY`, inductor off) — flips an earlier "no speedup" result into 3.6× after LLMM1 (#63).
- **TurboQuant KV-cache** quant (`turboquant_k8v4`) validated lossless (WikiText-2 PPL within noise); 2.3–2.5× KV capacity (#62).

### Key findings (documented in `GFX900_RECOMMENDED.md` + linked issues)
- **Topology:** GPUs 0–7 = socket 0, 8–15 = socket 1; cross-socket P2P is 0.26 GB/s (Xeon E5 v3 QPI, ~30× cliff). Never span sockets in a TP/PP group. TP4 is the dense sweet spot.
- **MoE layout — TP8 vs TP4×PP2 (clean A/B):** TP8 wins single-stream (33.2 vs 23.2 tok/s @ c=1, no PP bubble); TP4×PP2 wins concurrency (44.9 vs 42.3 @ c=8, scales to 114 @ c=32). Decode profiling shows single-stream MoE is PP-pipeline-bubble-bound (~80 ms/step), not compute-bound — the MoE expert kernel is only ~9% of decode GPU time.

### Docs added
`GFX900_RECOMMENDED.md` (best validated path, both models), `PERF_GFX900.md`, `BENCH_DECODE_PROFILE.md`, `BENCH_GFX900.md`, `GFX900_SETUP.md`, plus benchmark scripts under `bench_scripts/`.

### Testing
All numbers measured on the 16× gfx900 box (ROCm 7.2.4, torch 2.12.0+rocm7.2, custom gfx900 RCCL + Triton fork). gfx900-specific code paths are gated behind `on_gfx900()`; other archs unaffected. Tracked across issues #55–#65.
