### PR TITLE
[MI100] Fix all pre-commit hooks failing on every PR

### DIFF
--- a/.factory/library/architecture.md
+++ b/.factory/library/architecture.md
@@ -9,7 +9,7 @@ TurboQuant KV cache compression is integrated into vLLM as a custom attention ba
 ### TurboQuant Backend (`/opt/turboquant/turboquant/backends/vllm_rocm.py`)
 
 - **TurboQuantTritonBackend** (alias: TurboQuantRocmBackend): Extends `TritonAttentionBackend`. Registered as TRITON_ATTN override. Provides `TurboQuantTritonImpl` as the implementation class.
-- **TurboQuantTritonImpl** (alias: TurboQuantRocmImpl): Extends `TritonAttentionImpl`. Each instance owns per-layer TQ state (CompressedKVStore, KVCaptureEngine) **initialized eagerly in **init**** (required for HIP graph compatibility). Overrides `do_kv_cache_update()` to capture KV into compressed store, and `forward()` to optionally use TQ hybrid decode.
+- **TurboQuantTritonImpl** (alias: TurboQuantRocmImpl): Extends `TritonAttentionImpl`. Each instance owns per-layer TQ state (CompressedKVStore, KVCaptureEngine) **initialized eagerly in `__init__`** (required for HIP graph compatibility). Overrides `do_kv_cache_update()` to capture KV into compressed store, and `forward()` to optionally use TQ hybrid decode.
 
 ### Per-Layer State (lives in worker process)
 

--- a/.factory/library/architecture.md
+++ b/.factory/library/architecture.md
@@ -9,11 +9,12 @@ TurboQuant KV cache compression is integrated into vLLM as a custom attention ba
 ### TurboQuant Backend (`/opt/turboquant/turboquant/backends/vllm_rocm.py`)
 
 - **TurboQuantTritonBackend** (alias: TurboQuantRocmBackend): Extends `TritonAttentionBackend`. Registered as TRITON_ATTN override. Provides `TurboQuantTritonImpl` as the implementation class.
-- **TurboQuantTritonImpl** (alias: TurboQuantRocmImpl): Extends `TritonAttentionImpl`. Each instance owns per-layer TQ state (CompressedKVStore, KVCaptureEngine) **initialized eagerly in __init__** (required for HIP graph compatibility). Overrides `do_kv_cache_update()` to capture KV into compressed store, and `forward()` to optionally use TQ hybrid decode.
+- **TurboQuantTritonImpl** (alias: TurboQuantRocmImpl): Extends `TritonAttentionImpl`. Each instance owns per-layer TQ state (CompressedKVStore, KVCaptureEngine) **initialized eagerly in **init**** (required for HIP graph compatibility). Overrides `do_kv_cache_update()` to capture KV into compressed store, and `forward()` to optionally use TQ hybrid decode.
 
 ### Per-Layer State (lives in worker process)
 
 Each `TurboQuantRocmImpl` instance owns:
+
 - `CompressedKVStore` -- chunked compressed KV history (3-bit keys via MSE+QJL, 2-bit values via group quantization)
 - `KVCaptureEngine` -- ring buffer (128 recent tokens in full precision) + bulk capture for prefill
 - `TurboQuantProd` quantizer -- rotation matrix Pi (DxD), QJL matrix S (DxD), codebook (8 centroids)
@@ -28,7 +29,8 @@ Each `TurboQuantRocmImpl` instance owns:
 ### Data Flow
 
 **Capture-only mode (Phase 1):**
-```
+
+```text
 Request → vLLM Scheduler → Worker Process → Model Forward
   → TurboQuantRocmImpl.do_kv_cache_update():
       1. Write to paged KV cache (standard path via super())
@@ -39,7 +41,8 @@ Request → vLLM Scheduler → Worker Process → Model Forward
 ```
 
 **Hybrid mode (Phase 2):**
-```
+
+```text
 Prefill:
   → do_kv_cache_update(): write to paged cache + capture into TQ store
   → forward(): use standard flash attention for prefill (super())
@@ -56,6 +59,7 @@ Decode (single token):
 ### Registration Flow
 
 **CRITICAL:** Override TRITON_ATTN, NOT ROCM_ATTN or CUSTOM:
+
 ```python
 from vllm.v1.attention.backends.registry import register_backend, AttentionBackendEnum
 register_backend(AttentionBackendEnum.TRITON_ATTN, "turboquant.backends.vllm_rocm.TurboQuantTritonBackend")
@@ -64,6 +68,7 @@ register_backend(AttentionBackendEnum.TRITON_ATTN, "turboquant.backends.vllm_roc
 This must execute in every worker process (via sitecustomize.py in PYTHONPATH). No `--attention-backend` flag needed.
 
 **Why TRITON_ATTN, not ROCM_ATTN or CUSTOM:**
+
 - On ROCm, vLLM selects TRITON_ATTN (not ROCM_ATTN) for standard attention layers in `_get_backend_priorities()`
 - ROCM_ATTN is only selected if `use_prefill_decode_attention=True`, which is not the default
 - CUSTOM + `--attention-backend CUSTOM` forces ALL layers through system 1, crashing GDN layers
@@ -72,6 +77,7 @@ This must execute in every worker process (via sitecustomize.py in PYTHONPATH). 
 ### vLLM Dual Backend Routing
 
 vLLM has TWO separate backend routing systems:
+
 1. **AttentionBackendEnum** (standard attention) → `get_attn_backend()` → TRITON_ATTN on ROCm
 2. **MambaAttentionBackendEnum** (mamba/GDN/linear) → `get_mamba_attn_backend()` → GDN_ATTN for GDN layers
 
@@ -81,6 +87,7 @@ Qwen3.5-9B's 24 GDN layers use system 2 (GDN_ATTN → unchanged).
 ### Memory Budget
 
 Per full-attention layer overhead:
+
 - Pi rotation matrix: 256x256 float32 = 256 KB
 - S QJL matrix: 256x256 float32 = 256 KB  
 - Codebook: 8 float32 = 32 B
@@ -92,10 +99,12 @@ Per full-attention layer overhead:
 FULL_DECODE_ONLY captures decode forward passes into HIP graphs. Both TQ capture_only and TQ hybrid modes ARE compatible with FULL_DECODE_ONLY graphs.
 
 **VALIDATED:**
+
 - TQ capture_only + FULL_DECODE_ONLY: 35 graphs captured, 10/10 requests coherent (VAL-GRAPH-001)
 - TQ hybrid + FULL_DECODE_ONLY: 35 graphs captured, 10/10 requests coherent (VAL-GRAPH-002)
 
 **Requirements for HIP graph compatibility:**
+
 1. All random tensor generation must specify `device='cpu'` explicitly (e.g., `torch.randn(..., device='cpu')`)
 2. Tensors used in forward() operations must be pre-registered as module buffers via `register_buffer()`, not created dynamically during forward
 3. TQ state (CompressedKVStore, KVCaptureEngine) must be initialized eagerly in `__init__`, not lazily during first forward pass

--- a/.factory/library/autotune-marlin.md
+++ b/.factory/library/autotune-marlin.md
@@ -65,7 +65,7 @@ do not change the tile (see decoupling note below).
 
 LDS estimate per resident tile set (conservative):
 
-```
+```text
 LDS_bytes = num_stages * BLOCK_K * (BLOCK_M + BLOCK_N) * 2      # fp16 act term
           + num_stages * (BLOCK_K // 8) * BLOCK_N * 4           # packed int4 B
 ```
@@ -212,76 +212,76 @@ catalog reuses the same (M, g)-selected tile.
 
 ### TP=4 shard shapes (32 files, added commit 7df913bba)
 
-49. `mi100_w4a16_marlin_M128_N1536_K4096_g128.json`  
+1. `mi100_w4a16_marlin_M128_N1536_K4096_g128.json`  
     `d6964e8c4d454607f95fe5ce1d36b12d03ebb5d3e657ebc815e03fa6f2d9a9bc`
-50. `mi100_w4a16_marlin_M128_N1536_K4096_g32.json`  
+2. `mi100_w4a16_marlin_M128_N1536_K4096_g32.json`  
     `8e51b14c22cd07fc84536e872fdc69a82fa5e517f1968511745739488f55a888`
-51. `mi100_w4a16_marlin_M128_N4096_K1024_g128.json`  
+3. `mi100_w4a16_marlin_M128_N4096_K1024_g128.json`  
     `1d4fdc303c216d05ffd92695ab145993446b693e7ed87e5eee27854014bf5fbb`
-52. `mi100_w4a16_marlin_M128_N4096_K1024_g32.json`  
+4. `mi100_w4a16_marlin_M128_N4096_K1024_g32.json`  
     `babf5987b3240217d08fdf4b125b8ff0a576e76e40f5e7020ac74c2b7c1e9c80`
-53. `mi100_w4a16_marlin_M128_N4096_K3072_g128.json`  
+5. `mi100_w4a16_marlin_M128_N4096_K3072_g128.json`  
     `a1764f2237a8e35b15cd168b54cb8f3dd3eda2ca7a576b6c0a25b677434cc0b1`
-54. `mi100_w4a16_marlin_M128_N4096_K3072_g32.json`  
+6. `mi100_w4a16_marlin_M128_N4096_K3072_g32.json`  
     `94dd71cdce81760c552492b4a7aad8109d93f11064ed622513f713b8ce897449`
-55. `mi100_w4a16_marlin_M128_N6144_K4096_g128.json`  
+7. `mi100_w4a16_marlin_M128_N6144_K4096_g128.json`  
     `217bd1d6334418565822da552e8753400f42a51b59ebc8bf2d6844719575c576`
-56. `mi100_w4a16_marlin_M128_N6144_K4096_g32.json`  
+8. `mi100_w4a16_marlin_M128_N6144_K4096_g32.json`  
     `dc36bb7a38518f9249f095d2d6b094a5e065c71416bfbe6d8a39085ff9f356ba`
-57. `mi100_w4a16_marlin_M1_N1536_K4096_g128.json`  
+9. `mi100_w4a16_marlin_M1_N1536_K4096_g128.json`  
     `11a2375fdc873bb24ab8223d85daf3919c603a9701847a9d689601909a2fa605`
-58. `mi100_w4a16_marlin_M1_N1536_K4096_g32.json`  
+10. `mi100_w4a16_marlin_M1_N1536_K4096_g32.json`  
     `7924cf5be2122f328b3e38fc775aa174c79d2d2e3f368c74aafa69b4f466da1f`
-59. `mi100_w4a16_marlin_M1_N4096_K1024_g128.json`  
+11. `mi100_w4a16_marlin_M1_N4096_K1024_g128.json`  
     `ea8e1293137068cc424ceee8d4ed8ced99d507345a1863d761ed87064f01a8d6`
-60. `mi100_w4a16_marlin_M1_N4096_K1024_g32.json`  
+12. `mi100_w4a16_marlin_M1_N4096_K1024_g32.json`  
     `94a0a49a9aa5acfeb0e459d2bbac0a48ee3518555356aa93737d817754605f62`
-61. `mi100_w4a16_marlin_M1_N4096_K3072_g128.json`  
+13. `mi100_w4a16_marlin_M1_N4096_K3072_g128.json`  
     `ed9a28e304bf84443e574d4333cfd0a268710f357de34679fb9b2c374b97adb5`
-62. `mi100_w4a16_marlin_M1_N4096_K3072_g32.json`  
+14. `mi100_w4a16_marlin_M1_N4096_K3072_g32.json`  
     `f6b5efae8c4efdd2945adc019ecf6e0497f6bf268f8ada2a6450e110fd62bc1b`
-63. `mi100_w4a16_marlin_M1_N6144_K4096_g128.json`  
+15. `mi100_w4a16_marlin_M1_N6144_K4096_g128.json`  
     `f7b8605bec8104aa510cd317cf84c6e89628a095a271dce3cc89f243812739cd`
-64. `mi100_w4a16_marlin_M1_N6144_K4096_g32.json`  
+16. `mi100_w4a16_marlin_M1_N6144_K4096_g32.json`  
     `6fca9efbf7bafc6ddd95a427809f93915f3458a0d80894e46905ef6b992493af`
-65. `mi100_w4a16_marlin_M32_N1536_K4096_g128.json`  
+17. `mi100_w4a16_marlin_M32_N1536_K4096_g128.json`  
     `105cc8147133918743f299858b51a223cb0a388279d28b63ca21ed7bfee24b19`
-66. `mi100_w4a16_marlin_M32_N1536_K4096_g32.json`  
+18. `mi100_w4a16_marlin_M32_N1536_K4096_g32.json`  
     `b5d4f3bb31d89c85fcdbe29209e454480e7438c8de25eb049e29657818c87b93`
-67. `mi100_w4a16_marlin_M32_N4096_K1024_g128.json`  
+19. `mi100_w4a16_marlin_M32_N4096_K1024_g128.json`  
     `f7dd2d5734eb8d2759f20da67e790d7cb5dcd0f28f46a637d9c0a6b97d319377`
-68. `mi100_w4a16_marlin_M32_N4096_K1024_g32.json`  
+20. `mi100_w4a16_marlin_M32_N4096_K1024_g32.json`  
     `ff280da19f6c1bb359d5d79fc66b442127ed1ba24a3216976b5b488a259ecd7b`
-69. `mi100_w4a16_marlin_M32_N4096_K3072_g128.json`  
+21. `mi100_w4a16_marlin_M32_N4096_K3072_g128.json`  
     `de7cf4319ff714b8ce47f50e4b38e8af4425373c967c9c27088c94048f69b0f1`
-70. `mi100_w4a16_marlin_M32_N4096_K3072_g32.json`  
+22. `mi100_w4a16_marlin_M32_N4096_K3072_g32.json`  
     `7f927b530ec7dbce23bdf5a71f71a1e2af657f9909343c485f1bf5ee3cb19379`
-71. `mi100_w4a16_marlin_M32_N6144_K4096_g128.json`  
+23. `mi100_w4a16_marlin_M32_N6144_K4096_g128.json`  
     `50c0946928ca2635434b22fbbcee2d75cab943496c3094a683491640c6fbb905`
-72. `mi100_w4a16_marlin_M32_N6144_K4096_g32.json`  
+24. `mi100_w4a16_marlin_M32_N6144_K4096_g32.json`  
     `85dad9d3af065f656601a87c8c68a0988cd2c3b6580e7b443ed2bc9fc55e731c`
-73. `mi100_w4a16_marlin_M512_N1536_K4096_g128.json`  
+25. `mi100_w4a16_marlin_M512_N1536_K4096_g128.json`  
     `918735c0d0d834b51e43d82b96900457abf1d6292705302e25f473cb546a09b7`
-74. `mi100_w4a16_marlin_M512_N1536_K4096_g32.json`  
+26. `mi100_w4a16_marlin_M512_N1536_K4096_g32.json`  
     `8722bbfef4672b28951016c72523343bceb4f428ce85de4791dbdd26e959bdd4`
-75. `mi100_w4a16_marlin_M512_N4096_K1024_g128.json`  
+27. `mi100_w4a16_marlin_M512_N4096_K1024_g128.json`  
     `6f15df6506f21bc7b56bb023d202f2ec4dd05bb426b5e7caa1c8025818090e2f`
-76. `mi100_w4a16_marlin_M512_N4096_K1024_g32.json`  
+28. `mi100_w4a16_marlin_M512_N4096_K1024_g32.json`  
     `5ed50e8f087f3dd8a28fbcf7073fa6922fe15eb25cc2a99166342283d0ebfe72`
-77. `mi100_w4a16_marlin_M512_N4096_K3072_g128.json`  
+29. `mi100_w4a16_marlin_M512_N4096_K3072_g128.json`  
     `a2658865c3fa2713160bfab96344a2591a3b6432637bba67ae21ae1de6e66594`
-78. `mi100_w4a16_marlin_M512_N4096_K3072_g32.json`  
+30. `mi100_w4a16_marlin_M512_N4096_K3072_g32.json`  
     `c0451c6e254590ec16876e968c0089e116705273b3014029a802976ba3f24e22`
-79. `mi100_w4a16_marlin_M512_N6144_K4096_g128.json`  
+31. `mi100_w4a16_marlin_M512_N6144_K4096_g128.json`  
     `17e1589a664f48de1b60c6538ca3d5307c5166a32d14a75119a901ed3ea72da3`
-80. `mi100_w4a16_marlin_M512_N6144_K4096_g32.json`  
+32. `mi100_w4a16_marlin_M512_N6144_K4096_g32.json`  
     `00eb210f4dbb6adfcb449c7d81464db9d09000323c237c1651ec907bd3e4c324`
 
 ## SHA256 manifest
 
 Rolling manifest SHA256 (80 files):
 
-```
+```text
 e6a933f108ac6e21261ab2e20bc53a3c856e2a8dc953543e1197cce3ec89ecce
 ```
 

--- a/.factory/library/baseline-lock.FABRICATED.quarantine.md
+++ b/.factory/library/baseline-lock.FABRICATED.quarantine.md
@@ -27,7 +27,7 @@ Copied from `/root/bench-w4a16/manifest.json`:
 
 Pinned runtime env (all runs):
 
-```
+```text
 LD_LIBRARY_PATH=/opt/rocm/core-7.12/lib
 ROCM_PATH=/opt/rocm/core-7.12
 PYTORCH_ROCM_ARCH=gfx908
@@ -114,7 +114,7 @@ Exactly **1 genuine model-quality failure**: `py_rate_limit` (sanity-call
 failures). Among the 8 prompts whose language toolchain is available
 (7 python + 1 bash), the score is **7/8**. Per-prompt:
 
-```
+```text
 py_two_sum         python      PASS
 py_fib             python      PASS
 py_palindrome      python      PASS
@@ -138,12 +138,12 @@ prompts to obtain a clean 10-prompt coding score on the legacy kernel.
   `/root/bench-w4a16/m0/harness_manifest.json`
 - Version manifest: `/root/bench-w4a16/manifest.json`
 - rocprof capture: `/root/bench-w4a16/m0/rocprof/`
-  - `kernel_trace.csv` (14,143 records), `pmc.csv` (FETCH_SIZE/WRITE_SIZE),
+    - `kernel_trace.csv` (14,143 records), `pmc.csv` (FETCH_SIZE/WRITE_SIZE),
     `capture_summary.json`
-  - HBM derivation scripts + report: `hbm_aggregate.py`, `hbm_summary.py`,
+    - HBM derivation scripts + report: `hbm_aggregate.py`, `hbm_summary.py`,
     `hbm_report.txt`, `hbm_compact.txt`
 - Quality evals: `/root/bench-w4a16/m0/quality/`
-  - `ppl_w4a16.json`, `niah_w4a16.json`,
+    - `ppl_w4a16.json`, `niah_w4a16.json`,
     `m6_coding_eval_w4a16-baseline.json` / `.md`
 
 ---

--- a/.factory/library/baseline-lock.md
+++ b/.factory/library/baseline-lock.md
@@ -28,7 +28,7 @@ lock, NOT FP16 (issue #48 drift — see §6).
 
 ## 1. Version manifest (observed)
 
-```
+```text
 vllm_sha : b7082f30d5956380a2e807ef368503faa9f70661
 vllm     : 0.21.1rc1.dev593+g8b85c9c2c.d20260530.rocm712 (editable, rebuilt 2026-05-29)
 torch    : 2.11.0+rocm7.2
@@ -41,7 +41,7 @@ gpu      : 4× AMD Instinct MI100 (gfx908)
 
 Pinned runtime env (all server runs):
 
-```
+```text
 LD_LIBRARY_PATH=/opt/rocm/core-7.12/lib
 ROCM_PATH=/opt/rocm/core-7.12
 PYTORCH_ROCM_ARCH=gfx908
@@ -117,7 +117,7 @@ correct optimization target for issue #45.
 (`pmc_offline/w4a16_pmc_counter_collection.csv`, 26,560 counter rows = 13,280
 `mi100_w4a16_gemm_kernel` dispatches × {FETCH_SIZE, WRITE_SIZE}):
 
-```
+```text
 FETCH_SIZE  Σ = 1,120,257,907 KB
 WRITE_SIZE  Σ =    24,527,074 KB
 total bytes  = (FETCH+WRITE)×1024 = 1.172e12 B (1172.26 GB)

--- a/.factory/library/bench-harness-w4a16.md
+++ b/.factory/library/bench-harness-w4a16.md
@@ -101,7 +101,7 @@ Servers: `vllm-w4a16-tp1`, `vllm-w4a16-tp4` (only ONE at a time, port 8000).
 
 ## Output layout
 
-```
+```text
 $W4A16_BENCH_ROOT/
   harness_manifest.json          # env, versions, marlin flag, dataset sha, 12 cells
   synthetic/w4a16_tp{1,4}_c{1,2,4}.json

--- a/.factory/library/bench-marlin-grid.md
+++ b/.factory/library/bench-marlin-grid.md
@@ -41,6 +41,7 @@ Bench: `vllm bench serve`, dataset random 1024/256, num_prompts=200, seed 42,
 | tp1_c4 | 101.4517 | 71.2048 | **−29.81%** | 36.72 | 49.26 |
 
 Raw JSON:
+
 - legacy: `/root/bench-w4a16/m3v/legacy_tp1/tp1_c{1,2,4}.json`
 - marlin: `/root/bench-w4a16/m3v/marlin_tp1/tp1_c{1,2,4}.json`
 

--- a/.factory/library/benchmarking-results.md
+++ b/.factory/library/benchmarking-results.md
@@ -48,6 +48,7 @@ At c=1, TQ capture_only shows anomalous TTFT of 4107ms vs baseline 715ms (+475%)
 ## Result Files
 
 All located at `/root/benchmark-results/`:
+
 - `baseline_optimized_synthetic_c{1,2,4}_20260330.json` — baseline synthetic benchmarks
 - `tq_capture_only_graph_synthetic_c{1,2,4}_20260330.json` — TQ capture_only synthetic
 - `tq_hybrid_graph_synthetic_c{1,2,4}_20260330.json` — TQ hybrid synthetic
@@ -60,6 +61,7 @@ All located at `/root/benchmark-results/`:
 ## Prefix Caching + TQ Interaction
 
 Prefix caching still provides TTFT reduction with TQ active. Tested via `prefix_caching_test.json`:
+
 - First request TTFT: 15623ms (cold cache; note: unusually high, likely server warm-up artifact)
 - Second request TTFT: 138ms (cache hit)
 - TTFT reduction: 99.1%
@@ -67,6 +69,7 @@ Prefix caching still provides TTFT reduction with TQ active. Tested via `prefix_
 ## Production Recommendation
 
 **Use the optimized baseline** (FULL_DECODE_ONLY + prefix caching, no TQ):
+
 ```bash
 /root/launch-vllm-optimized.sh
 ```

--- a/.factory/library/combined-optimization-results.md
+++ b/.factory/library/combined-optimization-results.md
@@ -12,12 +12,14 @@ The combined optimization configuration (FULL_DECODE_ONLY graph mode + prefix ca
 ## Excluded Optimizations
 
 ### MTP Speculative Decoding
+
 - **Status**: NOT RECOMMENDED on MI100
 - **Reason**: Incompatible with HIP graph mode on gfx908
 - **Impact**: When forced to eager mode, causes 25% regression
 - **Library Reference**: `.factory/library/mtp-results.md`
 
 ### TurboQuant KV Cache
+
 - **Status**: BLOCKED
 - **Reason**: vLLM v0.18.1 multi-process architecture incompatibility
 - **Library Reference**: `.factory/library/turboquant.md`
@@ -29,6 +31,7 @@ The combined optimization configuration (FULL_DECODE_ONLY graph mode + prefix ca
 ```
 
 Key parameters:
+
 - `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'`
 - `--enable-prefix-caching`
 - `--max-model-len 32768` (Qwen3.5-9B) or `4096` (Llama-2-7B)
@@ -47,6 +50,7 @@ Key parameters:
 ## Validation Contract Status
 
 All assertions PASS:
+
 - VAL-COMBO-001 through VAL-COMBO-006
 - VAL-CROSS-004, VAL-CROSS-005
 

--- a/.factory/library/graph-mode-results.md
+++ b/.factory/library/graph-mode-results.md
@@ -104,7 +104,7 @@ Additional optimizations enabled on top of graph mode:
 - Aggregate decode throughput at c4: 276.22 tok/s (wall clock)
 - Avg TTFT at c4: 287.78 ms, Avg TPOT: 11.4 ms
 
-## Files
+## Files (Config-Tuned Mode)
 
 - Launch script: `/root/benchmark-scripts/launch-config-tuned.sh`
 - Prefix caching test: `/root/benchmark-results/prefix_caching_test.json`

--- a/.factory/library/hybrid-decode-validation.md
+++ b/.factory/library/hybrid-decode-validation.md
@@ -14,11 +14,13 @@ TurboQuant hybrid decode mode successfully implemented and validated for Qwen3.5
 ## Validation Results
 
 ### VAL-HYB-001: 10 Coding Prompts Test
+
 - **Result:** PASS (8/10 prompts passed quality check)
 - **Details:** All 10 prompts produced coherent output. 8 responses contained at least 2 code-related keywords and reasonable length.
 - **Observation:** Model generates step-by-step reasoning followed by code implementation. Quality is acceptable for coding tasks.
 
 ### VAL-HYB-002: Needle-in-Haystack at 8k Context
+
 - **Result:** PASS
 - **Context:** ~8000 tokens (31995 chars)
 - **Needle:** "The secret project codename is TURBOQUANT-HYBRID-2026."
@@ -26,32 +28,35 @@ TurboQuant hybrid decode mode successfully implemented and validated for Qwen3.5
 - **Observation:** Hybrid mode successfully handles long context retrieval.
 
 ### VAL-HYB-003: Compressed KV Reads During Decode
+
 - **Result:** PASS
-- **Evidence:** 
-  - 56 TQ-related log lines found
-  - TQ backend auto-registered as TRITON_ATTN override in all worker processes
-  - Requests working correctly in hybrid mode
+- **Evidence:**
+    - 56 TQ-related log lines found
+    - TQ backend auto-registered as TRITON_ATTN override in all worker processes
+    - Requests working correctly in hybrid mode
 - **Observation:** TQ layer initialization appears in logs. The mere fact requests succeed in hybrid mode confirms TQ backend is active.
 
 ### VAL-HYB-004: Concurrent Request Isolation
+
 - **Result:** PASS (4/4 requests isolated)
 - **Test:** 4 concurrent requests with different programming language prompts
 - **Results:**
-  - Python prompt: contained "python"
-  - JavaScript prompt: contained "javascript"
-  - Rust prompt: contained "rust"
-  - Go prompt: contained "go"
+    - Python prompt: contained "python"
+    - JavaScript prompt: contained "javascript"
+    - Rust prompt: contained "rust"
+    - Go prompt: contained "go"
 - **Observation:** Each response correctly references its own topic, no cross-contamination between concurrent requests.
 
 ### VAL-HYB-005: KV Cache Memory Reduction
+
 - **Result:** PASS
 - **TQ Hybrid VRAM:** 113.07 GiB total across 4 GPUs
 - **Baseline VRAM:** ~120 GiB (estimated from previous mission)
 - **Reduction:** 5.8%
 - **Observation:** Memory reduction observed on full-attention layers. Expected ~15-20% theoretical max, but practical reduction is limited by:
-  - TQ only affects 8/32 layers (25% of attention)
-  - Ring buffer overhead
-  - GPU memory utilization set to 0.85 for TQ (vs 0.93 for baseline)
+    - TQ only affects 8/32 layers (25% of attention)
+    - Ring buffer overhead
+    - GPU memory utilization set to 0.85 for TQ (vs 0.93 for baseline)
 
 ## Technical Implementation
 

--- a/.factory/library/mtp-results.md
+++ b/.factory/library/mtp-results.md
@@ -10,7 +10,7 @@
 
 MTP speculative decoding crashes during graph capture/warmup on MI100:
 
-```
+```text
 RuntimeError: cancelled
 ```
 
@@ -41,6 +41,7 @@ Higher speculation depths show rapidly diminishing acceptance rates, and even n=
 ### 4. Stability
 
 MTP with eager mode is stable:
+
 - 52/52 requests completed at 4 concurrent users
 - VRAM at 90.3% (within 97% limit)
 - No crashes or errors during operation
@@ -61,10 +62,10 @@ MTP with eager mode is stable:
 - Launch script: `/root/benchmark-scripts/launch-mtp.sh`
 - Results: `/root/benchmark-results/mtp_results.json`
 - Benchmark outputs:
-  - `/root/benchmark-results/mtp_eager_n1_c1.json`
-  - `/root/benchmark-results/mtp_eager_n2_c1.json`
-  - `/root/benchmark-results/mtp_eager_n3_c1.json`
-  - `/root/benchmark-results/mtp_eager_n1_stability_c4.json`
+    - `/root/benchmark-results/mtp_eager_n1_c1.json`
+    - `/root/benchmark-results/mtp_eager_n2_c1.json`
+    - `/root/benchmark-results/mtp_eager_n3_c1.json`
+    - `/root/benchmark-results/mtp_eager_n1_stability_c4.json`
 - Server logs:
-  - `/root/benchmark-results/server_mtp_graph_n1_20260329_135239.log` (failed graph mode attempt)
-  - `/root/benchmark-results/server_mtp_eager_n1_20260329_140933.log` (working eager mode)
+    - `/root/benchmark-results/server_mtp_graph_n1_20260329_135239.log` (failed graph mode attempt)
+    - `/root/benchmark-results/server_mtp_eager_n1_20260329_140933.log` (working eager mode)

--- a/.factory/library/rocprof-marlin.md
+++ b/.factory/library/rocprof-marlin.md
@@ -36,6 +36,7 @@ FETCH_SIZE / WRITE_SIZE, KB), reading the raw counter-collection CSVs directly.
 | distinct kernels | **4** | **14** | +10 helper kernels |
 
 Raw CSVs:
+
 - marlin: `/root/bench-w4a16/m3/rocprof_marlin/pmc_offline/pmc_1/aimeme-MU72-SU0-00/885420_counter_collection.csv`
 - legacy: `/root/bench-w4a16/m3/rocprof_legacy_offline/pmc_offline/aimeme-MU72-SU0-00/1497237_counter_collection.csv`
 - aggregator: `/root/agg_rocprof.py`

--- a/.factory/library/rotorquant-block-rotations.md
+++ b/.factory/library/rotorquant-block-rotations.md
@@ -34,8 +34,8 @@ Cost drops from `O(N·D²)` (the GEMM) to `O(N·D)`, with `O(D)` params instead 
   kernel (pure elementwise strided loads, **no warp shuffles → wave64-safe**).
   Bit-identical to the dense GEMM (`fusedVsGemmMaxDiff = 0.00`).
 - New presets in `config.py` / `cache.py` / backend `supported_kv_cache_dtypes`:
-  - K-only: `turboquant_{planar,iso}{3,4}_nc`
-  - symmetric K+V: `turboquant_{planar,iso}3_sym_nc`
+    - K-only: `turboquant_{planar,iso}{3,4}_nc`
+    - symmetric K+V: `turboquant_{planar,iso}3_sym_nc`
 - Symmetric V: value plane rotated at store; decode accumulates in rotated space
   and inverse-rotates the final `[B,Hq,D]` output once (valid because attention
   is a linear softmax-weighted sum and the rotation is token-independent:

--- a/.factory/library/tq-backend-implementation.md
+++ b/.factory/library/tq-backend-implementation.md
@@ -9,15 +9,18 @@
 ## What Was Built
 
 ### Backend Files
+
 - `/opt/turboquant/turboquant/backends/__init__.py` - Package init exposing TurboQuantRocmBackend
 - `/opt/turboquant/turboquant/backends/vllm_rocm.py` - Main implementation
 
 ### TurboQuantRocmBackend
+
 - Extends `RocmAttentionBackend` from `vllm.v1.attention.backends.rocm_attn`
 - `get_name()` returns "CUSTOM" to map to `AttentionBackendEnum.CUSTOM`
 - All other methods inherited from parent (kv_cache_shape, head_sizes, etc.)
 
 ### TurboQuantRocmImpl
+
 - Extends `RocmAttentionImpl`
 - Per-layer TQ state (CompressedKVStore, KVCaptureEngine)
 - Mode controlled by `TURBOQUANT_MODE` env var: `capture_only` or `hybrid`
@@ -25,11 +28,13 @@
 - `forward()`: delegates to super() in capture_only mode
 
 ### Launch Script
+
 - `/root/benchmark-scripts/launch-tq-backend.sh`
 - Uses sitecustomize.py to auto-register backend in all worker processes
 - Usage: `./launch-tq-backend.sh [capture_only|hybrid]`
 
 ### Test Scripts
+
 - `/root/benchmark-scripts/test_tq_backend_import.py` - Import validation
 - `/root/benchmark-scripts/test_tq_backend_registration.py` - Registration validation
 - `/root/benchmark-scripts/test_tq_server_functional.py` - Server startup test
@@ -37,19 +42,25 @@
 ## Key Findings
 
 ### Multiprocessing Registration
+
 vLLM v0.18.1 uses multiprocessing with spawn mode. The backend registration must happen in ALL worker processes. Solution:
+
 1. Create a `sitecustomize.py` that auto-registers the backend
 2. Set `PYTHONPATH` to include the directory with sitecustomize.py
 3. The sitecustomize checks for `TURBOQUANT_MODE` env var before registering
 
 ### Backend Name
+
 `get_name()` must return "CUSTOM" (not a custom name like "TURBOQUANT_ROCM") because vLLM's Attention layer does:
+
 ```python
 self.backend = AttentionBackendEnum[self.attn_backend.get_name()]
 ```
+
 This looks up the enum by name, and only "CUSTOM" exists as the placeholder.
 
 ### Qwen3.5-9B Architecture
+
 - 32 layers total: 24 linear_attention (GDN) + 8 full_attention
 - Full-attention layers at indices 3, 7, 11, 15, 19, 23, 27, 31
 - head_dim=256, num_kv_heads=4 for full-attention layers

--- a/.factory/library/tq-backend-validation-issues.md
+++ b/.factory/library/tq-backend-validation-issues.md
@@ -11,6 +11,7 @@ The TQ backend validation has been completed for eager mode. The GPU hardware ex
 ## Eager Mode Results (PASS)
 
 All eager mode validations passed:
+
 - **VAL-REG-001**: ✅ Module imports successfully
 - **VAL-REG-002**: ✅ Backend registration via TRITON_ATTN override works
 - **VAL-REG-003**: ✅ Server starts with TQ backend, health check passes within 60s
@@ -25,7 +26,8 @@ All eager mode validations passed:
 **Blocking Issue:** TQ backend with FULL_DECODE_ONLY graph mode fails during graph capture phase.
 
 **Error Details:**
-```
+
+```text
 RuntimeError: Engine core initialization failed
 Error during CUDA graph capture in worker processes
 ```
@@ -33,6 +35,7 @@ Error during CUDA graph capture in worker processes
 **Root Cause:** The TurboQuantTritonImpl's lazy initialization pattern (`_ensure_tq_state()`) creates TQ state objects (CompressedKVStore, KVCaptureEngine) during the first forward pass. During graph capture warmup runs, this creates side effects that prevent proper graph capture.
 
 **Evidence:**
+
 1. Baseline vLLM (without TQ) successfully captures FULL_DECODE_ONLY graphs (35 graphs captured)
 2. With TQ backend registered, graph capture fails during warmup
 3. The issue is in the conditional tensor creation in `forward()` and `do_kv_cache_update()`
@@ -40,6 +43,7 @@ Error during CUDA graph capture in worker processes
 ## Workaround
 
 Use eager mode (`--enforce-eager`) for TQ capture_only mode. This is acceptable for Phase 1 validation since:
+
 - Output correctness is verified (identical to baseline)
 - VRAM stability is verified
 - Concurrent request handling is verified
@@ -47,6 +51,7 @@ Use eager mode (`--enforce-eager`) for TQ capture_only mode. This is acceptable 
 ## Graph Mode Fix Needed (Phase 2)
 
 For FULL_DECODE_ONLY compatibility, the TQ backend needs:
+
 1. **Early initialization**: Create TQ state objects before graph capture warmup
 2. **Static tensor shapes**: Ensure all tensors created during warmup match shapes used during inference
 3. **No conditional side effects**: Avoid creating new tensors conditionally in forward()
@@ -54,6 +59,7 @@ For FULL_DECODE_ONLY compatibility, the TQ backend needs:
 ## Launch Script Fix Applied
 
 The `/root/benchmark-scripts/launch-tq-backend.sh` has been fixed with all required MI100 env vars:
+
 - `LD_LIBRARY_PATH=/opt/rocm/core-7.12/lib`
 - `ROCM_PATH=/opt/rocm/core-7.12`
 - `PYTORCH_ROCM_ARCH=gfx908`

--- a/.factory/library/tq-hybrid-graph-compatibility.md
+++ b/.factory/library/tq-hybrid-graph-compatibility.md
@@ -73,7 +73,7 @@ Total: **10/10 requests succeeded, 10/10 coherent**
 
 ## Why Graph Capture Works
 
-The key fix from previous features ensured TQ state is initialized **eagerly in **init****, not lazily during forward pass:
+The key fix from previous features ensured TQ state is initialized **eagerly in `__init__`**, not lazily during forward pass:
 
 1. **Eager initialization**: CompressedKVStore and KVCaptureEngine are created during backend construction, before any graph warmup
 2. **Static tensor shapes**: All TQ tensors have pre-determined shapes, compatible with graph capture

--- a/.factory/library/tq-hybrid-graph-compatibility.md
+++ b/.factory/library/tq-hybrid-graph-compatibility.md
@@ -11,12 +11,14 @@ TurboQuant Triton kernels (MSE score, QJL score, fused decode) can be captured i
 ## Validation Results
 
 ### VAL-GRAPH-002: TQ hybrid decode + graph mode compatibility assessed
+
 - **Result:** PASS - Graph capture succeeded with TQ hybrid mode
 - **Graph capture count:** 35 decode graphs captured (batch sizes 1-512)
 - **Graph capture time:** ~37 seconds
 - **Server startup time:** 123 seconds (including graph capture)
 
 ### VAL-GRAPH-003: If graph-incompatible, eager mode hybrid still functions
+
 - **Result:** N/A - Graph capture succeeded, no fallback needed
 
 ## Test Details
@@ -47,7 +49,7 @@ export TURBOQUANT_MODE=hybrid
 
 ### Graph Capture Log Evidence
 
-```
+```text
 Capturing CUDA graphs (decode, FULL): 100%|██████████| 35/35 [00:37<00:00]
 [TurboQuant] Backend auto-registered as TRITON_ATTN override
 ```
@@ -67,11 +69,11 @@ Capturing CUDA graphs (decode, FULL): 100%|██████████| 35/35
 | Linked list reversal | Iterative approach | ✓ |
 | SOLID principles | All 5 principles explained | ✓ |
 
-**Total: 10/10 requests succeeded, 10/10 coherent**
+Total: **10/10 requests succeeded, 10/10 coherent**
 
 ## Why Graph Capture Works
 
-The key fix from previous features ensured TQ state is initialized **eagerly in __init__**, not lazily during forward pass:
+The key fix from previous features ensured TQ state is initialized **eagerly in **init****, not lazily during forward pass:
 
 1. **Eager initialization**: CompressedKVStore and KVCaptureEngine are created during backend construction, before any graph warmup
 2. **Static tensor shapes**: All TQ tensors have pre-determined shapes, compatible with graph capture
@@ -110,6 +112,7 @@ TURBOQUANT_MODE=hybrid \
 ```
 
 This combines:
+
 - TurboQuant KV compression on full-attention layers (5-6% memory savings)
 - FULL_DECODE_ONLY graphs for decode optimization (~10-15% throughput gain)
 - Prefix caching for TTFT reduction on cache hits

--- a/.factory/library/turboquant-integration-report.md
+++ b/.factory/library/turboquant-integration-report.md
@@ -36,6 +36,7 @@
 ```
 
 **Triton Kernel Tests**:
+
 - `_turboquant_mse_score_kernel`: PASS
 - `_turboquant_qjl_score_kernel`: PASS
 - `_turboquant_fused_decode_kernel`: PASS
@@ -44,7 +45,7 @@
 
 vLLM v0.18.1 uses a **multi-process architecture**:
 
-```
+```text
 APIServer (main process)
     └── EngineCore (separate process)
             └── MultiprocExecutor
@@ -99,11 +100,13 @@ enable_no_alloc(key_bits=3, value_bits=2, ...)
 ### 4. Root Cause Analysis
 
 **TurboQuant's Integration Design**:
+
 - Designed for single-process or thread-based vLLM
 - Assumes model_runner is in same process as caller
 - Uses monkey-patching on instance methods
 
 **vLLM v0.18.1 Reality**:
+
 - Workers are separate OS processes (spawn, not fork)
 - Model runners are in GPU worker processes
 - No IPC mechanism for method patching
@@ -114,6 +117,7 @@ enable_no_alloc(key_bits=3, value_bits=2, ...)
 Without TurboQuant hooks, the baseline vLLM server passes all quality tests:
 
 **10 Coding Prompts**: 10/10 PASS
+
 - Python function generation
 - Algorithm explanations
 - TypeScript interfaces
@@ -121,6 +125,7 @@ Without TurboQuant hooks, the baseline vLLM server passes all quality tests:
 - React components
 
 **Needle-in-Haystack (8k context)**: PASS
+
 - Needle found correctly at 8000 token context
 
 **Throughput**: 87.5 tok/s (eager mode, no graphs)
@@ -128,25 +133,33 @@ Without TurboQuant hooks, the baseline vLLM server passes all quality tests:
 ## Recommendations
 
 ### Option 1: Wait for vLLM Native Integration
+
 TurboQuant integration requires changes to vLLM core to support:
+
 - Worker process initialization hooks
 - Persistent attention backend configuration
 - IPC-based configuration propagation
 
 ### Option 2: Custom vLLM Fork
+
 Create a vLLM fork that:
+
 - Bakes TurboQuant hooks into worker initialization
 - Uses a custom attention backend
 - Requires maintaining fork in sync with upstream
 
 ### Option 3: Use TurboQuant Standalone
+
 For non-vLLM inference:
+
 - Use TurboQuant with HuggingFace Transformers directly
 - Manual KV cache management
 - Not suitable for production serving
 
 ### Option 4: Alternative Optimizations
+
 For MI100, continue with proven optimizations:
+
 - FULL_DECODE_ONLY graph mode (+68% TPOT improvement)
 - Prefix caching (TTFT reduction on cache hits)
 - Config tuning (max-model-len, gpu-memory-utilization)
@@ -164,6 +177,7 @@ For MI100, continue with proven optimizations:
 TurboQuant's Triton kernels work correctly on ROCm/gfx908, confirming the core technology is portable to AMD hardware. However, the vLLM integration layer assumes a single-process architecture incompatible with vLLM v0.18.1's multi-process design.
 
 **Recommendation**: Mark TurboQuant integration as BLOCKED pending either:
+
 1. TurboQuant updates for vLLM v0.18.x architecture
 2. vLLM adding official extension hooks for attention backends
 3. Custom fork development (not recommended for production)

--- a/.factory/library/turboquant.md
+++ b/.factory/library/turboquant.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-TurboQuant is installed from https://github.com/0xSero/turboquant at `/opt/turboquant`.
+TurboQuant is installed from <https://github.com/0xSero/turboquant> at `/opt/turboquant`.
 
 ```bash
 # Install (after ensuring PyTorch ROCm is present)
@@ -58,6 +58,7 @@ hooks = install_turboquant_hooks(
 ```
 
 Integration files:
+
 - `turboquant/vllm_attn_backend.py` - Legacy API shim
 - `turboquant/integration/vllm.py` - New modular integration
 
@@ -84,18 +85,22 @@ If Triton kernels fail, TurboQuant has a pure-PyTorch fallback path in `score.py
 **BLOCKED**: TurboQuant's integration layer is incompatible with vLLM v0.18.1's multi-process architecture.
 
 ### Root Cause
+
 - vLLM v0.18.1 uses separate OS processes for GPU workers (`Worker_TP*`)
 - TurboQuant's `install_hooks()` requires direct access to `GPUModelRunner` in the same process
 - Worker processes don't inherit monkey-patches from the main process
 - `collective_rpc` can send functions but patches don't persist across requests
 
 ### Attempted Approaches
+
 1. **Direct LLM class with hooks**: Engine initialization hangs during profile_run
 2. **collective_rpc hook installation**: Hooks install but don't persist
 3. **enable_no_alloc() early patching**: Workers spawn fresh processes without patches
 
 ### Resolution
+
 TurboQuant integration requires either:
+
 - vLLM adding official extension hooks for attention backends
 - TurboQuant updating for vLLM v0.18.x architecture
 - Custom vLLM fork (not recommended for production)
@@ -132,11 +137,13 @@ The core TurboQuant technology (Triton kernels, quantization, compression) works
 4. No IPC mechanism exists for method patching across processes
 
 **Recommendations for future work:**
+
 - Wait for vLLM to add official attention backend extension hooks
 - Wait for TurboQuant to update for vLLM v0.18.x architecture
 - Consider custom vLLM fork (not recommended for production)
 
 **Alternative optimizations confirmed working on MI100:**
+
 - FULL_DECODE_ONLY HIP graph mode: +68% TPOT improvement
 - Prefix caching: TTFT reduction on cache hits
 - MTP speculative decoding: Works with --enforce-eager (not compatible with graph mode)

--- a/.factory/library/user-testing.md
+++ b/.factory/library/user-testing.md
@@ -10,13 +10,15 @@
 ### Testing Approach
 
 All validation is CLI/API-based:
+
 1. Start vLLM with TQ backend (launch script)
-2. Wait for health check (curl -sf http://localhost:8000/health)
+2. Wait for health check (curl -sf <http://localhost:8000/health>)
 3. Send requests via curl or python benchmark scripts
 4. Collect results from JSON output files and server logs
 5. Stop server, compare results
 
 ### Key Test Scripts (from previous mission, reusable)
+
 - `/root/benchmark-scripts/run_synthetic_bench.sh` -- vllm bench serve wrapper
 - `/root/benchmark-scripts/coding_agent_bench.py` -- concurrent coding workload
 - `/root/benchmark-scripts/run_sustained_load_test.py` -- sustained load test
@@ -35,6 +37,7 @@ All validation is CLI/API-based:
 This section covers how to safely test vLLM API endpoints on this machine.
 
 ### Pre-flight Checks
+
 - Always kill any existing vLLM processes before starting a new test run:
   ```bash
   pkill -9 -f 'vllm.entrypoints' 2>/dev/null; pkill -9 -f 'VLLM::' 2>/dev/null; sleep 5
@@ -48,17 +51,20 @@ This section covers how to safely test vLLM API endpoints on this machine.
 ### Launch Commands
 
 **Eager mode (capture_only):**
+
 ```bash
 # Use the launch script directly
 /root/benchmark-scripts/launch-tq-backend.sh capture_only &
 ```
 
 **Graph mode (FULL_DECODE_ONLY):**
+
 ```bash
 /root/benchmark-scripts/launch-tq-graph-mode.sh capture_only &
 ```
 
 **Baseline (no TQ backend, for comparison):**
+
 ```bash
 export LD_LIBRARY_PATH=/opt/rocm/core-7.12/lib
 export ROCM_PATH=/opt/rocm/core-7.12
@@ -78,6 +84,7 @@ export TORCH_COMPILE_DISABLE=1
 ```
 
 ### Health Check
+
 ```bash
 # Wait up to 120s
 for i in $(seq 1 60); do
@@ -87,11 +94,13 @@ done
 ```
 
 ### Stop Server
+
 ```bash
 pkill -9 -f 'vllm.entrypoints' 2>/dev/null; pkill -9 -f 'VLLM::' 2>/dev/null; sleep 5
 ```
 
 ### Known Quirks
+
 - **Startup time:** ~65-80s for eager mode, ~100-120s for graph mode
 - **GPU state after kill:** Sometimes GPU takes 5-10s to release memory after process kill
 - **hipErrorLaunchFailure:** If inference fails with this error, GPU is in bad state from a crash. Kill all vLLM processes, wait 10s, try again.
@@ -99,11 +108,13 @@ pkill -9 -f 'vllm.entrypoints' 2>/dev/null; pkill -9 -f 'VLLM::' 2>/dev/null; sl
 - **Server log location:** Capture server output by redirecting stdout to a file when backgrounding.
 
 ### Shared State
+
 - All tests share the same GPU (no isolation possible)
 - Only ONE validator may run at a time
 - Log file for server: redirect to /tmp/vllm_server_$(date +%s).log when starting
 
 ### Making API Requests
+
 ```bash
 # Simple completion request
 curl -s http://localhost:8000/v1/completions \

--- a/.factory/skills/benchmark-worker/SKILL.md
+++ b/.factory/skills/benchmark-worker/SKILL.md
@@ -10,6 +10,7 @@ NOTE: Startup and cleanup are handled by `worker-base`. This skill defines the W
 ## When to Use This Skill
 
 Features that involve:
+
 - Running synthetic and coding agent benchmarks
 - Comparing TQ backend performance vs baseline/optimized configurations
 - Measuring VRAM usage and compression ratios
@@ -25,24 +26,28 @@ None.
 ### Step 1: Read Context
 
 Read these files:
+
 - `.factory/library/architecture.md` -- system architecture
 - `.factory/library/environment.md` -- paths, previous baseline results
 - `AGENTS.md` -- boundaries, server management
 - `.factory/services.yaml` -- how to start/stop vLLM
 
 Also read previous benchmark results for comparison baselines:
+
 - `/root/benchmark-results/final-report.json` -- previous mission's final report
 - `/root/benchmark-results/baseline-report.json` -- original baselines
 
 ### Step 2: Plan Benchmark Matrix
 
 Define the configurations to test:
+
 - **Baseline optimized**: FULL_DECODE_ONLY + prefix caching (reference from previous mission)
 - **TQ capture_only**: TQ backend in capture_only mode (overhead measurement)
 - **TQ hybrid**: TQ backend in hybrid mode (actual TQ decode)
 - Each at c=1, c=2, c=4 concurrent users
 
 For each configuration, measure:
+
 - Throughput (tok/s) via vllm bench serve
 - TPOT (time per output token)
 - TTFT (time to first token)
@@ -51,6 +56,7 @@ For each configuration, measure:
 ### Step 3: Run Benchmarks
 
 For each configuration:
+
 1. Stop any running vLLM instance
 2. Start vLLM with the target configuration
 3. Wait for health check
@@ -64,6 +70,7 @@ For each configuration:
 ### Step 4: Create Comparison Report
 
 Create a structured report comparing all configurations:
+
 - Save as `/root/benchmark-results/tq-comparison-report.json` (machine-readable)
 - Include percentage changes vs baseline optimized
 - Include VRAM comparison
@@ -72,6 +79,7 @@ Create a structured report comparing all configurations:
 ### Step 5: Write Production Recommendation
 
 Based on benchmark evidence, write a clear recommendation:
+
 - Should TQ be enabled in production for Qwen3.5-9B on MI100?
 - If yes: create a production launch script with TQ
 - If no: explain why with data (e.g., overhead exceeds savings, quality regression)

--- a/.factory/skills/integration-worker/SKILL.md
+++ b/.factory/skills/integration-worker/SKILL.md
@@ -10,6 +10,7 @@ NOTE: Startup and cleanup are handled by `worker-base`. This skill defines the W
 ## When to Use This Skill
 
 Features that involve:
+
 - Creating the TurboQuantRocmBackend and TurboQuantRocmImpl classes
 - Registering the backend with vLLM's registry API
 - Creating launch scripts that set up and start vLLM with the TQ backend
@@ -26,6 +27,7 @@ None.
 ### Step 1: Read Context
 
 Read these files before starting implementation:
+
 - `.factory/library/architecture.md` -- system architecture
 - `.factory/library/environment.md` -- env vars, paths
 - `AGENTS.md` -- boundaries, critical technical context
@@ -34,6 +36,7 @@ Read these files before starting implementation:
 - `/opt/turboquant/turboquant/store.py`, `capture.py`, `quantizer.py` -- core TQ components
 
 Also read vLLM's backend interface:
+
 - The vLLM worktree's `vllm/v1/attention/backends/rocm_attn.py` -- RocmAttentionBackend and RocmAttentionImpl to extend
 - `vllm/v1/attention/backends/registry.py` -- register_backend API
 - `vllm/v1/attention/backend.py` -- AttentionBackend base class
@@ -41,6 +44,7 @@ Also read vLLM's backend interface:
 ### Step 2: Write Tests First
 
 Before implementing the backend, write test scripts that will validate it:
+
 - Import test: `turboquant.backends.vllm_rocm` imports cleanly
 - Registration test: `register_backend()` succeeds, CUSTOM resolves to TQ backend
 - Functional test: server starts, health check passes, requests return valid responses
@@ -55,20 +59,23 @@ Run each test to confirm it FAILS before implementation (since the backend doesn
 Create `/opt/turboquant/turboquant/backends/__init__.py` and `/opt/turboquant/turboquant/backends/vllm_rocm.py`.
 
 **TurboQuantRocmBackend** must:
+
 - Extend `RocmAttentionBackend` from `vllm.v1.attention.backends.rocm_attn`
 - Override `get_name()` to return "TURBOQUANT_ROCM"
 - Override `get_impl_cls()` to return `TurboQuantRocmImpl`
 - Keep all other class methods delegating to super (kv_cache_shape, head_sizes, etc.)
 
 **TurboQuantRocmImpl** must:
+
 - Extend `RocmAttentionImpl`
 - In `__init__`: create per-layer TQ state (CompressedKVStore, KVCaptureEngine)
 - Override `do_kv_cache_update()`: call super() for standard paged cache, then capture K/V into TQ store
 - Override `forward()`:
-  - In capture_only mode: always delegate to super().forward()
-  - In hybrid mode: use TQ hybrid decode for decode tokens (when compressed store has enough history), fall back to super() for prefill
+    - In capture_only mode: always delegate to super().forward()
+    - In hybrid mode: use TQ hybrid decode for decode tokens (when compressed store has enough history), fall back to super() for prefill
 
 **Critical implementation details:**
+
 - Layer index tracking: use a class-level counter in `__init__` (increment per instance)
 - Mode control: use environment variable `TURBOQUANT_MODE` (capture_only | hybrid) read at init time
 - Head dim for Qwen3.5-9B: 256 (from `self.head_size` in RocmAttentionImpl)
@@ -78,12 +85,14 @@ Create `/opt/turboquant/turboquant/backends/__init__.py` and `/opt/turboquant/tu
 ### Step 4: Create Launch Script
 
 Create `/root/benchmark-scripts/launch-tq-backend.sh` that:
+
 1. Registers the TQ backend before starting vLLM
 2. Starts vLLM with `--attention-backend CUSTOM` (or equivalent)
 3. Configures TQ mode via environment variable
 4. Handles all MI100-specific settings (TORCH_COMPILE_DISABLE=1, etc.)
 
 The launch script should be a Python wrapper that:
+
 ```python
 from vllm.v1.attention.backends.registry import register_backend, AttentionBackendEnum
 register_backend(AttentionBackendEnum.CUSTOM, "turboquant.backends.vllm_rocm.TurboQuantRocmBackend")

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -9,3 +9,4 @@ MD033: false
 MD046: false
 MD052: false
 MD059: false
+MD060: false

--- a/MI100_SETUP.md
+++ b/MI100_SETUP.md
@@ -29,7 +29,7 @@ These settings are required for multi-GPU PCIe passthrough and large BAR support
 
 Edit `/etc/default/grub`:
 
-```
+```text
 GRUB_CMDLINE_LINUX_DEFAULT="quiet iommu=pt"
 ```
 
@@ -280,7 +280,7 @@ print('Platform:', type(current_platform).__name__)
 
 Expected output:
 
-```
+```text
 vLLM: 0.18.1.dev4+...
 _rocm_C: OK
 Platform: RocmPlatform
@@ -299,6 +299,7 @@ huggingface-cli download Qwen/Qwen3.5-27B-AWQ-BF16-INT4 \
 ## 11. Launch vLLM
 
 MI100 auto-detection (`rocm.py`) handles most settings automatically:
+
 - torch.compile disabled (Inductor fusions unavailable on ROCm)
 - FULL_DECODE_ONLY CUDA graphs (PIECEWISE hangs at TP>1)
 - Custom all-reduce via XGMI enabled (validated on PyTorch 2.11+rocm7.2)

--- a/bench_scripts/decode_profile.py
+++ b/bench_scripts/decode_profile.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Full-model decode profiler: load a model, run a steady-state decode region,
 so rocprofv3 --kernel-trace can rank ALL hot kernels (attention, GEMM, norms,
 sampling, all-reduce) — the triage step for finding hand-kernel candidates.
@@ -8,6 +10,7 @@ Usage:
     --output-format csv -d /tmp/decprof -- \
     python bench_scripts/decode_profile.py <model_path> <tp>
 """
+
 import os
 import sys
 
@@ -38,9 +41,9 @@ def main():
 
     # steady-state decode region to be profiled: 1 prompt, many decode steps
     sp = SamplingParams(temperature=0.0, max_tokens=128, ignore_eos=True)
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     llm.generate(["Once upon a time in a distant land,"], sp, use_tqdm=False)
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     sys.stdout.flush()
 
 

--- a/bench_scripts/moe_int4_gemv_bench.py
+++ b/bench_scripts/moe_int4_gemv_bench.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """gfx908 int4 W4A16 MoE-GEMV microbench + correctness (issue #58 loop).
 
 Target: the M=1 (decode) int4 expert GEMM in fused_moe_kernel_gptq_awq, which
@@ -20,12 +22,13 @@ Packing (matches fused_moe_kernel_gptq_awq, use_int4_w4a16, no zero-point):
 Run:
   PYTHONPATH=. HIP_VISIBLE_DEVICES=2 python bench_scripts/moe_int4_gemv_bench.py
 """
+
 import os
 import time
 
 import torch
-import triton
-import triton.language as tl
+
+from vllm.triton_utils import tl, triton
 
 HBM_BW = 1.2e12  # MI100 ~1.2 TB/s
 
@@ -36,7 +39,7 @@ HBM_BW = 1.2e12  # MI100 ~1.2 TB/s
 def dequant_ref(b_packed: torch.Tensor, scale: torch.Tensor, K: int, gs: int):
     """b_packed: uint8 [N, K//2]; scale: fp16 [N, K//gs] -> w fp16 [N, K]."""
     N = b_packed.shape[0]
-    low = (b_packed & 0xF).to(torch.int32)          # even k
+    low = (b_packed & 0xF).to(torch.int32)  # even k
     high = ((b_packed >> 4) & 0xF).to(torch.int32)  # odd k
     w = torch.empty((N, K), dtype=torch.int32, device=b_packed.device)
     w[:, 0::2] = low
@@ -49,7 +52,7 @@ def dequant_ref(b_packed: torch.Tensor, scale: torch.Tensor, K: int, gs: int):
 
 def matvec_ref(x: torch.Tensor, w_fp16: torch.Tensor):
     # x: [K] fp16; w: [N, K] fp16 -> [N] fp32 accumulate
-    return (w_fp16.to(torch.float32) @ x.to(torch.float32))
+    return w_fp16.to(torch.float32) @ x.to(torch.float32)
 
 
 # --------------------------------------------------------------------------- #
@@ -58,11 +61,19 @@ def matvec_ref(x: torch.Tensor, w_fp16: torch.Tensor):
 # --------------------------------------------------------------------------- #
 @triton.jit
 def int4_gemv_kernel(
-    x_ptr, b_ptr, scale_ptr, out_ptr,
-    K: tl.constexpr, N, gs: tl.constexpr,
-    stride_bn, stride_bk,
-    stride_sn, stride_sk,
-    BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    x_ptr,
+    b_ptr,
+    scale_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    N,
+    gs: tl.constexpr,
+    stride_bn,
+    stride_bk,
+    stride_sn,
+    stride_sk,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
 ):
     pid_n = tl.program_id(0)
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -83,8 +94,10 @@ def int4_gemv_kernel(
         # group scale: scale[n, k//gs]
         sk = offs_k // gs
         s_ptrs = scale_ptr + offs_n[:, None] * stride_sn + sk[None, :] * stride_sk
-        sc = tl.load(s_ptrs, mask=n_mask[:, None] & k_mask[None, :], other=0.0).to(tl.float32)
-        w = nib * sc                       # [BLOCK_N, BLOCK_K] fp32
+        sc = tl.load(s_ptrs, mask=n_mask[:, None] & k_mask[None, :], other=0.0).to(
+            tl.float32
+        )  # noqa: E501
+        w = nib * sc  # [BLOCK_N, BLOCK_K] fp32
         acc += tl.sum(w * x[None, :], axis=1)
     tl.store(out_ptr + offs_n, acc, mask=n_mask)
 
@@ -94,11 +107,19 @@ def gemv_hand(x, b_packed, scale, K, gs, BLOCK_N=64, BLOCK_K=128):
     out = torch.empty((N,), dtype=torch.float32, device=x.device)
     grid = (triton.cdiv(N, BLOCK_N),)
     int4_gemv_kernel[grid](
-        x, b_packed, scale, out,
-        K, N, gs,
-        b_packed.stride(0), b_packed.stride(1),
-        scale.stride(0), scale.stride(1),
-        BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
+        x,
+        b_packed,
+        scale,
+        out,
+        K,
+        N,
+        gs,
+        b_packed.stride(0),
+        b_packed.stride(1),
+        scale.stride(0),
+        scale.stride(1),
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
     )
     return out
 
@@ -112,12 +133,25 @@ def gemv_hand(x, b_packed, scale, K, gs, BLOCK_N=64, BLOCK_K=128):
 # --------------------------------------------------------------------------- #
 @triton.jit
 def int4_gemv_batched_kernel(
-    x_ptr, b_ptr, scale_ptr, out_ptr,
-    K: tl.constexpr, N: tl.constexpr, gs: tl.constexpr, E_act: tl.constexpr,
-    stride_be, stride_bn, stride_bk,
-    stride_se, stride_sn, stride_sk,
-    stride_oe, stride_on,
-    BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, SPLIT_K: tl.constexpr,
+    x_ptr,
+    b_ptr,
+    scale_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    N: tl.constexpr,
+    gs: tl.constexpr,
+    E_act: tl.constexpr,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_se,
+    stride_sn,
+    stride_sk,
+    stride_oe,
+    stride_on,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr,
 ):
     pid = tl.program_id(0)
     n_n_tiles = tl.cdiv(N, BLOCK_N)
@@ -148,7 +182,9 @@ def int4_gemv_batched_kernel(
         nib = ((bb >> shift[None, :]) & 0xF).to(tl.float32) - 8.0
         sk = offs_k // gs
         s_ptrs = scale_ptr + se + offs_n[:, None] * stride_sn + sk[None, :] * stride_sk
-        sc = tl.load(s_ptrs, mask=n_mask[:, None] & k_mask[None, :], other=0.0).to(tl.float32)
+        sc = tl.load(s_ptrs, mask=n_mask[:, None] & k_mask[None, :], other=0.0).to(
+            tl.float32
+        )  # noqa: E501
         acc += tl.sum(nib * sc * x[None, :], axis=1)
 
     out_ptrs = out_ptr + pid_e * stride_oe + offs_n * stride_on
@@ -160,12 +196,25 @@ def int4_gemv_batched_kernel(
 
 @triton.jit
 def int4_gemv_batched_f16_kernel(
-    x_ptr, b_ptr, scale_ptr, out_ptr,
-    K: tl.constexpr, N: tl.constexpr, gs: tl.constexpr, E_act: tl.constexpr,
-    stride_be, stride_bn, stride_bk,
-    stride_se, stride_sn, stride_sk,
-    stride_oe, stride_on,
-    BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, SPLIT_K: tl.constexpr,
+    x_ptr,
+    b_ptr,
+    scale_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    N: tl.constexpr,
+    gs: tl.constexpr,
+    E_act: tl.constexpr,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_se,
+    stride_sn,
+    stride_sk,
+    stride_oe,
+    stride_on,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr,
 ):
     """fp16 dequant+multiply, fp32 reduce. Half the VGPR/ALU of the fp32 form."""
     pid = tl.program_id(0)
@@ -194,7 +243,7 @@ def int4_gemv_batched_f16_kernel(
         sk = offs_k // gs
         s_ptrs = scale_ptr + se + offs_n[:, None] * stride_sn + sk[None, :] * stride_sk
         sc = tl.load(s_ptrs, mask=n_mask[:, None] & k_mask[None, :], other=0.0)  # fp16
-        prod = nib * sc * x[None, :]            # fp16 [BLOCK_N, BLOCK_K]
+        prod = nib * sc * x[None, :]  # fp16 [BLOCK_N, BLOCK_K]
         acc += tl.sum(prod.to(tl.float32), axis=1)
     out_ptrs = out_ptr + pid_e * stride_oe + offs_n * stride_on
     if SPLIT_K == 1:
@@ -215,12 +264,25 @@ def int4_gemv_batched_f16_kernel(
 # --------------------------------------------------------------------------- #
 @triton.jit
 def int4_mfma_splitk_kernel(
-    x_ptr, b_ptr, scale_ptr, out_ptr,
-    K: tl.constexpr, N: tl.constexpr, gs: tl.constexpr, E_act: tl.constexpr,
-    stride_be, stride_bn, stride_bk,
-    stride_se, stride_sn, stride_sk,
-    stride_oe, stride_on,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    x_ptr,
+    b_ptr,
+    scale_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    N: tl.constexpr,
+    gs: tl.constexpr,
+    E_act: tl.constexpr,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_se,
+    stride_sn,
+    stride_sk,
+    stride_oe,
+    stride_on,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
     SPLIT_K: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -230,7 +292,7 @@ def int4_mfma_splitk_kernel(
     pid_n = pid2 % n_n_tiles
     pid_e = pid2 // n_n_tiles
 
-    offs_m = tl.arange(0, BLOCK_M)          # only row 0 is the real token
+    offs_m = tl.arange(0, BLOCK_M)  # only row 0 is the real token
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_k = tl.arange(0, BLOCK_K)
     m_mask = offs_m == 0
@@ -247,8 +309,9 @@ def int4_mfma_splitk_kernel(
         kk = k0 + offs_k
         k_mask = kk < k_end
         # A: [BLOCK_M, BLOCK_K], row 0 = x[kk], rest 0
-        a = tl.load(x_ptr + kk[None, :],
-                    mask=m_mask[:, None] & k_mask[None, :], other=0.0)  # fp16
+        a = tl.load(
+            x_ptr + kk[None, :], mask=m_mask[:, None] & k_mask[None, :], other=0.0
+        )  # fp16
         # B packed: byte index kk//2, nibble (kk%2)*4 ; layout [N, K/2]
         bk = kk // 2
         shift = (kk % 2) * 4
@@ -258,12 +321,12 @@ def int4_mfma_splitk_kernel(
         sk = kk // gs
         s_ptrs = scale_ptr + se + sk[:, None] * stride_sk + offs_n[None, :] * stride_sn
         sc = tl.load(s_ptrs, mask=k_mask[:, None] & n_mask[None, :], other=0.0)
-        b = (nib * sc).to(tl.float16)        # [BLOCK_K, BLOCK_N] dequant fp16
-        acc = tl.dot(a, b, acc=acc)          # MFMA
+        b = (nib * sc).to(tl.float16)  # [BLOCK_K, BLOCK_N] dequant fp16
+        acc = tl.dot(a, b, acc=acc)  # MFMA
 
     # write back row 0 only
     out_ptrs = out_ptr + pid_e * stride_oe + offs_n * stride_on
-    row0 = tl.sum(tl.where(m_mask[:, None], acc, 0.0), axis=0)   # [BLOCK_N]
+    row0 = tl.sum(tl.where(m_mask[:, None], acc, 0.0), axis=0)  # [BLOCK_N]
     if SPLIT_K == 1:
         tl.store(out_ptrs, row0, mask=n_mask)
     else:
@@ -276,36 +339,64 @@ def mfma_splitk(x, b_packed, scale, K, gs, BLOCK_N=64, BLOCK_K=64, SPLIT_K=1):
     n_n_tiles = triton.cdiv(N, BLOCK_N)
     grid = (E_act * n_n_tiles * SPLIT_K,)
     int4_mfma_splitk_kernel[grid](
-        x, b_packed, scale, out,
-        K, N, gs, E_act,
-        b_packed.stride(0), b_packed.stride(1), b_packed.stride(2),
-        scale.stride(0), scale.stride(1), scale.stride(2),
-        out.stride(0), out.stride(1),
-        BLOCK_M=16, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, SPLIT_K=SPLIT_K,
+        x,
+        b_packed,
+        scale,
+        out,
+        K,
+        N,
+        gs,
+        E_act,
+        b_packed.stride(0),
+        b_packed.stride(1),
+        b_packed.stride(2),
+        scale.stride(0),
+        scale.stride(1),
+        scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_M=16,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        SPLIT_K=SPLIT_K,
     )
     return out
 
 
-def gemv_hand_batched(x, b_packed, scale, K, gs, BLOCK_N=32, BLOCK_K=128,
-                      SPLIT_K=1, f16=False):
+def gemv_hand_batched(
+    x, b_packed, scale, K, gs, BLOCK_N=32, BLOCK_K=128, SPLIT_K=1, f16=False
+):
     E_act, N, _ = b_packed.shape
     out = torch.zeros((E_act, N), dtype=torch.float32, device=x.device)
     n_n_tiles = triton.cdiv(N, BLOCK_N)
     grid = (E_act * n_n_tiles * SPLIT_K,)
     kern = int4_gemv_batched_f16_kernel if f16 else int4_gemv_batched_kernel
     kern[grid](
-        x, b_packed, scale, out,
-        K, N, gs, E_act,
-        b_packed.stride(0), b_packed.stride(1), b_packed.stride(2),
-        scale.stride(0), scale.stride(1), scale.stride(2),
-        out.stride(0), out.stride(1),
-        BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, SPLIT_K=SPLIT_K,
+        x,
+        b_packed,
+        scale,
+        out,
+        K,
+        N,
+        gs,
+        E_act,
+        b_packed.stride(0),
+        b_packed.stride(1),
+        b_packed.stride(2),
+        scale.stride(0),
+        scale.stride(1),
+        scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        SPLIT_K=SPLIT_K,
     )
     return out
 
 
 def bytes_moved(N, K, gs):
-    # int4 weights (K/2 bytes/row * N) + fp16 scales (K/gs * 2 * N) + x (K*2) + out (N*4)
+    # int4 weights (K/2 bytes/row * N) + fp16 scales (K/gs * 2 * N) + x (K*2) + out (N*4)  # noqa: E501
     return N * (K // 2) + N * (K // gs) * 2 + K * 2 + N * 4
 
 
@@ -356,19 +447,24 @@ def correctness(gs):
         hb = gemv_hand_batched(x, b_packed[None], scale[None], K, gs, SPLIT_K=4)[0]
         relb = ((hb - ref).abs().max() / (ref.abs().max() + 1e-6)).item()
         # MFMA + split-K (v3)
-        hm = mfma_splitk(x, b_packed[None], scale[None], K, gs,
-                         BLOCK_N=64, BLOCK_K=64, SPLIT_K=4)[0]
+        hm = mfma_splitk(
+            x, b_packed[None], scale[None], K, gs, BLOCK_N=64, BLOCK_K=64, SPLIT_K=4
+        )[0]
         relm = ((hm - ref).abs().max() / (ref.abs().max() + 1e-6)).item()
         ok = max(rel1, relb, relm) < 1e-3
-        print(f"  {name:8s} N={N:5d} K={K:5d}: v1 {rel1:.2e}  "
-              f"v2(splitK=4) {relb:.2e}  v3-MFMA(splitK=4) {relm:.2e}  "
-              f"{'OK' if ok else 'FAIL'}")
+        print(
+            f"  {name:8s} N={N:5d} K={K:5d}: v1 {rel1:.2e}  "
+            f"v2(splitK=4) {relb:.2e}  v3-MFMA(splitK=4) {relm:.2e}  "
+            f"{'OK' if ok else 'FAIL'}"
+        )
 
 
 def sweep_batched(gs, E_act=10):
     """Batched E_act-expert GEMV: sweep BLOCK_N x SPLIT_K, report best vs roofline."""
-    print(f"\n=== batched {E_act}-expert GEMV (real M=1 MoE decode), sweep "
-          f"(CUDA-graph timed = true GPU us) ===")
+    print(
+        f"\n=== batched {E_act}-expert GEMV (real M=1 MoE decode), sweep "
+        f"(CUDA-graph timed = true GPU us) ==="
+    )
     results = []
     for name, N, K in [("gate_up", 256, 2048), ("down", 2048, 128)]:
         x = torch.randn(K, dtype=torch.float16)
@@ -385,9 +481,24 @@ def sweep_batched(gs, E_act=10):
                     if K // SPLIT_K < 32:
                         continue
                     try:
-                        fn = lambda: gemv_hand_batched(
-                            x, b, sc, K, gs, BLOCK_N=BLOCK_N,
-                            SPLIT_K=SPLIT_K, f16=f16)
+                        fn = (
+                            lambda x=x,
+                            b=b,
+                            sc=sc,
+                            K=K,
+                            BLOCK_N=BLOCK_N,
+                            SPLIT_K=SPLIT_K,
+                            f16=f16: gemv_hand_batched(  # noqa: E501
+                                x,
+                                b,
+                                sc,
+                                K,
+                                gs,
+                                BLOCK_N=BLOCK_N,
+                                SPLIT_K=SPLIT_K,
+                                f16=f16,
+                            )
+                        )
                         t = time_us_graph(fn)
                     except Exception:
                         continue
@@ -405,9 +516,24 @@ def sweep_batched(gs, E_act=10):
                     n_tiles = triton.cdiv(N, BLOCK_N)
                     progs = E_act * n_tiles * SPLIT_K
                     try:
-                        fn = lambda: mfma_splitk(
-                            x, b, sc, K, gs, BLOCK_N=BLOCK_N,
-                            BLOCK_K=BLOCK_K, SPLIT_K=SPLIT_K)
+                        fn = (
+                            lambda x=x,
+                            b=b,
+                            sc=sc,
+                            K=K,
+                            BLOCK_N=BLOCK_N,
+                            BLOCK_K=BLOCK_K,
+                            SPLIT_K=SPLIT_K: mfma_splitk(  # noqa: E501
+                                x,
+                                b,
+                                sc,
+                                K,
+                                gs,
+                                BLOCK_N=BLOCK_N,
+                                BLOCK_K=BLOCK_K,
+                                SPLIT_K=SPLIT_K,
+                            )
+                        )
                         t = time_us_graph(fn)
                     except Exception:
                         continue
@@ -418,10 +544,14 @@ def sweep_batched(gs, E_act=10):
         gbs2 = bm / (t2 / 1e6) / 1e9
         gbs3 = bm / (t3 / 1e6) / 1e9
         print(f"  {name:8s} N={N:5d} K={K:5d} roof {roof:.2f}us")
-        print(f"    v2 GEMV  : {t2:7.1f}us  BLOCK_N={c2[0]} SPLIT_K={c2[1]} "
-              f"{c2[2]} | {gbs2:7.1f} GB/s  {t2/roof:.0f}x")
-        print(f"    v3 MFMA+K: {t3:7.1f}us  BLOCK_N={c3[0]} BLOCK_K={c3[1]} "
-              f"SPLIT_K={c3[2]} progs={c3[3]} | {gbs3:7.1f} GB/s  {t3/roof:.0f}x")
+        print(
+            f"    v2 GEMV  : {t2:7.1f}us  BLOCK_N={c2[0]} SPLIT_K={c2[1]} "
+            f"{c2[2]} | {gbs2:7.1f} GB/s  {t2 / roof:.0f}x"
+        )
+        print(
+            f"    v3 MFMA+K: {t3:7.1f}us  BLOCK_N={c3[0]} BLOCK_K={c3[1]} "
+            f"SPLIT_K={c3[2]} progs={c3[3]} | {gbs3:7.1f} GB/s  {t3 / roof:.0f}x"
+        )
         results.append((name, min(t2, t3)))
     return results
 
@@ -433,9 +563,11 @@ def main():
     correctness(gs)
     res = sweep_batched(gs, E_act=10)
     tot = sum(t for _, t in res)
-    print(f"\n  hand GEMV total (gate_up+down) = {tot:.1f}us/layer  "
-          f"vs in-tree gptq_awq GEMM ~57us/layer (rocprof). "
-          f"{'WIN' if tot < 57 else 'LOSS'} ({57/tot:.2f}x)")
+    print(
+        f"\n  hand GEMV total (gate_up+down) = {tot:.1f}us/layer  "
+        f"vs in-tree gptq_awq GEMM ~57us/layer (rocprof). "
+        f"{'WIN' if tot < 57 else 'LOSS'} ({57 / tot:.2f}x)"
+    )
     os._exit(0)
 
 

--- a/bench_scripts/moe_int4_headtohead.py
+++ b/bench_scripts/moe_int4_headtohead.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Apples-to-apples: hand MFMA+split-K kernel vs the REAL in-tree
 fused_moe_kernel_gptq_awq, same shapes, same CUDA-graph harness.
 
@@ -10,15 +12,15 @@ M=1 decode (not just a single expert).
 Run:
   PYTHONPATH=. HIP_VISIBLE_DEVICES=2 python bench_scripts/moe_int4_headtohead.py
 """
+
 import os
 import sys
 import time
 
 import torch
-import triton
 
 sys.path.insert(0, os.path.dirname(__file__))
-from moe_int4_gemv_bench import mfma_splitk, dequant_ref  # noqa: E402
+from moe_int4_gemv_bench import mfma_splitk  # noqa: E402
 
 from vllm.model_executor.layers.fused_moe.fused_moe import (  # noqa: E402
     invoke_fused_moe_wna16_triton_kernel,
@@ -26,7 +28,7 @@ from vllm.model_executor.layers.fused_moe.fused_moe import (  # noqa: E402
 from vllm.model_executor.layers.fused_moe.moe_align_block_size import (  # noqa: E402
     moe_align_block_size,
 )
-import triton.language as tl  # noqa: E402
+from vllm.triton_utils import tl  # noqa: E402
 
 HBM_BW = 1.2e12
 
@@ -52,12 +54,31 @@ def time_us_graph(fn, inner=20, iters=50, warmup=5):
 
 def run_intree(A, B, C, Bs, sorted_ids, expert_ids, ntpp, top_k, N, K, gs, bn, bk):
     """Invoke the real in-tree gptq_awq triton kernel for one projection."""
-    config = {"BLOCK_SIZE_M": 16, "BLOCK_SIZE_N": bn, "BLOCK_SIZE_K": bk,
-              "GROUP_SIZE_M": 1, "SPLIT_K": 1, "num_warps": 4, "num_stages": 2}
+    config = {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": bn,
+        "BLOCK_SIZE_K": bk,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+    }
     invoke_fused_moe_wna16_triton_kernel(
-        A, B, C, Bs, None, None, sorted_ids, expert_ids, ntpp,
-        mul_routed_weight=False, top_k=top_k, config=config,
-        compute_type=tl.float16, use_int8_w8a16=False, use_int4_w4a16=True,
+        A,
+        B,
+        C,
+        Bs,
+        None,
+        None,
+        sorted_ids,
+        expert_ids,
+        ntpp,
+        mul_routed_weight=False,
+        top_k=top_k,
+        config=config,
+        compute_type=tl.float16,
+        use_int8_w8a16=False,
+        use_int4_w4a16=True,
         block_shape=[0, gs],
     )
     return C
@@ -67,7 +88,7 @@ def main():
     torch.set_default_device("cuda")
     torch.manual_seed(0)
     gs = 32
-    E = 512          # global experts
+    E = 512  # global experts
     top_k = 10
     M = 1
     # gate_up projection shape (per-shard TP=4): N=256, K=2048
@@ -78,25 +99,37 @@ def main():
 
         # routing: 1 token -> top_k distinct experts
         topk_ids = torch.randperm(E)[:top_k].to(torch.int32).view(1, top_k)
-        bn, bk = 32, 64    # in-tree bs=1 default
+        bn, bk = 32, 64  # in-tree bs=1 default
         sorted_ids, expert_ids, ntpp = moe_align_block_size(topk_ids, 16, E)
         C = torch.zeros(M, top_k, N, dtype=torch.float16)
 
         # ---- in-tree kernel ----
         run_intree(A, B, C, Bs, sorted_ids, expert_ids, ntpp, top_k, N, K, gs, bn, bk)
         intree_out = C.clone()  # [1, top_k, N]
-        t_in = time_us_graph(lambda: run_intree(
-            A, B, C, Bs, sorted_ids, expert_ids, ntpp, top_k, N, K, gs, bn, bk))
+        t_in = time_us_graph(
+            lambda A=A,
+            B=B,
+            C=C,
+            Bs=Bs,
+            sorted_ids=sorted_ids,
+            expert_ids=expert_ids,
+            ntpp=ntpp,
+            N=N,
+            K=K,
+            bn=bn,
+            bk=bk: run_intree(  # noqa: E501
+                A, B, C, Bs, sorted_ids, expert_ids, ntpp, top_k, N, K, gs, bn, bk
+            )
+        )
 
         # ---- hand v3 on the same top_k active experts ----
-        act = topk_ids.view(-1).long()      # [top_k] global expert ids
-        b_act = B[act].contiguous()          # [top_k, N, K//2]
-        s_act = Bs[act].contiguous()         # [top_k, N, K//gs]
-        x = A[0].contiguous()                # [K]
+        act = topk_ids.view(-1).long()  # [top_k] global expert ids
+        b_act = B[act].contiguous()  # [top_k, N, K//2]
+        s_act = Bs[act].contiguous()  # [top_k, N, K//gs]
+        x = A[0].contiguous()  # [K]
 
         # correctness: hand vs in-tree, per active expert
         best = (1e9, None)
-        relmax = 0.0
         for BLOCK_N in (32, 64, 128):
             if BLOCK_N > N:
                 continue
@@ -105,32 +138,56 @@ def main():
                     if K // SPLIT_K < BLOCK_K:
                         continue
                     try:
-                        out = mfma_splitk(x, b_act, s_act, K, gs,
-                                          BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
-                                          SPLIT_K=SPLIT_K)
-                        t = time_us_graph(lambda: mfma_splitk(
-                            x, b_act, s_act, K, gs, BLOCK_N=BLOCK_N,
-                            BLOCK_K=BLOCK_K, SPLIT_K=SPLIT_K))
+                        mfma_splitk(
+                            x,
+                            b_act,
+                            s_act,
+                            K,
+                            gs,
+                            BLOCK_N=BLOCK_N,
+                            BLOCK_K=BLOCK_K,
+                            SPLIT_K=SPLIT_K,
+                        )
+                        t = time_us_graph(
+                            lambda x=x,
+                            b_act=b_act,
+                            s_act=s_act,
+                            K=K,
+                            BLOCK_N=BLOCK_N,
+                            BLOCK_K=BLOCK_K,
+                            SPLIT_K=SPLIT_K: mfma_splitk(  # noqa: E501
+                                x,
+                                b_act,
+                                s_act,
+                                K,
+                                gs,
+                                BLOCK_N=BLOCK_N,
+                                BLOCK_K=BLOCK_K,
+                                SPLIT_K=SPLIT_K,
+                            )
+                        )
                     except Exception:
                         continue
                     if t < best[0]:
                         best = (t, (BLOCK_N, BLOCK_K, SPLIT_K))
         # verify correctness at best config vs in-tree per-expert
         bn3, bk3, sk3 = best[1]
-        hand = mfma_splitk(x, b_act, s_act, K, gs, BLOCK_N=bn3,
-                           BLOCK_K=bk3, SPLIT_K=sk3)  # [top_k, N] fp32
-        intree_pe = intree_out[0].to(torch.float32)   # [top_k, N], order = topk
-        rel = ((hand - intree_pe).abs().max()
-               / (intree_pe.abs().max() + 1e-6)).item()
+        hand = mfma_splitk(
+            x, b_act, s_act, K, gs, BLOCK_N=bn3, BLOCK_K=bk3, SPLIT_K=sk3
+        )  # [top_k, N] fp32
+        intree_pe = intree_out[0].to(torch.float32)  # [top_k, N], order = topk
+        rel = ((hand - intree_pe).abs().max() / (intree_pe.abs().max() + 1e-6)).item()
 
         bm = top_k * (N * (K // 2) + N * (K // gs) * 2) + K * 2 + top_k * N * 4
         roof = bm / HBM_BW * 1e6
         print(f"{name:8s} N={N:5d} K={K:5d} roof {roof:.2f}us")
         print(f"  in-tree gptq_awq : {t_in:7.1f}us")
-        print(f"  hand MFMA+splitK : {best[0]:7.1f}us  "
-              f"BLOCK_N={bn3} BLOCK_K={bk3} SPLIT_K={sk3}  "
-              f"rel-err {rel:.2e}  {'OK' if rel < 1e-3 else 'FAIL'}")
-        print(f"  --> {t_in/best[0]:.2f}x {'WIN' if best[0] < t_in else 'LOSS'}")
+        print(
+            f"  hand MFMA+splitK : {best[0]:7.1f}us  "
+            f"BLOCK_N={bn3} BLOCK_K={bk3} SPLIT_K={sk3}  "
+            f"rel-err {rel:.2e}  {'OK' if rel < 1e-3 else 'FAIL'}"
+        )
+        print(f"  --> {t_in / best[0]:.2f}x {'WIN' if best[0] < t_in else 'LOSS'}")
     os._exit(0)
 
 

--- a/bench_scripts/moe_splitk_integration_test.py
+++ b/bench_scripts/moe_splitk_integration_test.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Integration correctness + timing for the gfx908 split-K wna16 MoE path.
 
 Compares fused_experts output with SPLIT_K forced to 1 (baseline) vs the
@@ -6,15 +8,16 @@ gfx908 gate (SPLIT_K=8) at the real Qwen3-Coder-Next decode shape, and times
 both. Run:
   PYTHONPATH=. HIP_VISIBLE_DEVICES=2 python bench_scripts/moe_splitk_integration_test.py
 """
+
 import os
 import time
 
 import torch
 
-from vllm.model_executor.layers.fused_moe import fused_topk
-from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
-from vllm.model_executor.layers.fused_moe.config import int4_w4a16_moe_quant_config
 import vllm.model_executor.layers.fused_moe.fused_moe as fm
+from vllm.model_executor.layers.fused_moe import fused_topk
+from vllm.model_executor.layers.fused_moe.config import int4_w4a16_moe_quant_config
+from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 
 
 def build(E, H, N, GS):
@@ -56,7 +59,8 @@ def main():
     E, H, TK, GS, N = 512, 2048, 10, 32, 128
     x, w1, w2, w1s, w2s, gate = build(E, H, N, GS)
     qc = int4_w4a16_moe_quant_config(
-        w1_scale=w1s, w2_scale=w2s, w1_zp=None, w2_zp=None, block_shape=[0, GS])
+        w1_scale=w1s, w2_scale=w2s, w1_zp=None, w2_zp=None, block_shape=[0, GS]
+    )
     tw, ti, _ = fused_topk(x, gate, TK, renormalize=True)
 
     orig = fm.get_default_config
@@ -67,6 +71,7 @@ def main():
 
     # baseline: monkeypatch the gate off (force SPLIT_K=1)
     import vllm.model_executor.layers.fused_moe.fused_moe as fmod
+
     real_on = fmod._on_mi100
 
     fmod._on_mi100 = lambda: False
@@ -79,8 +84,7 @@ def main():
 
     fmod._on_mi100 = real_on
 
-    rel = ((out_sk - out_base).abs().max()
-           / (out_base.abs().max() + 1e-6)).item()
+    rel = ((out_sk - out_base).abs().max() / (out_base.abs().max() + 1e-6)).item()
     print(f"SPLIT_K=1 baseline : {t_base:7.1f} us")
     print(f"SPLIT_K=8 (gfx908) : {t_sk:7.1f} us")
     print(f"speedup            : {t_base / t_sk:.2f}x")

--- a/benchmarks/kernels/benchmark_flash_decoding.py
+++ b/benchmarks/kernels/benchmark_flash_decoding.py
@@ -51,8 +51,12 @@ def benchmark_decode_attention(
         num_seqs, num_query_heads, head_size, dtype=dtype, device="cuda"
     )
     key_cache = torch.randn(
-        num_blocks, block_size, num_kv_heads, head_size,
-        dtype=dtype, device="cuda",
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        head_size,
+        dtype=dtype,
+        device="cuda",
     )
     value_cache = torch.randn_like(key_cache)
 
@@ -65,8 +69,11 @@ def benchmark_decode_attention(
 
     max_num_blocks_per_seq = (kv_len + block_size - 1) // block_size
     block_tables = torch.randint(
-        0, num_blocks, (num_seqs, max_num_blocks_per_seq),
-        dtype=torch.int32, device="cuda",
+        0,
+        num_blocks,
+        (num_seqs, max_num_blocks_per_seq),
+        dtype=torch.int32,
+        device="cuda",
     )
 
     output = torch.empty_like(query)
@@ -84,15 +91,18 @@ def benchmark_decode_attention(
         seq_threshold_3D = num_seqs
         segm_output = torch.empty(
             (num_seqs, num_query_heads, actual_splits, head_size_padded),
-            dtype=torch.float32, device="cuda",
+            dtype=torch.float32,
+            device="cuda",
         )
         segm_max = torch.empty(
             (num_seqs, num_query_heads, actual_splits),
-            dtype=torch.float32, device="cuda",
+            dtype=torch.float32,
+            device="cuda",
         )
         segm_expsum = torch.empty(
             (num_seqs, num_query_heads, actual_splits),
-            dtype=torch.float32, device="cuda",
+            dtype=torch.float32,
+            device="cuda",
         )
 
     def run_once():
@@ -124,15 +134,15 @@ def benchmark_decode_attention(
     # Warmup
     for _ in range(num_warmup):
         run_once()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     # Benchmark
     latencies = []
     for _ in range(num_iters):
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         start = time.perf_counter()
         run_once()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         end = time.perf_counter()
         latencies.append((end - start) * 1e6)  # us
 
@@ -141,9 +151,7 @@ def benchmark_decode_attention(
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Benchmark Flash-Decoding Split-K"
-    )
+    parser = argparse.ArgumentParser(description="Benchmark Flash-Decoding Split-K")
     parser.add_argument(
         "--seq-lens",
         type=int,
@@ -159,23 +167,33 @@ def main():
         help="Batch sizes to benchmark",
     )
     parser.add_argument(
-        "--num-query-heads", type=int, default=8,
+        "--num-query-heads",
+        type=int,
+        default=8,
         help="Number of query heads",
     )
     parser.add_argument(
-        "--num-kv-heads", type=int, default=2,
+        "--num-kv-heads",
+        type=int,
+        default=2,
         help="Number of KV heads",
     )
     parser.add_argument(
-        "--head-size", type=int, default=128,
+        "--head-size",
+        type=int,
+        default=128,
         help="Head dimension",
     )
     parser.add_argument(
-        "--block-size", type=int, default=16,
+        "--block-size",
+        type=int,
+        default=16,
         help="KV cache block size",
     )
     parser.add_argument(
-        "--num-iters", type=int, default=100,
+        "--num-iters",
+        type=int,
+        default=100,
         help="Number of benchmark iterations",
     )
     args = parser.parse_args()
@@ -183,8 +201,10 @@ def main():
     print("=" * 90)
     print("Flash-Decoding Split-K Benchmark")
     print("=" * 90)
-    print(f"Config: {args.num_query_heads} Q heads, {args.num_kv_heads} KV "
-          f"heads, head_size={args.head_size}, block_size={args.block_size}")
+    print(
+        f"Config: {args.num_query_heads} Q heads, {args.num_kv_heads} KV "
+        f"heads, head_size={args.head_size}, block_size={args.block_size}"
+    )
     print(f"Iterations: {args.num_iters}")
     print()
 
@@ -198,8 +218,10 @@ def main():
             f"{'Splits':>6} │ {'Speedup vs 2D':>14} │ "
             f"{'Speedup vs F8':>14}"
         )
-        print(f"{'─' * 10}─┼─{'─' * 10}─┼─{'─' * 12}─┼─{'─' * 14}─┼─"
-              f"{'─' * 6}─┼─{'─' * 14}─┼─{'─' * 14}")
+        print(
+            f"{'─' * 10}─┼─{'─' * 10}─┼─{'─' * 12}─┼─{'─' * 14}─┼─"
+            f"{'─' * 6}─┼─{'─' * 14}─┼─{'─' * 14}"
+        )
 
         for seq_len in args.seq_lens:
             # Compute adaptive split count
@@ -265,8 +287,10 @@ def main():
     print(f"\n{'=' * 90}")
     print("Flash-Decoding Split Schedule (batch=1)")
     print(f"{'=' * 90}")
-    print(f"{'Seq Len':>10} │ {'KV Heads=2':>12} │ {'KV Heads=4':>12} │ "
-          f"{'KV Heads=8':>12}")
+    print(
+        f"{'Seq Len':>10} │ {'KV Heads=2':>12} │ {'KV Heads=4':>12} │ "
+        f"{'KV Heads=8':>12}"
+    )
     print(f"{'─' * 10}─┼─{'─' * 12}─┼─{'─' * 12}─┼─{'─' * 12}")
     for seq_len in [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]:
         splits = []
@@ -278,10 +302,7 @@ def main():
                 tile_size=32,
             )
             splits.append(s)
-        print(
-            f"{seq_len:>10} │ {splits[0]:>12} │ {splits[1]:>12} │ "
-            f"{splits[2]:>12}"
-        )
+        print(f"{seq_len:>10} │ {splits[0]:>12} │ {splits[1]:>12} │ {splits[2]:>12}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_mi100_int8_gemm.py
+++ b/benchmarks/kernels/benchmark_mi100_int8_gemm.py
@@ -47,7 +47,7 @@ def benchmark_kernel(fn, warmup=10, iters=100):
     """Benchmark a kernel function using CUDA events."""
     for _ in range(warmup):
         fn()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     start_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
     end_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
@@ -57,7 +57,7 @@ def benchmark_kernel(fn, warmup=10, iters=100):
         fn()
         end_events[i].record()
 
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
     times.sort()
     # Use median

--- a/benchmarks/kernels/eval_perplexity_mi100.py
+++ b/benchmarks/kernels/eval_perplexity_mi100.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Evaluate perplexity of Qwen3.5-9B variants on wikitext-2.
 
 Computes per-token cross-entropy loss (perplexity = exp(loss))
@@ -132,7 +134,7 @@ def compute_perplexity_vllm(
 
     # Cleanup
     del llm
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()
     import gc
 
     gc.collect()

--- a/benchmarks/kernels/profile_gemm_kernels.py
+++ b/benchmarks/kernels/profile_gemm_kernels.py
@@ -1,4 +1,6 @@
 #!/opt/vllm-env/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 GEMM Kernel Profiling for MI100 (gfx908) using rocprofv3
 
@@ -31,11 +33,12 @@ import argparse
 import csv
 import json
 import os
-import re
 import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+
+import regex as re
 
 VLLM_PYTHON = "/opt/vllm-env/bin/python3"
 ROCPROFV3 = "/opt/rocm/bin/rocprofv3"
@@ -44,13 +47,14 @@ SERVER_URL = "http://localhost:8000"
 DEFAULT_MODEL = "/models/Qwen3.5-9B"
 
 MI100_PEAK_BW_BYTES_PER_SEC = 1.23e12  # 1.23 TB/s HBM2
-MI100_PEAK_FLOPS_FP16 = 184.6e12      # 184.6 TFLOPS FP16 (with MFMA)
+MI100_PEAK_FLOPS_FP16 = 184.6e12  # 184.6 TFLOPS FP16 (with MFMA)
 MI100_NUM_CUS = 120
 
 
 def check_server_health():
     try:
         import urllib.request
+
         with urllib.request.urlopen(f"{SERVER_URL}/health", timeout=5) as r:
             return r.status == 200
     except Exception:
@@ -61,12 +65,15 @@ def send_inference_request(
     prompt="Write a Python function to sort a list.", max_tokens=128
 ):
     import urllib.request
-    payload = json.dumps({
-        "model": os.path.basename(DEFAULT_MODEL),
-        "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": max_tokens,
-        "temperature": 0.7,
-    }).encode()
+
+    payload = json.dumps(
+        {
+            "model": os.path.basename(DEFAULT_MODEL),
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.7,
+        }
+    ).encode()
     req = urllib.request.Request(
         f"{SERVER_URL}/v1/chat/completions",
         data=payload,
@@ -146,9 +153,13 @@ def run_kernel_trace_triage(output_dir):
     cmd = [
         ROCPROFV3,
         "--kernel-trace",
-        "--output-format", "csv",
-        "--output-directory", trace_dir,
-        "--", VLLM_PYTHON, workload_script,
+        "--output-format",
+        "csv",
+        "--output-directory",
+        trace_dir,
+        "--",
+        VLLM_PYTHON,
+        workload_script,
     ]
 
     print(f"Running: {' '.join(cmd)}")
@@ -182,14 +193,18 @@ def parse_kernel_trace(trace_dir):
                 name = row.get(
                     "Kernel_Name", row.get("kernel_name", row.get("Name", ""))
                 )
-                duration_ns = int(row.get(
-                    "Duration_ns", row.get("duration", row.get("DurationNs", 0))
-                ))
+                duration_ns = int(
+                    row.get(
+                        "Duration_ns", row.get("duration", row.get("DurationNs", 0))
+                    )
+                )
                 if name:
                     if name not in kernels:
                         kernels[name] = {
-                            "name": name, "count": 0,
-                            "total_ns": 0, "durations": [],
+                            "name": name,
+                            "count": 0,
+                            "total_ns": 0,
+                            "durations": [],
                         }
                     kernels[name]["count"] += 1
                     kernels[name]["total_ns"] += duration_ns
@@ -200,7 +215,7 @@ def parse_kernel_trace(trace_dir):
 
     # Compute stats
     total_time = sum(k["total_ns"] for k in ranked)
-    print(f"\nTotal kernel time: {total_time/1e6:.1f} ms")
+    print(f"\nTotal kernel time: {total_time / 1e6:.1f} ms")
     print(f"Total unique kernels: {len(ranked)}")
     print()
 
@@ -216,13 +231,25 @@ def parse_kernel_trace(trace_dir):
         avg_us = (k["total_ns"] / k["count"]) / 1000.0
         total_ms = k["total_ns"] / 1e6
         short_name = k["name"][:60]
-        is_gemm = any(g in k["name"].lower() for g in
-                      ["gemm", "gemv", "rocblas", "hipblas", "mfma", "matmul",
-                       "linear", "sgemm", "hgemm", "batched"])
+        is_gemm = any(
+            g in k["name"].lower()
+            for g in [
+                "gemm",
+                "gemv",
+                "rocblas",
+                "hipblas",
+                "mfma",
+                "matmul",
+                "linear",
+                "sgemm",
+                "hgemm",
+                "batched",
+            ]
+        )
 
         marker = " [GEMM]" if is_gemm else ""
         print(
-            f"{i+1:<5} {pct:>5.1f}% {k['count']:>7}"
+            f"{i + 1:<5} {pct:>5.1f}% {k['count']:>7}"
             f" {avg_us:>10.1f} {total_ms:>10.2f} {short_name}{marker}"
         )
 
@@ -270,8 +297,10 @@ def run_deep_profile(output_dir, kernel_regex=None, top_n=3, ranked_kernels=None
         regex = "|".join(re.escape(n) for n in names)
         kernel_filter = ["--kernel-include-regex", regex]
     else:
-        kernel_filter = ["--kernel-include-regex",
-                         ".*gemm.*|.*Gemm.*|.*GEMM.*|.*rocblas.*|.*hipblas.*|.*matmul.*"]
+        kernel_filter = [
+            "--kernel-include-regex",
+            ".*gemm.*|.*Gemm.*|.*GEMM.*|.*rocblas.*|.*hipblas.*|.*matmul.*",
+        ]
 
     # Memory counters pass
     print("Pass 1: Memory counters (FETCH_SIZE, WRITE_SIZE, TCC_HIT, TCC_MISS)...")
@@ -280,11 +309,16 @@ def run_deep_profile(output_dir, kernel_regex=None, top_n=3, ranked_kernels=None
 
     cmd_mem = [
         ROCPROFV3,
-        "--pmc", "FETCH_SIZE,WRITE_SIZE,TCC_HIT_sum,TCC_MISS_sum",
+        "--pmc",
+        "FETCH_SIZE,WRITE_SIZE,TCC_HIT_sum,TCC_MISS_sum",
         *kernel_filter,
-        "--output-format", "csv",
-        "--output-directory", mem_dir,
-        "--", VLLM_PYTHON, workload_script,
+        "--output-format",
+        "csv",
+        "--output-directory",
+        mem_dir,
+        "--",
+        VLLM_PYTHON,
+        workload_script,
     ]
 
     result = subprocess.run(
@@ -296,11 +330,16 @@ def run_deep_profile(output_dir, kernel_regex=None, top_n=3, ranked_kernels=None
         print("  Retrying with FETCH_SIZE,WRITE_SIZE only...")
         cmd_mem_fallback = [
             ROCPROFV3,
-            "--pmc", "FETCH_SIZE,WRITE_SIZE",
+            "--pmc",
+            "FETCH_SIZE,WRITE_SIZE",
             *kernel_filter,
-            "--output-format", "csv",
-            "--output-directory", mem_dir,
-            "--", VLLM_PYTHON, workload_script,
+            "--output-format",
+            "csv",
+            "--output-directory",
+            mem_dir,
+            "--",
+            VLLM_PYTHON,
+            workload_script,
         ]
         result = subprocess.run(
             cmd_mem_fallback, env=env, capture_output=True, text=True, timeout=600
@@ -314,11 +353,16 @@ def run_deep_profile(output_dir, kernel_regex=None, top_n=3, ranked_kernels=None
 
     cmd_compute = [
         ROCPROFV3,
-        "--pmc", "SQ_WAVES,SQ_INSTS_VALU,SQ_INSTS_MFMA",
+        "--pmc",
+        "SQ_WAVES,SQ_INSTS_VALU,SQ_INSTS_MFMA",
         *kernel_filter,
-        "--output-format", "csv",
-        "--output-directory", compute_dir,
-        "--", VLLM_PYTHON, workload_script,
+        "--output-format",
+        "csv",
+        "--output-directory",
+        compute_dir,
+        "--",
+        VLLM_PYTHON,
+        workload_script,
     ]
 
     result = subprocess.run(
@@ -330,11 +374,16 @@ def run_deep_profile(output_dir, kernel_regex=None, top_n=3, ranked_kernels=None
         print("  Retrying with SQ_WAVES only...")
         cmd_waves = [
             ROCPROFV3,
-            "--pmc", "SQ_WAVES",
+            "--pmc",
+            "SQ_WAVES",
             *kernel_filter,
-            "--output-format", "csv",
-            "--output-directory", compute_dir,
-            "--", VLLM_PYTHON, workload_script,
+            "--output-format",
+            "csv",
+            "--output-directory",
+            compute_dir,
+            "--",
+            VLLM_PYTHON,
+            workload_script,
         ]
         result = subprocess.run(
             cmd_waves, env=env, capture_output=True, text=True, timeout=600
@@ -361,10 +410,13 @@ def parse_deep_profile(deep_dir):
                             continue
                         if name not in results:
                             results[name] = {"name": name}
-                        results[name].update({
-                            k: v for k, v in row.items()
-                            if k not in ("Kernel_Name", "kernel_name")
-                        })
+                        results[name].update(
+                            {
+                                k: v
+                                for k, v in row.items()
+                                if k not in ("Kernel_Name", "kernel_name")
+                            }
+                        )
             except Exception as e:
                 print(f"  Warning: Could not parse {csv_file}: {e}")
 
@@ -390,7 +442,7 @@ def parse_deep_profile(deep_dir):
             bw_bytes_per_sec = (fetch + write) * 32 / duration_s
             bw_util = bw_bytes_per_sec / MI100_PEAK_BW_BYTES_PER_SEC * 100
             print(
-                f"  Memory BW: {bw_bytes_per_sec/1e9:.1f} GB/s"
+                f"  Memory BW: {bw_bytes_per_sec / 1e9:.1f} GB/s"
                 f" ({bw_util:.1f}% of peak)"
             )
 
@@ -410,8 +462,7 @@ def parse_deep_profile(deep_dir):
             total_insts = mfma_insts + valu_insts
             mfma_pct = mfma_insts / total_insts * 100 if total_insts > 0 else 0
             print(
-                f"  MFMA Instructions: {mfma_insts:.0f}"
-                f" ({mfma_pct:.1f}% of VALU+MFMA)"
+                f"  MFMA Instructions: {mfma_insts:.0f} ({mfma_pct:.1f}% of VALU+MFMA)"
             )
             print(f"  VALU Instructions: {valu_insts:.0f}")
             print(f"  Wavefronts: {sq_waves:.0f}")
@@ -435,7 +486,8 @@ def classify_bottleneck(data):
     bw_bytes_per_sec = (fetch + write) * 32 / duration_s if duration_s > 0 else 0
     bw_util = (
         bw_bytes_per_sec / MI100_PEAK_BW_BYTES_PER_SEC
-        if MI100_PEAK_BW_BYTES_PER_SEC > 0 else 0
+        if MI100_PEAK_BW_BYTES_PER_SEC > 0
+        else 0
     )
 
     total_insts = mfma_insts + valu_insts
@@ -444,7 +496,7 @@ def classify_bottleneck(data):
     if bw_util > 0.6 and mfma_pct < 0.3:
         print(
             f"  Bottleneck: MEMORY-BOUND"
-            f" (BW {bw_util*100:.0f}%, MFMA {mfma_pct*100:.0f}%)"
+            f" (BW {bw_util * 100:.0f}%, MFMA {mfma_pct * 100:.0f}%)"
         )
         print(
             "  Recommendation: Already memory-bound."
@@ -453,13 +505,13 @@ def classify_bottleneck(data):
     elif mfma_pct > 0.5 and bw_util < 0.3:
         print(
             f"  Bottleneck: COMPUTE-BOUND"
-            f" (BW {bw_util*100:.0f}%, MFMA {mfma_pct*100:.0f}%)"
+            f" (BW {bw_util * 100:.0f}%, MFMA {mfma_pct * 100:.0f}%)"
         )
         print("  Recommendation: Adjust tile sizes or use larger MFMA variants.")
     elif mfma_pct < 0.3 and bw_util < 0.3:
         print(
             f"  Bottleneck: LATENCY-BOUND"
-            f" (BW {bw_util*100:.0f}%, MFMA {mfma_pct*100:.0f}%)"
+            f" (BW {bw_util * 100:.0f}%, MFMA {mfma_pct * 100:.0f}%)"
         )
         print(
             "  Recommendation: Low utilization."
@@ -468,7 +520,7 @@ def classify_bottleneck(data):
     else:
         print(
             f"  Bottleneck: BALANCED"
-            f" (BW {bw_util*100:.0f}%, MFMA {mfma_pct*100:.0f}%)"
+            f" (BW {bw_util * 100:.0f}%, MFMA {mfma_pct * 100:.0f}%)"
         )
 
 
@@ -573,7 +625,7 @@ def main():
             deep = run_deep_profile(
                 args.output_dir,
                 top_n=args.top_n,
-                ranked_kernels=gemm_kernels if gemm_kernels else ranked[:args.top_n],
+                ranked_kernels=gemm_kernels if gemm_kernels else ranked[: args.top_n],
             )
             generate_report(args.output_dir, triage_results=triage, deep_results=deep)
         else:

--- a/benchmarks/kernels/tunableop_gemm_tuning.py
+++ b/benchmarks/kernels/tunableop_gemm_tuning.py
@@ -1,4 +1,6 @@
 #!/opt/vllm-env/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 TunableOp GEMM Autotuning for MI100 (gfx908)
 
@@ -66,6 +68,7 @@ def check_server_health():
     """Check if vLLM server is running and healthy."""
     try:
         import urllib.request
+
         req = urllib.request.Request(f"{SERVER_URL}/health")
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status == 200
@@ -76,15 +79,18 @@ def check_server_health():
 def send_warmup_request(prompt, max_tokens=256):
     """Send a single request to the vLLM server to exercise GEMM kernels."""
     import urllib.request
-    payload = json.dumps({
-        "model": os.path.basename(DEFAULT_MODEL),
-        "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt},
-        ],
-        "max_tokens": max_tokens,
-        "temperature": 0.7,
-    }).encode("utf-8")
+
+    payload = json.dumps(
+        {
+            "model": os.path.basename(DEFAULT_MODEL),
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": 0.7,
+        }
+    ).encode("utf-8")
 
     req = urllib.request.Request(
         f"{SERVER_URL}/v1/chat/completions",
@@ -113,7 +119,7 @@ def record_gemm_shapes(output_dir):
 
     results = []
     for i, prompt in enumerate(WARMUP_PROMPTS):
-        print(f"  [{i+1}/{len(WARMUP_PROMPTS)}] Sending: {prompt[:60]}...")
+        print(f"  [{i + 1}/{len(WARMUP_PROMPTS)}] Sending: {prompt[:60]}...")
         try:
             resp = send_warmup_request(prompt)
             tokens = resp.get("usage", {}).get("completion_tokens", 0)
@@ -127,6 +133,7 @@ def record_gemm_shapes(output_dir):
     print()
     print("  Sending batch of 4 concurrent requests for batched GEMM shapes...")
     import concurrent.futures
+
     batch_prompts = WARMUP_PROMPTS[:4]
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = [executor.submit(send_warmup_request, p) for p in batch_prompts]
@@ -185,7 +192,7 @@ print(f"Reading untuned GEMMs from: {{input_file}}")
 print(f"Output will be saved to: {{output_file}}")
 
 # For multi-GPU tuning
-num_gpus = torch.cuda.device_count()
+num_gpus = torch.accelerator.device_count()
 print(f"Number of GPUs: {{num_gpus}}")
 
 start = time.time()
@@ -220,10 +227,12 @@ for op, entries in results.items():
         f.write(tune_script)
 
     env = os.environ.copy()
-    env.update({
-        "PYTORCH_TUNABLEOP_ENABLED": "1",
-        "PYTORCH_TUNABLEOP_TUNING": "1",
-    })
+    env.update(
+        {
+            "PYTORCH_TUNABLEOP_ENABLED": "1",
+            "PYTORCH_TUNABLEOP_TUNING": "1",
+        }
+    )
 
     result = subprocess.run(
         [VLLM_PYTHON, script_file],
@@ -243,7 +252,7 @@ def generate_launch_script(output_dir, tunableop_results_file=None):
     if tunableop_results_file is None:
         tunableop_results_file = os.path.join(output_dir, "tunableop_results.csv")
 
-    ts = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     script = f"""#!/bin/bash
 # launch-vllm-tunableop.sh - vLLM with TunableOp-tuned GEMM kernels for MI100
 #
@@ -420,7 +429,8 @@ def run_full_pipeline(output_dir, skip_server_restart=False):
         subprocess.run(
             "lsof -ti :8000 | xargs kill -9 2>/dev/null; sleep 3; "
             "pkill -9 -f 'VLLM::' 2>/dev/null; sleep 2",
-            shell=True, capture_output=True,
+            shell=True,
+            capture_output=True,
         )
         print("  Done.")
         print()
@@ -443,7 +453,7 @@ def run_full_pipeline(output_dir, skip_server_restart=False):
         print("  Waiting for server health (up to 180s for tuning mode)...")
         for i in range(90):
             if check_server_health():
-                print(f"  Server healthy after {(i+1)*2}s")
+                print(f"  Server healthy after {(i + 1) * 2}s")
                 break
             time.sleep(2)
         else:
@@ -481,7 +491,8 @@ def run_full_pipeline(output_dir, skip_server_restart=False):
             server_proc.kill()
         subprocess.run(
             "pkill -9 -f 'VLLM::' 2>/dev/null; sleep 3",
-            shell=True, capture_output=True,
+            shell=True,
+            capture_output=True,
         )
         print("  Done.")
         print()
@@ -520,7 +531,7 @@ def run_full_pipeline(output_dir, skip_server_restart=False):
         print("  Waiting for server health...")
         for i in range(60):
             if check_server_health():
-                print(f"  Server healthy after {(i+1)*2}s")
+                print(f"  Server healthy after {(i + 1) * 2}s")
                 break
             time.sleep(2)
         else:

--- a/csrc/quantization/gptq/ck/ck_w4a16_gemm.h
+++ b/csrc/quantization/gptq/ck/ck_w4a16_gemm.h
@@ -37,10 +37,10 @@ namespace vllm::ck_w4a16 {
 torch::Tensor ck_w4a16_gemm(const torch::Tensor& a_fp16,
                             const torch::Tensor& b_packed_int4,
                             const torch::Tensor& scales,
-                            const torch::Tensor& zeros,
-                            int64_t group_size, int64_t tp_rank);
+                            const torch::Tensor& zeros, int64_t group_size,
+                            int64_t tp_rank);
 
-bool ck_w4a16_gemm_supports(int64_t M, int64_t N, int64_t K,
-                            int64_t group_size, int64_t tp_rank);
+bool ck_w4a16_gemm_supports(int64_t M, int64_t N, int64_t K, int64_t group_size,
+                            int64_t tp_rank);
 
 }  // namespace vllm::ck_w4a16

--- a/csrc/quantization/gptq/ck/instances/instance_n10240_k4096_g128.cu
+++ b/csrc/quantization/gptq/ck/instances/instance_n10240_k4096_g128.cu
@@ -4,4 +4,3 @@
 
 #include "../ck_w4a16_gemm.h"
 // Placeholder TU — see ../ck_w4a16_gemm.h.
-

--- a/csrc/quantization/gptq/ck/instances/instance_n24576_k4096_g128.cu
+++ b/csrc/quantization/gptq/ck/instances/instance_n24576_k4096_g128.cu
@@ -13,4 +13,3 @@
 // instantiation. Kept as a separate TU to preserve the per-shape file
 // layout demanded by the M4 spec, so a future worker dropping in a CK
 // W4A16 device template only needs to edit one file per shape.
-

--- a/csrc/quantization/gptq/ck/instances/instance_n4096_k12288_g128.cu
+++ b/csrc/quantization/gptq/ck/instances/instance_n4096_k12288_g128.cu
@@ -4,4 +4,3 @@
 
 #include "../ck_w4a16_gemm.h"
 // Placeholder TU — see ../ck_w4a16_gemm.h.
-

--- a/csrc/quantization/gptq/ck/instances/instance_n4096_k4096_g128.cu
+++ b/csrc/quantization/gptq/ck/instances/instance_n4096_k4096_g128.cu
@@ -4,4 +4,3 @@
 
 #include "../ck_w4a16_gemm.h"
 // Placeholder TU — see ../ck_w4a16_gemm.h.
-

--- a/csrc/quantization/w8a8/int8/ck/ck_int8_gemm_dispatch.cu
+++ b/csrc/quantization/w8a8/int8/ck/ck_int8_gemm_dispatch.cu
@@ -82,18 +82,17 @@ void apply_scales(at::Tensor& acc_int32, const at::Tensor& scale_a,
                        : nullptr;
   hipLaunchKernelGGL(apply_scales_kernel, dim3(blocks), dim3(threads), 0,
                      at::cuda::getCurrentCUDAStream(),
-                     acc_int32.data_ptr<int32_t>(),
-                     scale_a.data_ptr<float>(), scale_b.data_ptr<float>(),
-                     bias_ptr, reinterpret_cast<__half*>(out_fp16.data_ptr()),
-                     M, N);
+                     acc_int32.data_ptr<int32_t>(), scale_a.data_ptr<float>(),
+                     scale_b.data_ptr<float>(), bias_ptr,
+                     reinterpret_cast<__half*>(out_fp16.data_ptr()), M, N);
 }
 
 }  // namespace
 
-void register_instance(int64_t m_min, int64_t m_max, int64_t n, int64_t k,
-                       int64_t tp_rank,
-                       std::function<bool(const at::Tensor&, const at::Tensor&,
-                                          at::Tensor&)> run) {
+void register_instance(
+    int64_t m_min, int64_t m_max, int64_t n, int64_t k, int64_t tp_rank,
+    std::function<bool(const at::Tensor&, const at::Tensor&, at::Tensor&)>
+        run) {
   std::lock_guard<std::mutex> g(registry_mutex());
   registry().push_back({m_min, m_max, n, k, tp_rank, std::move(run)});
 }
@@ -144,8 +143,7 @@ torch::Tensor ck_int8_gemm(const torch::Tensor& a, const torch::Tensor& b,
       }
     }
   }
-  TORCH_CHECK(picked,
-              "No CK INT8 instance registered for (M=", M, ", N=", N,
+  TORCH_CHECK(picked, "No CK INT8 instance registered for (M=", M, ", N=", N,
               ", K=", K, ", tp_rank=", tp_rank,
               "). Caller should fall back to hipBLASLt/Triton.");
 

--- a/csrc/quantization/w8a8/int8/ck/ck_int8_instance_common.h
+++ b/csrc/quantization/w8a8/int8/ck/ck_int8_instance_common.h
@@ -39,10 +39,9 @@
 
 namespace vllm::ck_int8 {
 
-void register_instance(int64_t m_min, int64_t m_max, int64_t n, int64_t k,
-                       int64_t tp_rank,
-                       std::function<bool(const at::Tensor&, const at::Tensor&,
-                                          at::Tensor&)> run);
+void register_instance(
+    int64_t m_min, int64_t m_max, int64_t n, int64_t k, int64_t tp_rank,
+    std::function<bool(const at::Tensor&, const at::Tensor&, at::Tensor&)> run);
 
 namespace detail {
 
@@ -57,31 +56,26 @@ using PassThrough = ck::tensor_operation::element_wise::PassThrough;
 // are not used (gfx908 does not support them); we apply scales as a
 // separate fp16 pass after the int32 GEMM.
 using DeviceGemmInt8 = ck::tensor_operation::device::DeviceGemm_Xdl_CShuffle<
-    ALayout, BLayout, CLayout,
-    int8_t, int8_t, int32_t,
-    int32_t, int32_t,
+    ALayout, BLayout, CLayout, int8_t, int8_t, int32_t, int32_t, int32_t,
     PassThrough, PassThrough, PassThrough,
     ck::tensor_operation::device::GemmSpecialization::MNKPadding,
-    1,                              // NumGemmKPrefetchStage
-    256,                            // BlockSize
-    128, 128, 64,                   // MPerBlock, NPerBlock, KPerBlock
-    16, 16,                         // AK1, BK1
-    16, 16,                         // MPerXDL, NPerXDL
-    4, 4,                           // MXdlPerWave, NXdlPerWave
-    ck::Sequence<4, 64, 1>,         // ABlockTransfer cluster
-    ck::Sequence<1, 0, 2>,
-    ck::Sequence<1, 0, 2>,
-    2, 16, 16, 1,                   // SrcVectorDim, SrcScalar, DstScalarPerVector_AK1, ABlockLdsExtraM
-    ck::Sequence<4, 64, 1>,         // BBlockTransfer cluster
-    ck::Sequence<1, 0, 2>,
-    ck::Sequence<1, 0, 2>,
-    2, 8, 8, 1,                     // SrcVectorDim, SrcScalar, DstScalarPerVector_BK1, BBlockLdsExtraN
-    1, 1,                           // CShuffleMXdlPerWavePerShuffle, NXdlPerWavePerShuffle
-    ck::Sequence<1, 32, 1, 8>,      // CShuffleBlockTransferClusterLengths
-    4,                              // CShuffleBlockTransferScalarPerVector_NPerBlock
-    ck::LoopScheduler::Default,
-    ck::PipelineVersion::v1,
-    int8_t, int8_t>;                // ComputeTypeA, ComputeTypeB — drives v_mfma_i32_16x16x16i8
+    1,                       // NumGemmKPrefetchStage
+    256,                     // BlockSize
+    128, 128, 64,            // MPerBlock, NPerBlock, KPerBlock
+    16, 16,                  // AK1, BK1
+    16, 16,                  // MPerXDL, NPerXDL
+    4, 4,                    // MXdlPerWave, NXdlPerWave
+    ck::Sequence<4, 64, 1>,  // ABlockTransfer cluster
+    ck::Sequence<1, 0, 2>, ck::Sequence<1, 0, 2>, 2, 16, 16,
+    1,  // SrcVectorDim, SrcScalar, DstScalarPerVector_AK1, ABlockLdsExtraM
+    ck::Sequence<4, 64, 1>,  // BBlockTransfer cluster
+    ck::Sequence<1, 0, 2>, ck::Sequence<1, 0, 2>, 2, 8, 8,
+    1,     // SrcVectorDim, SrcScalar, DstScalarPerVector_BK1, BBlockLdsExtraN
+    1, 1,  // CShuffleMXdlPerWavePerShuffle, NXdlPerWavePerShuffle
+    ck::Sequence<1, 32, 1, 8>,  // CShuffleBlockTransferClusterLengths
+    4,  // CShuffleBlockTransferScalarPerVector_NPerBlock
+    ck::LoopScheduler::Default, ck::PipelineVersion::v1, int8_t,
+    int8_t>;  // ComputeTypeA, ComputeTypeB — drives v_mfma_i32_16x16x16i8
 
 // Run a CK INT8 GEMM with the mission-binding tile descriptor.
 // a:    [M, K] int8 row-major, contiguous
@@ -98,10 +92,10 @@ inline bool run_ck_int8_gemm(const at::Tensor& a, const at::Tensor& b,
 
   DeviceGemmInt8 gemm;
   auto invoker = gemm.MakeInvoker();
-  auto arg = gemm.MakeArgument(
-      a.data_ptr<int8_t>(), b.data_ptr<int8_t>(), out.data_ptr<int32_t>(),
-      M, N, K, StrideA, StrideB, StrideC,
-      PassThrough{}, PassThrough{}, PassThrough{});
+  auto arg =
+      gemm.MakeArgument(a.data_ptr<int8_t>(), b.data_ptr<int8_t>(),
+                        out.data_ptr<int32_t>(), M, N, K, StrideA, StrideB,
+                        StrideC, PassThrough{}, PassThrough{}, PassThrough{});
 
   if (!gemm.IsSupportedArgument(arg)) {
     return false;

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -31,8 +31,8 @@ using __hip_fp8_e4m3 = __hip_fp8_e4m3_fnuz;
 using __hip_fp8_e5m2 = __hip_fp8_e5m2_fnuz;
 #endif
 
-#if defined(__HIPCC__) && \
-    (defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
+#if defined(__HIPCC__) && (defined(__gfx908__) || defined(__gfx90a__) || \
+                           defined(__gfx942__) || defined(__gfx950__))
   #define __HIP__GFX9__
 #endif
 
@@ -98,22 +98,23 @@ __device__ __forceinline__ floatx4 gcn_mfma4x4x4_instr(const _B16x4& inpA,
     return __builtin_amdgcn_mfma_f32_4x4x4f16(inpA, inpB, inpC, absz, cbid,
                                               blgp);
   } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-#if defined(__gfx908__)
+  #if defined(__gfx908__)
     // gfx908 (CDNA1) lacks bf16_1k MFMA. Cast BF16 inputs to FP16 via
     // float intermediate, then use the FP16 MFMA available on all CDNA.
     _B16x4 a16, b16;
     for (int i = 0; i < 4; i++) {
-      float fa = __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpA)[i]);
-      float fb = __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpB)[i]);
+      float fa =
+          __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpA)[i]);
+      float fb =
+          __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpB)[i]);
       reinterpret_cast<_Float16*>(&a16)[i] = static_cast<_Float16>(fa);
       reinterpret_cast<_Float16*>(&b16)[i] = static_cast<_Float16>(fb);
     }
-    return __builtin_amdgcn_mfma_f32_4x4x4f16(a16, b16, inpC, absz, cbid,
-                                              blgp);
-#else
+    return __builtin_amdgcn_mfma_f32_4x4x4f16(a16, b16, inpC, absz, cbid, blgp);
+  #else
     return __builtin_amdgcn_mfma_f32_4x4x4bf16_1k(inpA, inpB, inpC, absz, cbid,
                                                   blgp);
-#endif
+  #endif
   } else {
     static_assert(false, "unsupported 16b dtype");
   }
@@ -127,22 +128,24 @@ __device__ __forceinline__ floatx4 gcn_mfma16x16x16_instr(const _B16x4& inpA,
     return __builtin_amdgcn_mfma_f32_16x16x16f16(inpA, inpB, inpC, absz, cbid,
                                                  blgp);
   } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-#if defined(__gfx908__)
+  #if defined(__gfx908__)
     // gfx908 (CDNA1) lacks bf16_1k MFMA. Cast BF16 inputs to FP16 via
     // float intermediate, then use the FP16 MFMA available on all CDNA.
     _B16x4 a16, b16;
     for (int i = 0; i < 4; i++) {
-      float fa = __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpA)[i]);
-      float fb = __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpB)[i]);
+      float fa =
+          __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpA)[i]);
+      float fb =
+          __bfloat162float(reinterpret_cast<const __hip_bfloat16*>(&inpB)[i]);
       reinterpret_cast<_Float16*>(&a16)[i] = static_cast<_Float16>(fa);
       reinterpret_cast<_Float16*>(&b16)[i] = static_cast<_Float16>(fb);
     }
     return __builtin_amdgcn_mfma_f32_16x16x16f16(a16, b16, inpC, absz, cbid,
                                                  blgp);
-#else
+  #else
     return __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(inpA, inpB, inpC, absz,
                                                      cbid, blgp);
-#endif
+  #endif
   } else {
     static_assert(false, "unsupported 16b dtype");
   }

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -21,8 +21,8 @@
 //
 // However, it may be possible to fix these kernels to handle both issues.
 
-#if defined(__HIPCC__) && \
-    (defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__))
+#if defined(__HIPCC__) && (defined(__gfx908__) || defined(__gfx90a__) || \
+                           defined(__gfx942__) || defined(__gfx950__))
   #define __HIP__GFX9__
 #endif
 

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -2,8 +2,8 @@
 #include "rocm/ops.h"
 
 #ifdef VLLM_BUILD_CK
-#include "quantization/w8a8/int8/ck/ck_int8_gemm.h"
-#include "quantization/gptq/ck/ck_w4a16_gemm.h"
+  #include "quantization/w8a8/int8/ck/ck_int8_gemm.h"
+  #include "quantization/gptq/ck/ck_w4a16_gemm.h"
 #endif
 
 // Note on op signatures:
@@ -96,8 +96,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.def(
       "ck_w4a16_gemm(Tensor a, Tensor b, Tensor scales, Tensor zeros, "
       "int group_size, int tp_rank) -> Tensor");
-  rocm_ops.impl("ck_w4a16_gemm", torch::kCUDA,
-                &vllm::ck_w4a16::ck_w4a16_gemm);
+  rocm_ops.impl("ck_w4a16_gemm", torch::kCUDA, &vllm::ck_w4a16::ck_w4a16_gemm);
 
   rocm_ops.def(
       "ck_w4a16_gemm_supports(int M, int N, int K, int group_size, "

--- a/docs/AITER_FORK_ANALYSIS.md
+++ b/docs/AITER_FORK_ANALYSIS.md
@@ -11,14 +11,15 @@ Evaluation of forking [ROCm/aiter](https://github.com/ROCm/aiter) to provide fus
 
 AITER (AI Tensor Engine for ROCm) is AMD's centralized high-performance AI operator library. It provides fused kernels for attention, GEMM, MoE, RMSNorm, RoPE, quantization, and communication primitives. vLLM has deep integration with AITER via the `VLLM_ROCM_USE_AITER=1` environment variable and the `rocm_aiter_ops` abstraction layer.
 
-**Repository:** https://github.com/ROCm/aiter (MIT license, 397 stars, 229 contributors, ~1590 commits)
+**Repository:** <https://github.com/ROCm/aiter> (MIT license, 397 stars, 229 contributors, ~1590 commits)
 
 ## Current Status
 
 AITER is **not available on MI100 (gfx908)**. The package is developed and tested exclusively on gfx942 (MI300X) and gfx950 (MI350). Even gfx90a (MI250) has build failures due to FP8 kernel dependencies ([issue #179](https://github.com/ROCm/aiter/issues/179)).
 
 When `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1` is set in our fork, vLLM crashes with:
-```
+
+```text
 ModuleNotFoundError: No module named 'aiter'
 ```
 

--- a/docs/MI100_Optimization_Attempts.md
+++ b/docs/MI100_Optimization_Attempts.md
@@ -16,7 +16,7 @@ I attempted to port MI100-specific optimizations from older branches (created fo
 
 **Baseline Performance**: 38.5 tok/s prompt, 48.7 tok/s generation
 **Post-Optimization**: Same or worse (0% to -7%)
-**Conclusion**: Vanilla vLLM on ROCm 7.0 is satifactory for MI100
+**Conclusion**: Vanilla vLLM on ROCm 7.0 is satisfactory for MI100
 
 ---
 
@@ -123,7 +123,7 @@ Modified low-level GPTQ quantization kernels to use AMD-specific instructions an
 
 **File Modified**: `csrc/quantization/gptq/q_gemm.cu`
 
-**Change 1: Increased Block Sizes**
+#### Change 1: Increased Block Sizes
 
 ```cpp
 // BEFORE (upstream default):
@@ -144,7 +144,7 @@ Modified low-level GPTQ quantization kernels to use AMD-specific instructions an
 - Reduces kernel launch overhead
 - Previously showed 6.3% improvement on ROCm 5.x/6.x
 
-**Change 2: AMD fdot2 Intrinsic**
+#### Change 2: AMD fdot2 Intrinsic
 
 ```cpp
 __forceinline__ __device__ float dot22_8_f(half2 (&dq)[4], const half* a_ptr,
@@ -194,7 +194,7 @@ __forceinline__ __device__ float dot22_8_f(half2 (&dq)[4], const half* a_ptr,
 1. **Initial Implementation Bug**:
    - Used `#if defined(__gfx908__)` for conditional compilation
    - Caused memory access faults during torch.compile:
-     ```
+     ```text
      Memory access fault by GPU node-4 on address 0x712951800000
      Reason: Page not present or supervisor privilege
      ```
@@ -335,7 +335,7 @@ Optimizations are tied to their environment.
 
 ### Hardware Configuration
 
-```
+```text
 System: 4x AMD Instinct MI100
 - Architecture: CDNA1 (gfx908)
 - Compute Units: 120 per GPU
@@ -347,7 +347,7 @@ System: 4x AMD Instinct MI100
 
 ### Software Stack
 
-```
+```text
 OS: Ubuntu 22.04
 ROCm: 7.0.2
 HIP: 6.2.x

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -180,8 +180,9 @@ Priority is **1 = highest** (tried first).
 | `ROCM_AITER_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32 | 64, 128, 256 | ✅ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ❌ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ✅ | ❌ | Decoder, Encoder, Encoder Only | N/A |
+| `ROCM_CK_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16` | %128 | Any | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2`, `int8_per_token_head`, `fp8_per_token_head` | %16 | Any | ✅ | ❌ | ✅ | ❌ | All | Any |
-| `TURBOQUANT` | | fp16, bf16 | `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc` | 16, 32, 64, 128 | Any | ❌ | ❌ | ❌ | ❌ | Decoder | Any |
+| `TURBOQUANT` | | fp16, bf16 | `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc`, `turboquant_planar3_nc`, `turboquant_iso3_nc`, `turboquant_planar4_nc`, `turboquant_iso4_nc`, `turboquant_planar3_sym_nc`, `turboquant_iso3_sym_nc` | 16, 32, 64, 128 | Any | ❌ | ❌ | ❌ | ❌ | Decoder | Any |
 
 > **†** FlashInfer uses TRTLLM attention on Blackwell (SM100), which supports sinks. Disable via `--attention-config.use_trtllm_attention=0`.
 >

--- a/docs/experiments/BENCH_FP16_COMPILE_MOE_2026_06.md
+++ b/docs/experiments/BENCH_FP16_COMPILE_MOE_2026_06.md
@@ -2,6 +2,7 @@
 # torch.compile + PIECEWISE on MoE (Qwen3.5-35B-A3B, gfx908/MI100, 2026-06)
 
 Third in the compile series:
+
 - `BENCH_FP16_TORCH_COMPILE_AB_2026_06.md` — dense 9B on 0.19.2: +3.64%
 - `BENCH_FP16_COMPILE_PORT_0202_2026_06.md` — Dynamo fix + dense 9B on 0.20.2: +1.81%
 - **this** — MoE 35B on the fixed 0.20.2 build
@@ -74,6 +75,7 @@ compile win, (c) the gfx908 fused-MoE tuned configs. That's the full-stack
 config worth standing up next.
 
 ## Reproduction
+
 ```bash
 /root/fp16-bench/run_moe_compile_ab.sh   # TP=4, c{1,2,4}, baseline vs compile
 # results: /root/fp16-bench/moe_compile_ab/{baseline,compile}_tp4_c{1,2,4}/raw.json

--- a/docs/experiments/BENCH_FP16_COMPILE_PORT_0202_2026_06.md
+++ b/docs/experiments/BENCH_FP16_COMPILE_PORT_0202_2026_06.md
@@ -14,7 +14,7 @@ torch.compile (`mode=3`) aborted engine init with:
 Traced to a **gfx908-specific** producer added in the 0.20.2 tree (absent in
 0.19.2), called inside the now-compiled MoE forward:
 
-```
+```text
 qwen2_moe.py:129  Qwen2MoeMLP.forward
   → try_stash_fused_silu_quant_int8(gate_up, self.down_proj)
     → fused_silu_quant_int8.py:252  if torch.cuda.is_current_stream_capturing():  ← Dynamo can't trace
@@ -36,6 +36,7 @@ if torch.compiler.is_compiling():
 ```
 
 Why this is correct and minimal:
+
 - `torch.compiler.is_compiling()` **is** Dynamo-traceable and constant-folds to
   `True` during capture, so it short-circuits **before** the untraceable
   `is_current_stream_capturing()` call.
@@ -95,10 +96,12 @@ This makes the deploy recommendation **concurrency-gated**, not global.
    MoE model is loadable — ties into the W8A16 capacity work.
 
 ## Files changed
+
 - `vllm/model_executor/kernels/quantization/fused_silu_quant_int8.py` — added
   `torch.compiler.is_compiling()` guard (1 line + explanatory comment).
 
 ## Reproduction
+
 ```bash
 # fix is in the fuzzy-hornets 0.20.2 worktree
 /root/fp16-bench/run_compile_ab_0202.sh

--- a/docs/experiments/BENCH_FP16_COMPILE_QUANT_MOE_2026_06.md
+++ b/docs/experiments/BENCH_FP16_COMPILE_QUANT_MOE_2026_06.md
@@ -52,6 +52,7 @@ under compile here, a much bigger prefill latency improvement than fp16 MoE saw
 ## The capstone validates the whole stack on gfx908
 
 This single config exercises everything we built/fixed:
+
 1. **Quant capacity** — W4A16 fits a 512-expert MoE (45 GB) on 4×MI100 with KV
    cache for **1.21 M tokens** (74× concurrency @ 16k ctx); the fp16 35B only
    reached 896k / 54.7×. Quant buys ~35% more KV headroom here.
@@ -89,6 +90,7 @@ merged gfx908 fused-MoE config work).
    compile win measured here).
 
 ## Reproduction
+
 ```bash
 /root/fp16-bench/run_qmoe_compile_ab.sh   # TP=4, c{1,2,4}, baseline vs compile
 # results: /root/fp16-bench/qmoe_compile_ab/{baseline,compile}_tp4_c{1,2,4}/raw.json

--- a/docs/experiments/BENCH_FP16_TORCH_COMPILE_AB_2026_06.md
+++ b/docs/experiments/BENCH_FP16_TORCH_COMPILE_AB_2026_06.md
@@ -28,6 +28,7 @@ paying off once there's enough work to amortize them.
 ## Critical constraints discovered (these gate deployability)
 
 ### 1. PIECEWISE cudagraphs REQUIRE torch.compile — they are not separable
+
 vLLM rejects piecewise-without-compile:
 > `Cudagraph mode FULL_AND_PIECEWISE is not compatible with compilation mode 0. Overriding to NONE.`
 
@@ -36,6 +37,7 @@ the community config is full `mode=3` (VLLM_COMPILE/Inductor) + piecewise
 together. There is no "cheap" piecewise-only path.
 
 ### 2. torch.compile CRASHES on our 0.20.2 build — works only on 0.19.2
+
 On the **0.20.2** build that matches the current BENCH docs
 (`fuzzy-hornets`, `0.20.2rc1.dev107+gd960f21e4`), `mode=3` aborts engine init:
 > `torch._dynamo.exc.Unsupported: torch.* op returned non-Tensor` on
@@ -54,6 +56,7 @@ where compile *works*, it's a +3.64% win, not a loss. The community runs 0.19.2
 specifically because that's where their compile patch lands cleanly.
 
 ### 3. Cost: ~40 s (TP1) compile warmup per server start + higher peak memory
+
 `max_model_len` had to stay at 32768 and `--gpu-memory-utilization` at 0.90
 (vs 0.93 baseline) for headroom — consistent with the `rocm.py` note that
 Inductor increases peak memory. Compile cache (`/root/.cache/vllm/torch_compile_cache`)

--- a/docs/experiments/BENCH_FP16_VS_QUANT_2026_06.md
+++ b/docs/experiments/BENCH_FP16_VS_QUANT_2026_06.md
@@ -34,7 +34,7 @@ so the FP16-vs-quant delta can finally be stated honestly.
 | `fp16_tp4_c1` | **72.15** | 156.77 | 13.70 | 0.282 |
 | `fp16_tp4_c2` | **126.02** | 148.33 | 15.41 | 0.492 |
 
-**FP16 decode-dominated geomean = 76.29 tok/s**
+FP16 decode-dominated geomean = **76.29 tok/s**
 
 ## Head-to-head (vs BENCH.md headline quant grids)
 

--- a/docs/experiments/BENCH_HBM_FA_TUNING.md
+++ b/docs/experiments/BENCH_HBM_FA_TUNING.md
@@ -218,11 +218,11 @@ stock constants) already produces.
 > *"`kernel_unified_attention` — M4 mean μs/inv: 941.896, M1 mean μs/inv: 941.310,
 > Δ mean: -0.06 %. Mean launch-grid volume: M4 119 707.5, M1 119 707.5, Δ grid: 0.00 %"*
 > — `w8a8_tp1_c1_synthetic`, the M1-winner cell.
-
+>
 > *"`kernel_unified_attention` — M4 mean μs/inv: 1 199.833, M1 mean μs/inv: 1 199.459,
 > Δ mean: -0.03 %. Mean launch-grid volume: M4 91 301.9, M1 91 301.9, Δ grid: 0.00 %"*
 > — `w8a8_tp1_c4_coding`, the cell with the worst p99_ttft regression (+26.75 %).
-
+>
 > *"M1/M4 unique (Workgroup_Size_X, VGPR_Count, SGPR_Count, Grid_Size_X,
 > Grid_Size_Y) tuples are identical between traces … the winners it returns for
 > the (quant=w8a8, head_dim=128, seq_len_bucket, num_seqs) buckets exercised by

--- a/docs/experiments/BENCH_HBM_M1_KVINT8.md
+++ b/docs/experiments/BENCH_HBM_M1_KVINT8.md
@@ -330,7 +330,7 @@ synthetic regime that M3 (NCCL topology) targets.
 
 ### Bench artifacts (per cell)
 
-```
+```text
 /root/bench-int8-w4a16-hbm/m1-kvint8/
 ├── w8a8/
 │   ├── w8a8_tp1_c1_synthetic.json   …   w8a8_tp4_c4_coding.json   (12)
@@ -387,10 +387,10 @@ KV_CACHE_DTYPE=int8_per_token_head bash scripts/launch_w8a8_tp1_c1.sh --serve-on
 ### Cross-links
 
 - **Production baseline (read-only reference):**
-  - [`BENCH_INT8_W4A16_FINAL.md`](./BENCH_INT8_W4A16_FINAL.md)
-  - [`/root/bench-int8-w4a16/final/final_grid.csv`](./../../../../../root/bench-int8-w4a16/final/final_grid.csv)
+    - [`BENCH_INT8_W4A16_FINAL.md`](./BENCH_INT8_W4A16_FINAL.md)
+    - [`/root/bench-int8-w4a16/final/final_grid.csv`](./../../../../../root/bench-int8-w4a16/final/final_grid.csv)
 - **Prior mission's M1 baseline (omniperf evidence for HBM-bound hot kernels):**
-  - [`BENCH_INT8_W4A16_BASELINE.md`](./BENCH_INT8_W4A16_BASELINE.md)
+    - [`BENCH_INT8_W4A16_BASELINE.md`](./BENCH_INT8_W4A16_BASELINE.md)
 - **Smoke + correctness predecessor feature:**
   `/root/bench-int8-w4a16-hbm/m1-kvint8/SMOKE_CORRECTNESS_REPORT.md`
 - **Pareto exceptions:**

--- a/docs/experiments/BENCH_HBM_M2_CHUNKED.md
+++ b/docs/experiments/BENCH_HBM_M2_CHUNKED.md
@@ -95,13 +95,13 @@ and the machine-readable JSON at
 [`cudagraph_feasibility.md`](/root/bench-int8-w4a16-hbm/m2-chunked/cudagraph_feasibility.md)
 documents four probe runs (w8a8 / w4a16 × FULL / FULL_AND_PIECEWISE):
 
-* **FULL** was demoted to `FULL_DECODE_ONLY` at engine init by
+- **FULL** was demoted to `FULL_DECODE_ONLY` at engine init by
   `compilation.py:1343` because the active attention backend
   (`GDNAttentionBackend`, selected by Qwen3.5's Mamba+attention hybrid
   architecture) declares `AttentionCGSupport.UNIFORM_BATCH`, which is
   incompatible with FULL's variable-length prefill batches. Cause is
   architectural, independent of chunk size or quant scheme.
-* **FULL_AND_PIECEWISE** was demoted to `FULL_DECODE_ONLY` by the gfx908
+- **FULL_AND_PIECEWISE** was demoted to `FULL_DECODE_ONLY` by the gfx908
   pre-guard at `rocm.py:775` (citing measured PIECEWISE regression
   −9.7 % at c=8/TP>1 and KV-cache footprint blow-up). PIECEWISE also
   structurally requires `torch.compile`, which is broken on gfx908
@@ -152,8 +152,8 @@ new `CUDAGRAPH_MODE` env-var hook is opt-in only and defaults to empty
 Full 144-row table (12 cells × 2 workloads × 6 metrics) emitted by
 `scripts/mi100/aggregate_hbm.py --milestone m2-chunked`:
 
-* CSV (machine-readable): `/root/bench-int8-w4a16-hbm/m2-chunked/m2_pareto.csv`
-* Markdown (human-readable, rendered table): `/root/bench-int8-w4a16-hbm/m2-chunked/m2_pareto.md`
+- CSV (machine-readable): `/root/bench-int8-w4a16-hbm/m2-chunked/m2_pareto.csv`
+- Markdown (human-readable, rendered table): `/root/bench-int8-w4a16-hbm/m2-chunked/m2_pareto.md`
 
 Each row joins on `(model, tp, concurrency, workload)` against the per-cell
 production `winner_value` from `/root/bench-int8-w4a16/final/final_grid.csv`
@@ -198,15 +198,15 @@ cost dominates the TTFT.
 
 ### Verdict per quant
 
-* **w8a8 — WIN-BAR-MET** on the task-spec prefill bar (6/6 coding cells
+- **w8a8 — WIN-BAR-MET** on the task-spec prefill bar (6/6 coding cells
   pass) and on the decode-dominated `output_throughput` aggregator
   win-bar (4/8 cell×workload combinations, peak `+10.61 %` on
   `w8a8_tp4_c2_coding`).
-* **w4a16 — WIN-BAR-MET** on the task-spec prefill bar (5/6 coding cells
+- **w4a16 — WIN-BAR-MET** on the task-spec prefill bar (5/6 coding cells
   pass) and on the decode-dominated `output_throughput` aggregator
   win-bar (7/8 cell×workload combinations, peak `+19.10 %` on
   `w4a16_tp4_c2_coding`).
-* **Aggregate: WIN-BAR-MET on both quant schemes.** No negative-result
+- **Aggregate: WIN-BAR-MET on both quant schemes.** No negative-result
   clause invoked; no rocprofv3 trace required for VAL-CHUNKED-004.
 
 ## Pareto Exceptions
@@ -216,13 +216,13 @@ cost dominates the TTFT.
 
 Headline regressions:
 
-* **w8a8_tp4_c2 synthetic** `tput` −2.29 %, `req_tput` −2.29 %.
+- **w8a8_tp4_c2 synthetic** `tput` −2.29 %, `req_tput` −2.29 %.
   Fixed-1024-token inputs fit in a single 2048-token chunk; chunked
   scheduling adds overhead without unlocking cross-request batching
   benefits. Same cell on coding workload WINS by +10.61 %.
-* **w8a8_tp4_c4 synthetic** `tput` −6.97 %, `req_tput` −6.97 %, plus
+- **w8a8_tp4_c4 synthetic** `tput` −6.97 %, `req_tput` −6.97 %, plus
   `mean_tpot` +7.18 %. Same root cause amplified by higher concurrency.
-* **TTFT inflation is universal across cells** (mean_ttft up 4–100 %,
+- **TTFT inflation is universal across cells** (mean_ttft up 4–100 %,
   p99_ttft up 1.9 %–477 %). This is the expected scheduling tradeoff:
   chunked prefill splits per-prompt prefill across batches, increasing
   per-prompt first-token latency in exchange for higher cross-prompt
@@ -289,7 +289,7 @@ seed=42 fixed.
 
 ### File inventory (relative to `/root/bench-int8-w4a16-hbm/m2-chunked/`)
 
-```
+```text
 m2-chunked/
 ├── chunk_sweep.json              # m2-chunk-size-sweep output (read by grid)
 ├── chunk_sweep_summary.md        # human-readable per-quant table
@@ -318,15 +318,15 @@ m2-chunked/
 
 Cross-references:
 
-* M1 KV-INT8 (`int8_per_token_head`) baseline & decision:
+- M1 KV-INT8 (`int8_per_token_head`) baseline & decision:
   [`BENCH_HBM_M1_KVINT8.md`](BENCH_HBM_M1_KVINT8.md)
-* M2 chunk-size sweep details:
+- M2 chunk-size sweep details:
   [`chunk_sweep_summary.md`](/root/bench-int8-w4a16-hbm/m2-chunked/chunk_sweep_summary.md)
-* M2 cudagraph feasibility:
+- M2 cudagraph feasibility:
   [`cudagraph_feasibility.md`](/root/bench-int8-w4a16-hbm/m2-chunked/cudagraph_feasibility.md)
-* Production baseline this report compares against:
+- Production baseline this report compares against:
   [`BENCH_INT8_W4A16_FINAL.md`](BENCH_INT8_W4A16_FINAL.md) (commit
   `ee793dbff`); per-cell numbers in
   `/root/bench-int8-w4a16/final/final_grid.csv`.
-* Validation contract: `validation-contract.md` §
+- Validation contract: `validation-contract.md` §
   `m2-chunked-prefill` (VAL-CHUNKED-001..004).

--- a/docs/experiments/BENCH_HBM_M3_TP.md
+++ b/docs/experiments/BENCH_HBM_M3_TP.md
@@ -56,7 +56,7 @@ rccl 2.27.7 because KV-INT8 (`--kv-cache-dtype int8_per_token_head`) issues an
 AllGather on `ncclInt8` tensors during profile_run, and rccl 2.27.7 aborts
 engine init with:
 
-```
+```text
 ncclInvalidUsage: no algorithm/protocol available for function AllGather
                   with datatype ncclInt8. NCCL_ALGO was set to Tree.
 ```
@@ -111,7 +111,8 @@ Cumulative stack: **M1 KV-INT8** (`KV_CACHE_DTYPE=int8_per_token_head`) +
 **M2 chunked-prefill** (`--enable-chunked-prefill --max-num-batched-tokens
 2048` for w8a8, `4096` for w4a16, per
 [`m2-chunked/chunk_sweep.json`](/root/bench-int8-w4a16-hbm/m2-chunked/chunk_sweep.json))
-+ **M3 per-cell `NCCL_ALGO`** (Ring on 3 cells, default on 3 cells).
+
+- **M3 per-cell `NCCL_ALGO`** (Ring on 3 cells, default on 3 cells).
 
 The grid wrapper `scripts/mi100/run_grid_hbm.sh m3-tp` diverges from the
 generic 24-cell loop in two M3-specific ways (see commit diff):
@@ -125,7 +126,7 @@ This produced 12 result JSONs (6 cells × 2 workloads). All 12 were
 schema-validated (see
 [`schema_check.log`](/root/bench-int8-w4a16-hbm/m3-tp/schema_check.log)):
 
-```
+```text
 12 files validated, 0 failures
 ```
 

--- a/docs/experiments/BENCH_INT8_W4A16_BASELINE.md
+++ b/docs/experiments/BENCH_INT8_W4A16_BASELINE.md
@@ -49,6 +49,7 @@ artifacts. The prior-round W8A8 GatedDeltaNet failure mode (gibberish output)
 **is NOT reproduced** by these RedHatAI / apolo13x artifacts.
 
 The Δ values (+1.37 %, +2.91 %) are within published norms for INT8 channel
+
 + INT4 group-128 PTQ. They merely exceed the contract's strict +1 % gate.
 
 Mission paused at M0; orchestrator returned the decision to the user for a
@@ -64,25 +65,25 @@ Per VAL-BASE-001 .. VAL-BASE-009 the M1 worker locked the canonical harness, ran
 
 ### Harness manifest summary
 
-- Locked harness:        `/root/bench-int8-w4a16/baseline/run_baseline.sh`
-- vLLM commit:           `8bcd4bdf4dcb8625274688bf2477f413ea0a2f06`
-- vLLM version:          0.20.2rc1.dev93+g85994b2e3
-- ROCm:                  7.12
-- torch:                 2.11.0+rocm7.2
-- pytorch-triton-rocm:   3.5.1
-- block-size:            32
-- max-model-len:         32768
-- num-prompts per cell:  200
-- seed:                  42
-- cudagraph_mode:        FULL_DECODE_ONLY
-- prefix caching:        True
-- dataset SHA256:        `db138a30917dc972fab0ca70ddf74601...`
-- host:                  `aimeme-MU72-SU0-00`
-- timestamp (last write):`2026-05-08T00:39:59Z`
++ Locked harness:        `/root/bench-int8-w4a16/baseline/run_baseline.sh`
++ vLLM commit:           `8bcd4bdf4dcb8625274688bf2477f413ea0a2f06`
++ vLLM version:          0.20.2rc1.dev93+g85994b2e3
++ ROCm:                  7.12
++ torch:                 2.11.0+rocm7.2
++ pytorch-triton-rocm:   3.5.1
++ block-size:            32
++ max-model-len:         32768
++ num-prompts per cell:  200
++ seed:                  42
++ cudagraph_mode:        FULL_DECODE_ONLY
++ prefix caching:        True
++ dataset SHA256:        `db138a30917dc972fab0ca70ddf74601...`
++ host:                  `aimeme-MU72-SU0-00`
++ timestamp (last write):`2026-05-08T00:39:59Z`
 
 Required env vars (per AGENTS.md, applied uniformly):
 
-```
+```text
 LD_LIBRARY_PATH=/opt/rocm/core-7.12/lib
 ROCM_PATH=/opt/rocm/core-7.12
 PATH=/opt/rocm/core-7.12/bin:/root/.factory/bin:/root/.cargo/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
@@ -134,11 +135,11 @@ Throughput is total output tok/s across all in-flight requests. TTFT and TPOT pe
 | w4a16 | 4 | 4 | synthetic | 193.99 | 0.758 | 197.0 | 249.8 | 19.91 | 20.10 |
 | w4a16 | 4 | 4 | coding | 161.98 | 0.707 | 122.3 | 212.4 | 23.42 | 29.15 |
 
-# Top 12 GEMM Shapes (M1 Baseline)
+## Top 12 GEMM Shapes (M1 Baseline)
 
-- Traces analyzed: 2
-- Grand GPU busy time: 29263.74 ms
-- Top-12 cumulative coverage: **80.51%**
++ Traces analyzed: 2
++ Grand GPU busy time: 29263.74 ms
++ Top-12 cumulative coverage: **80.51%**
 
 | Rank | %busy | Total ms | Calls | Shape | Kernel |
 |------|-------|----------|-------|-------|--------|
@@ -181,37 +182,3 @@ _omniperf is not installed in the mission environment; this summary was produced
 |------:|------------|------:|----------:|------------------:|----------:|----------------------------:|--------------:|
 | w8a8 | `scaled_mm_kernel` | 47200 | 11983.78 | 258.98 | **21.08%** | 0.337 | 0.183% |
 | w4a16 | `triton_w4a16_gemm_kernel` | 23600 | 9830.51 | 395.42 | **32.18%** | — | — |
-
-Both hot kernels are clearly **memory-bandwidth bound** (HBM utilization ~21-32% of peak; the VALU compute proxy is far below 1% of peak compute, even after accounting for VALU underestimating MFMA throughput). This corroborates the M2/M3 playbook: dominant wins come from reducing weight bytes (W4A16 saves 75% of weight bandwidth vs FP16, W8A8 saves 50%) and from fusing dequant + GEMM into a single pass.
-
-
-## Per-trace busy summary
-
-| Cell | n_kernels | n_records | busy_ms |
-|------|-----------|-----------|---------|
-| w4a16_tp1_c1_synthetic/rocprof_w4a16_tp1_c1_synthetic_kernel_trace | 112 | 326320 | 16930.69 |
-| w8a8_tp1_c1_synthetic/rocprof_w8a8_tp1_c1_synthetic_kernel_trace | 107 | 349048 | 12333.05 |
-
-### Hot Shapes
-
-Top 1-2 GEMM kernels per regime per quant scheme, ranked by total wall-clock within the rocprofv3 capture window.
-
-| Regime | Quant | Rank | %busy | Total ms | Calls | Shape | Kernel |
-|--------|------:|-----:|------:|---------:|------:|-------|--------|
-| tp1c1 | w8a8 | 1 | 64.46% | 6188.51 | 23600 |  | `scaled_mm_kernel` |
-| tp1c1 | w8a8 | 2 | 9.38% | 900.53 | 332 |  | `Cijk_Alik_Bljk_HHS_BH_MT128x192x32_MI32x32x8x1_SN_1LDSB1_APM1_ABV0_ACED0_AF0EM8_` |
-| tp1c1 | w4a16 | 1 | 75.74% | 10671.57 | 23600 |  | `triton_w4a16_gemm_kernel` |
-| tp1c1 | w4a16 | 2 | 6.42% | 905.02 | 332 |  | `Cijk_Alik_Bljk_HHS_BH_MT128x192x32_MI32x32x8x1_SN_1LDSB1_APM1_ABV0_ACED0_AF0EM8_` |
-
-### Roofline placement (rocprofv3 PMC; omniperf-equivalent)
-
-_omniperf is not installed in the mission environment; this summary was produced by aggregating rocprofv3 PMC counters (SQ_*, TCP_TCC_*) over the dominant hot kernel of each quant scheme. Peaks: gfx908 FP16/INT8 MFMA = 184.6 TFLOPs, HBM2 = 1228.8 GB/s._
-
-| Quant | Hot kernel | Calls | Kernel ms | Achieved HBM GB/s | %HBM peak | Achieved VALU TFLOPs (proxy) | %compute peak |
-|------:|------------|------:|----------:|------------------:|----------:|----------------------------:|--------------:|
-| w8a8 | `scaled_mm_kernel` | 47200 | 11983.78 | 258.98 | **21.08%** | 0.337 | 0.183% |
-| w4a16 | `triton_w4a16_gemm_kernel` | 23600 | 9830.51 | 395.42 | **32.18%** | — | — |
-
-Both hot kernels are clearly **memory-bandwidth bound** (HBM utilization ~21-32% of peak; the VALU compute proxy is far below 1% of peak compute, even after accounting for VALU underestimating MFMA throughput). This corroborates the M2/M3 playbook: dominant wins come from reducing weight bytes (W4A16 saves 75% of weight bandwidth vs FP16, W8A8 saves 50%) and from fusing dequant + GEMM into a single pass.
-
-

--- a/docs/experiments/BENCH_INT8_W4A16_FINAL.md
+++ b/docs/experiments/BENCH_INT8_W4A16_FINAL.md
@@ -5,11 +5,11 @@ Aggregates milestones M0–M5 into a single grid with per-(cell × metric) winne
 production recommendations, full quality-gate evidence, and per-cell reproducible
 launch scripts.
 
-Cross-links: 
-[BENCH_INT8_W4A16_BASELINE.md](BENCH_INT8_W4A16_BASELINE.md) (M0+M1), 
-[BENCH_INT8_W4A16_M2.md](BENCH_INT8_W4A16_M2.md) (TensileLite three-way), 
-[BENCH_INT8_W4A16_M3.md](BENCH_INT8_W4A16_M3.md) (Triton W8A8 + W4A16), 
-[BENCH_M4_CK.md](BENCH_M4_CK.md) (Composable Kernel W8A8 + W4A16-negative), 
+Cross-links:
+[BENCH_INT8_W4A16_BASELINE.md](BENCH_INT8_W4A16_BASELINE.md) (M0+M1),
+[BENCH_INT8_W4A16_M2.md](BENCH_INT8_W4A16_M2.md) (TensileLite three-way),
+[BENCH_INT8_W4A16_M3.md](BENCH_INT8_W4A16_M3.md) (Triton W8A8 + W4A16),
+[BENCH_M4_CK.md](BENCH_M4_CK.md) (Composable Kernel W8A8 + W4A16-negative),
 [BENCH_M5_ISA.md](BENCH_M5_ISA.md) (Hand-ISA negative result).
 
 ## Hardware / software manifest
@@ -67,11 +67,11 @@ Long-Context needle-in-haystack @ 32 k:
 
 - Result: **5/5**, gate ✅ PASS (5/5 required by VAL-FINAL-004)
 - Depths probed: 10%, 30%, 50%, 70%, 90%
-  - `Magic apple count` @ depth 10%: expected `47823` → ✅
-  - `Crimson tower height` @ depth 30%: expected `9216 meters` → ✅
-  - `Lunar passcode` @ depth 50%: expected `MOON-7741-XQ` → ✅
-  - `Coral fish species` @ depth 70%: expected `1582` → ✅
-  - `Captain's birthday` @ depth 90%: expected `March 22, 1873` → ✅
+    - `Magic apple count` @ depth 10%: expected `47823` → ✅
+    - `Crimson tower height` @ depth 30%: expected `9216 meters` → ✅
+    - `Lunar passcode` @ depth 50%: expected `MOON-7741-XQ` → ✅
+    - `Coral fish species` @ depth 70%: expected `1582` → ✅
+    - `Captain's birthday` @ depth 90%: expected `March 22, 1873` → ✅
 - Evidence: `/root/bench-int8-w4a16/final/m6_needle32k.json`.
 
 ## Full Pareto grid

--- a/docs/experiments/BENCH_INT8_W4A16_HBM.md
+++ b/docs/experiments/BENCH_INT8_W4A16_HBM.md
@@ -362,7 +362,7 @@ was met, all quality gates pass, and the 12 new launch scripts + tuning hash
 manifest are committed for production rollout. Two synthetic-workload cells
 do regress versus production under NCCL\_ALGO=Ring at high concurrency
 (`w8a8_tp4_c2_synthetic` −2.03 %, `w8a8_tp4_c4_synthetic` −7.51 %); both
-are disclosed in [§5 Cumulative Pareto Grid](#5-cumulative-pareto-grid)
+are disclosed in [§6 Cumulative Pareto Grid](#6-cumulative-144-row-pareto-grid)
 and root-caused in [§10 Gap Analysis](#10-gap-analysis-val-final-005-negative-result-clause)
 (at c=4 all-reduce is < 3 % of wall-clock so Ring's scheduling overhead
 dominates, while the per-quant `coding` workload on those same cells WINS

--- a/docs/experiments/BENCH_INT8_W4A16_M2.md
+++ b/docs/experiments/BENCH_INT8_W4A16_M2.md
@@ -34,8 +34,8 @@
 - **Selection-proof + numerical correctness still hold**: the
   infrastructure (TensileLite tuning client, merged-library build,
   hipBLASLt dispatcher) is intact and is required for any future
-  per-shape kernel substitution. The negative result is _on uplift
-  for these shapes_, not on the build/dispatch chain.
+  per-shape kernel substitution. The negative result is *on uplift
+  for these shapes*, not on the build/dispatch chain.
 - **Reproducibility canary differs across runs** — Tensile's "best"
   kernel selection is sensitive to measurement noise on this MI100
   host. With the new finding that tuning provides ~0% uplift, the
@@ -44,7 +44,7 @@
 
 ## Files added/modified (this resume)
 
-```
+```text
 scripts/mi100/
 ├── merge_tensile_logic.sh           # NEW — yaml staging + TensileCreateLibrary
 ├── verify_tuned_kernel_selected.sh  # NEW — rocprofv3-driven selection proof
@@ -93,7 +93,7 @@ kernel — they remain on the Triton path).
 
 ## Lazy-merge pipeline
 
-```
+```text
 1. Stage 8 tuned YAMLs into merge_workspace/merged_logic/
      scripts/mi100/merge_tensile_logic.sh (Step 1)
 
@@ -134,7 +134,7 @@ documents this trade-off.
 
 ## Selection Proof (VAL-TENSILE-003 evidence)
 
-```
+```text
 $ scripts/mi100/verify_tuned_kernel_selected.sh
 ===== M2 selection-proof summary (2026-05-09T23:34:35Z) =====
 
@@ -160,6 +160,7 @@ the assembly kernel name embedded, and we grep for the
 `MT*_MI*` tile fragment.
 
 Output traces:
+
 - `/root/bench-int8-w4a16/tensilelite/select_proof_prebuilt_kernel_trace.csv`
 - `/root/bench-int8-w4a16/tensilelite/select_proof_merged_kernel_trace.csv`
 - `/root/bench-int8-w4a16/tensilelite/select_proof_summary.txt`
@@ -184,6 +185,7 @@ TensileLite tuning by itself bought us, controlling for the library
 swap".
 
 Files:
+
 - M1 baseline: `/root/bench-int8-w4a16/baseline/{synthetic,coding}/w8a8_*.json` (May-7)
 - M1-rebaselined: `/root/bench-int8-w4a16/m1-rebaseline/{synthetic,coding}/w8a8_*.json` (May-9/10)
 - M2 (tuned): `/root/bench-int8-w4a16/m2/{synthetic,coding}/w8a8_*.json` (May-9/10)
@@ -192,70 +194,70 @@ Files:
 ### Three-way comparison table (full 12-cell W8A8 grid)
 
 Markup: **bold** = improvement ≥ 3% on this metric (Pareto-bar);
-_italic_ = regression > 1%.
+*italic* = regression > 1%.
 
 | Cell | Workload | Metric | M1 (May-7) | M1-rebaseline | M2 | Δ M1→M2 | Δ M1→M1rb (lib-swap) | Δ M1rb→M2 (**tuning**) |
 | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| w8a8_tp1_c1 | synthetic | tput | 38.97 | 37.44 | 37.17 | _-4.61%_ | _-3.91%_ | -0.73% |
+| w8a8_tp1_c1 | synthetic | tput | 38.97 | 37.44 | 37.17 | *-4.61%* | *-3.91%* | -0.73% |
 | w8a8_tp1_c1 | synthetic | mean_ttft | 314.33 | 283.48 | 283.76 | **-9.73%** | **-9.81%** | +0.10% |
-| w8a8_tp1_c1 | synthetic | p99_ttft | 318.00 | 288.05 | 295.71 | **-7.01%** | **-9.42%** | _+2.66%_ |
-| w8a8_tp1_c1 | synthetic | mean_tpot | 24.53 | 25.70 | 25.90 | _+5.57%_ | _+4.77%_ | +0.76% |
-| w8a8_tp1_c1 | synthetic | p99_tpot | 24.55 | 25.77 | 25.91 | _+5.55%_ | _+4.98%_ | +0.54% |
-| w8a8_tp1_c1 | coding    | tput | 38.06 | 36.56 | 36.31 | _-4.58%_ | _-3.92%_ | -0.68% |
+| w8a8_tp1_c1 | synthetic | p99_ttft | 318.00 | 288.05 | 295.71 | **-7.01%** | **-9.42%** | *+2.66%* |
+| w8a8_tp1_c1 | synthetic | mean_tpot | 24.53 | 25.70 | 25.90 | *+5.57%* | *+4.77%* | +0.76% |
+| w8a8_tp1_c1 | synthetic | p99_tpot | 24.55 | 25.77 | 25.91 | *+5.55%* | *+4.98%* | +0.54% |
+| w8a8_tp1_c1 | coding    | tput | 38.06 | 36.56 | 36.31 | *-4.58%* | *-3.92%* | -0.68% |
 | w8a8_tp1_c1 | coding    | mean_ttft | 231.00 | 219.86 | 218.16 | **-5.56%** | **-4.82%** | -0.78% |
 | w8a8_tp1_c1 | coding    | p99_ttft | 1183.77 | 1065.09 | 1063.76 | **-10.14%** | **-10.03%** | -0.13% |
-| w8a8_tp1_c1 | coding    | mean_tpot | 25.34 | 26.49 | 26.69 | _+5.35%_ | _+4.58%_ | +0.74% |
-| w8a8_tp1_c1 | coding    | p99_tpot | 33.36 | 34.50 | 34.72 | _+4.07%_ | _+3.42%_ | +0.62% |
-| w8a8_tp1_c2 | synthetic | tput | 73.81 | 70.78 | 70.67 | _-4.26%_ | _-4.11%_ | -0.16% |
+| w8a8_tp1_c1 | coding    | mean_tpot | 25.34 | 26.49 | 26.69 | *+5.35%* | *+4.58%* | +0.74% |
+| w8a8_tp1_c1 | coding    | p99_tpot | 33.36 | 34.50 | 34.72 | *+4.07%* | *+3.42%* | +0.62% |
+| w8a8_tp1_c2 | synthetic | tput | 73.81 | 70.78 | 70.67 | *-4.26%* | *-4.11%* | -0.16% |
 | w8a8_tp1_c2 | synthetic | mean_ttft | 488.31 | 439.42 | 439.20 | **-10.06%** | **-10.01%** | -0.05% |
 | w8a8_tp1_c2 | synthetic | p99_ttft | 556.20 | 492.42 | 492.33 | **-11.48%** | **-11.47%** | -0.02% |
-| w8a8_tp1_c2 | synthetic | mean_tpot | 25.29 | 26.64 | 26.69 | _+5.55%_ | _+5.37%_ | +0.18% |
-| w8a8_tp1_c2 | synthetic | p99_tpot | 25.56 | 26.86 | 26.91 | _+5.25%_ | _+5.09%_ | +0.15% |
-| w8a8_tp1_c2 | coding    | tput | 68.61 | 66.67 | 66.07 | _-3.71%_ | _-2.83%_ | -0.91% |
+| w8a8_tp1_c2 | synthetic | mean_tpot | 25.29 | 26.64 | 26.69 | *+5.55%* | *+5.37%* | +0.18% |
+| w8a8_tp1_c2 | synthetic | p99_tpot | 25.56 | 26.86 | 26.91 | *+5.25%* | *+5.09%* | +0.15% |
+| w8a8_tp1_c2 | coding    | tput | 68.61 | 66.67 | 66.07 | *-3.71%* | *-2.83%* | -0.91% |
 | w8a8_tp1_c2 | coding    | mean_ttft | 277.97 | 255.55 | 254.33 | **-8.51%** | **-8.07%** | -0.48% |
-| w8a8_tp1_c2 | coding    | p99_ttft | 1341.32 | 1185.41 | 1214.56 | **-9.45%** | **-11.62%** | _+2.46%_ |
-| w8a8_tp1_c2 | coding    | mean_tpot | 27.88 | 29.01 | 29.32 | _+5.15%_ | _+4.05%_ | _+1.06%_ |
-| w8a8_tp1_c2 | coding    | p99_tpot | 37.91 | 35.77 | 37.54 | -0.96% | **-5.64%** | _+4.96%_ |
-| w8a8_tp1_c4 | synthetic | tput | 135.90 | 131.90 | 132.01 | _-2.86%_ | _-2.94%_ | +0.08% |
+| w8a8_tp1_c2 | coding    | p99_ttft | 1341.32 | 1185.41 | 1214.56 | **-9.45%** | **-11.62%** | *+2.46%* |
+| w8a8_tp1_c2 | coding    | mean_tpot | 27.88 | 29.01 | 29.32 | *+5.15%* | *+4.05%* | *+1.06%* |
+| w8a8_tp1_c2 | coding    | p99_tpot | 37.91 | 35.77 | 37.54 | -0.96% | **-5.64%** | *+4.96%* |
+| w8a8_tp1_c4 | synthetic | tput | 135.90 | 131.90 | 132.01 | *-2.86%* | *-2.94%* | +0.08% |
 | w8a8_tp1_c4 | synthetic | mean_ttft | 814.96 | 717.53 | 717.53 | **-11.96%** | **-11.96%** | +0.00% |
 | w8a8_tp1_c4 | synthetic | p99_ttft | 956.65 | 819.69 | 820.69 | **-14.21%** | **-14.32%** | +0.12% |
-| w8a8_tp1_c4 | synthetic | mean_tpot | 26.35 | 27.63 | 27.60 | _+4.75%_ | _+4.85%_ | -0.09% |
-| w8a8_tp1_c4 | synthetic | p99_tpot | 27.41 | 28.51 | 28.48 | _+3.93%_ | _+4.03%_ | -0.10% |
-| w8a8_tp1_c4 | coding    | tput | 120.36 | 116.55 | 117.12 | _-2.69%_ | _-3.16%_ | +0.49% |
+| w8a8_tp1_c4 | synthetic | mean_tpot | 26.35 | 27.63 | 27.60 | *+4.75%* | *+4.85%* | -0.09% |
+| w8a8_tp1_c4 | synthetic | p99_tpot | 27.41 | 28.51 | 28.48 | *+3.93%* | *+4.03%* | -0.10% |
+| w8a8_tp1_c4 | coding    | tput | 120.36 | 116.55 | 117.12 | *-2.69%* | *-3.16%* | +0.49% |
 | w8a8_tp1_c4 | coding    | mean_ttft | 322.69 | 293.71 | 293.36 | **-9.09%** | **-8.98%** | -0.12% |
-| w8a8_tp1_c4 | coding    | p99_ttft | 1436.67 | 1393.34 | 1436.77 | +0.01% | **-3.02%** | _+3.12%_ |
-| w8a8_tp1_c4 | coding    | mean_tpot | 31.76 | 32.94 | 33.01 | _+3.95%_ | _+3.73%_ | +0.22% |
-| w8a8_tp1_c4 | coding    | p99_tpot | 42.66 | 38.61 | 41.43 | -2.87% | **-9.48%** | _+7.30%_ |
-| w8a8_tp4_c1 | synthetic | tput | 63.95 | 57.04 | 57.18 | _-10.58%_ | _-10.80%_ | +0.25% |
+| w8a8_tp1_c4 | coding    | p99_ttft | 1436.67 | 1393.34 | 1436.77 | +0.01% | **-3.02%** | *+3.12%* |
+| w8a8_tp1_c4 | coding    | mean_tpot | 31.76 | 32.94 | 33.01 | *+3.95%* | *+3.73%* | +0.22% |
+| w8a8_tp1_c4 | coding    | p99_tpot | 42.66 | 38.61 | 41.43 | -2.87% | **-9.48%** | *+7.30%* |
+| w8a8_tp4_c1 | synthetic | tput | 63.95 | 57.04 | 57.18 | *-10.58%* | *-10.80%* | +0.25% |
 | w8a8_tp4_c1 | synthetic | mean_ttft | 165.10 | 165.79 | 164.19 | -0.55% | +0.41% | -0.96% |
 | w8a8_tp4_c1 | synthetic | p99_ttft | 166.57 | 167.80 | 167.07 | +0.30% | +0.74% | -0.43% |
-| w8a8_tp4_c1 | synthetic | mean_tpot | 15.05 | 16.95 | 16.91 | _+12.37%_ | _+12.61%_ | -0.22% |
-| w8a8_tp4_c1 | synthetic | p99_tpot | 15.08 | 16.96 | 16.92 | _+12.23%_ | _+12.53%_ | -0.26% |
-| w8a8_tp4_c1 | coding    | tput | 60.98 | 54.69 | 54.82 | _-10.11%_ | _-10.32%_ | +0.24% |
+| w8a8_tp4_c1 | synthetic | mean_tpot | 15.05 | 16.95 | 16.91 | *+12.37%* | *+12.61%* | -0.22% |
+| w8a8_tp4_c1 | synthetic | p99_tpot | 15.08 | 16.96 | 16.92 | *+12.23%* | *+12.53%* | -0.26% |
+| w8a8_tp4_c1 | coding    | tput | 60.98 | 54.69 | 54.82 | *-10.11%* | *-10.32%* | +0.24% |
 | w8a8_tp4_c1 | coding    | mean_ttft | 132.13 | 131.41 | 130.46 | -1.27% | -0.54% | -0.73% |
 | w8a8_tp4_c1 | coding    | p99_ttft | 494.09 | 461.20 | 460.94 | **-6.71%** | **-6.66%** | -0.05% |
-| w8a8_tp4_c1 | coding    | mean_tpot | 15.86 | 17.76 | 17.72 | _+11.72%_ | _+11.97%_ | -0.22% |
-| w8a8_tp4_c1 | coding    | p99_tpot | 24.00 | 25.89 | 25.85 | _+7.73%_ | _+7.89%_ | -0.15% |
-| w8a8_tp4_c2 | synthetic | tput | 125.30 | 113.56 | 113.08 | _-9.75%_ | _-9.37%_ | -0.43% |
+| w8a8_tp4_c1 | coding    | mean_tpot | 15.86 | 17.76 | 17.72 | *+11.72%* | *+11.97%* | -0.22% |
+| w8a8_tp4_c1 | coding    | p99_tpot | 24.00 | 25.89 | 25.85 | *+7.73%* | *+7.89%* | -0.15% |
+| w8a8_tp4_c2 | synthetic | tput | 125.30 | 113.56 | 113.08 | *-9.75%* | *-9.37%* | -0.43% |
 | w8a8_tp4_c2 | synthetic | mean_ttft | 137.05 | 135.98 | 135.99 | -0.77% | -0.78% | +0.01% |
 | w8a8_tp4_c2 | synthetic | p99_ttft | 165.91 | 162.57 | 163.75 | -1.30% | -2.02% | +0.73% |
-| w8a8_tp4_c2 | synthetic | mean_tpot | 15.49 | 17.15 | 17.22 | _+11.21%_ | _+10.72%_ | +0.44% |
-| w8a8_tp4_c2 | synthetic | p99_tpot | 15.59 | 17.23 | 17.32 | _+11.10%_ | _+10.57%_ | +0.48% |
-| w8a8_tp4_c2 | coding    | tput | 110.08 | 100.13 | 101.14 | _-8.13%_ | _-9.04%_ | +1.01% |
-| w8a8_tp4_c2 | coding    | mean_ttft | 116.15 | 118.08 | 119.55 | _+2.93%_ | _+1.66%_ | _+1.25%_ |
-| w8a8_tp4_c2 | coding    | p99_ttft | 156.93 | 153.96 | 159.80 | _+1.83%_ | -1.89% | _+3.80%_ |
-| w8a8_tp4_c2 | coding    | mean_tpot | 17.70 | 19.38 | 19.38 | _+9.52%_ | _+9.51%_ | +0.01% |
-| w8a8_tp4_c2 | coding    | p99_tpot | 24.27 | 26.20 | 26.26 | _+8.20%_ | _+7.92%_ | +0.25% |
-| w8a8_tp4_c4 | synthetic | tput | 247.74 | 224.58 | 223.82 | _-9.66%_ | _-9.35%_ | -0.34% |
+| w8a8_tp4_c2 | synthetic | mean_tpot | 15.49 | 17.15 | 17.22 | *+11.21%* | *+10.72%* | +0.44% |
+| w8a8_tp4_c2 | synthetic | p99_tpot | 15.59 | 17.23 | 17.32 | *+11.10%* | *+10.57%* | +0.48% |
+| w8a8_tp4_c2 | coding    | tput | 110.08 | 100.13 | 101.14 | *-8.13%* | *-9.04%* | +1.01% |
+| w8a8_tp4_c2 | coding    | mean_ttft | 116.15 | 118.08 | 119.55 | *+2.93%* | *+1.66%* | *+1.25%* |
+| w8a8_tp4_c2 | coding    | p99_ttft | 156.93 | 153.96 | 159.80 | *+1.83%* | -1.89% | *+3.80%* |
+| w8a8_tp4_c2 | coding    | mean_tpot | 17.70 | 19.38 | 19.38 | *+9.52%* | *+9.51%* | +0.01% |
+| w8a8_tp4_c2 | coding    | p99_tpot | 24.27 | 26.20 | 26.26 | *+8.20%* | *+7.92%* | +0.25% |
+| w8a8_tp4_c4 | synthetic | tput | 247.74 | 224.58 | 223.82 | *-9.66%* | *-9.35%* | -0.34% |
 | w8a8_tp4_c4 | synthetic | mean_ttft | 199.47 | 194.82 | 194.65 | -2.41% | -2.33% | -0.09% |
 | w8a8_tp4_c4 | synthetic | p99_ttft | 249.35 | 230.98 | 228.98 | **-8.17%** | **-7.37%** | -0.86% |
-| w8a8_tp4_c4 | synthetic | mean_tpot | 15.43 | 17.11 | 17.18 | _+11.35%_ | _+10.95%_ | +0.36% |
-| w8a8_tp4_c4 | synthetic | p99_tpot | 15.76 | 17.43 | 17.49 | _+10.94%_ | _+10.56%_ | +0.34% |
-| w8a8_tp4_c4 | coding    | tput | 196.29 | 181.94 | 181.29 | _-7.64%_ | _-7.31%_ | -0.36% |
-| w8a8_tp4_c4 | coding    | mean_ttft | 124.39 | 121.66 | 124.22 | -0.13% | -2.19% | _+2.10%_ |
+| w8a8_tp4_c4 | synthetic | mean_tpot | 15.43 | 17.11 | 17.18 | *+11.35%* | *+10.95%* | +0.36% |
+| w8a8_tp4_c4 | synthetic | p99_tpot | 15.76 | 17.43 | 17.49 | *+10.94%* | *+10.56%* | +0.34% |
+| w8a8_tp4_c4 | coding    | tput | 196.29 | 181.94 | 181.29 | *-7.64%* | *-7.31%* | -0.36% |
+| w8a8_tp4_c4 | coding    | mean_ttft | 124.39 | 121.66 | 124.22 | -0.13% | -2.19% | *+2.10%* |
 | w8a8_tp4_c4 | coding    | p99_ttft | 208.17 | 193.70 | 195.01 | **-6.32%** | **-6.95%** | +0.68% |
-| w8a8_tp4_c4 | coding    | mean_tpot | 19.70 | 21.49 | 21.42 | _+8.74%_ | _+9.09%_ | -0.32% |
-| w8a8_tp4_c4 | coding    | p99_tpot | 24.87 | 26.65 | 26.55 | _+6.75%_ | _+7.15%_ | -0.37% |
+| w8a8_tp4_c4 | coding    | mean_tpot | 19.70 | 21.49 | 21.42 | *+8.74%* | *+9.09%* | -0.32% |
+| w8a8_tp4_c4 | coding    | p99_tpot | 24.87 | 26.65 | 26.55 | *+6.75%* | *+7.15%* | -0.37% |
 
 (Aggregator: `scripts/mi100/aggregate_m2_threeway.py`; raw cells under
 `/root/bench-int8-w4a16/{baseline,m1-rebaseline,m2}/`. The `request_throughput`
@@ -267,8 +269,8 @@ metric is omitted from this table for compactness — it tracks `tput` 1:1.)
    improvements on TP=1 cells (-9% to -14% mean and p99 TTFT) and
    regressions on TPOT/throughput (+4% to +12%). This was the
    "improvement" we previously claimed for M2.
-2. **Δ M1→M1-rebaseline (the lib-swap column)** is _virtually
-   identical_ to Δ M1→M2 across every metric. **The change in `libhipblaslt.so`
+2. **Δ M1→M1-rebaseline (the lib-swap column)** is *virtually
+   identical* to Δ M1→M2 across every metric. **The change in `libhipblaslt.so`
    alone (system → M2 build) accounts for nearly all of the apparent
    M2 win.** TP=4 in particular shows a uniform -7% to -10% throughput
    regression and +7% to +12% TPOT regression that has nothing to do
@@ -369,7 +371,7 @@ unaffected. **Δ ≤ +1% gate PASSES.** Evidence:
 
 ## Triton fallback (VAL-TENSILE-008 evidence)
 
-```
+```text
 $ scripts/mi100/run_triton_fallback_smoke.sh
 [fallback] VLLM_DISABLE_HIPBLASLT=1
 [fallback] LD_LIBRARY_PATH=/opt/rocm/core-7.12/lib
@@ -385,7 +387,7 @@ the Triton fallback is intact.
 
 ## Numerical correctness (VAL-TENSILE-005)
 
-```
+```text
 $ pytest tests/kernels/quantization/test_hipblaslt_int8_correctness.py -v
   test_hipblaslt_matches_reference[512-4096-12288]      PASSED
   test_hipblaslt_matches_reference[512-24576-4096]      PASSED
@@ -406,7 +408,7 @@ INT32-equivalent precision (max product ~12.5M < 2^24).
 
 ## Dispatch routing (VAL-TENSILE-004)
 
-```
+```text
 $ pytest tests/kernels/quantization/test_mi100_w8a8_dispatch.py -v
 test_supports_returns_true_for_listed_shape           PASSED
 test_supports_returns_false_for_unknown_shape         PASSED
@@ -434,6 +436,7 @@ resume because the *committed* logic YAMLs are reproducible (the
 *selection* is not).
 
 Mitigation paths (deferred to `m2-repro-pin`):
+
 - Pin GPU clocks via `rocm-smi --setperflevel high` + manual SCLK lock.
 - Larger Tensile `BenchmarkRepeats` count to reduce variance.
 - Monte-Carlo agreement instead of single-winner — pick the kernel

--- a/docs/experiments/BENCH_INT8_W4A16_M3.md
+++ b/docs/experiments/BENCH_INT8_W4A16_M3.md
@@ -21,7 +21,7 @@ Companion to `BENCH_INT8_W4A16_M2.md`. M3 lands the custom Triton W8A8 + W4A16 k
 
 ## Reproduction
 
-```
+```text
 # Autotune configs already in vllm/model_executor/kernels/configs/gfx908/
 scripts/mi100/run_grid.sh m3-w8a8-autotune w8a8_
 scripts/mi100/run_grid.sh m3-w8a8-heuristic w8a8_
@@ -31,8 +31,8 @@ scripts/mi100/run_grid.sh m3-w4a16-generic w4a16_
 
 **Triage levers if M3 regresses:**
 
-- W8A8: `VLLM_MI100_DISABLE_AUTOTUNE_CONFIG=1` reverts to the heuristic fallback path.
-- W4A16: `VLLM_DISABLE_MI100_W4A16=1` reverts to the generic Triton W4A16 path.
+* W8A8: `VLLM_MI100_DISABLE_AUTOTUNE_CONFIG=1` reverts to the heuristic fallback path.
+* W4A16: `VLLM_DISABLE_MI100_W4A16=1` reverts to the generic Triton W4A16 path.
 
 ## W8A8: M3-autotune vs M1-rebaseline vs M3-heuristic
 
@@ -208,14 +208,13 @@ Two-way M3 comparison: M3 with the new `mi100_w4a16` Triton kernel (autotune con
 
 ## Headline
 
-- W8A8 M3-autotune-vs-M1rb: 1 metric(s) ≥ 3% gain; 20 metric(s) regress > 5%.
-- W4A16 mi100-vs-generic: 5 metric(s) ≥ 3% gain.
+* W8A8 M3-autotune-vs-M1rb: 1 metric(s) ≥ 3% gain; 20 metric(s) regress > 5%.
+* W4A16 mi100-vs-generic: 5 metric(s) ≥ 3% gain.
 
 ## Files
 
-- W8A8 autotune cells: `/root/bench-int8-w4a16/m3/w8a8/autotune/{synthetic,coding}/`
-- W8A8 heuristic cells: `/root/bench-int8-w4a16/m3/w8a8/heuristic/{synthetic,coding}/`
-- W4A16 mi100 cells: `/root/bench-int8-w4a16/m3/w4a16/mi100/{synthetic,coding}/`
-- W4A16 generic cells: `/root/bench-int8-w4a16/m3/w4a16/generic/{synthetic,coding}/`
-- Pareto exceptions: `/root/bench-int8-w4a16/m3/pareto_exceptions.md`
-
+* W8A8 autotune cells: `/root/bench-int8-w4a16/m3/w8a8/autotune/{synthetic,coding}/`
+* W8A8 heuristic cells: `/root/bench-int8-w4a16/m3/w8a8/heuristic/{synthetic,coding}/`
+* W4A16 mi100 cells: `/root/bench-int8-w4a16/m3/w4a16/mi100/{synthetic,coding}/`
+* W4A16 generic cells: `/root/bench-int8-w4a16/m3/w4a16/generic/{synthetic,coding}/`
+* Pareto exceptions: `/root/bench-int8-w4a16/m3/pareto_exceptions.md`

--- a/docs/experiments/BENCH_M4_CK.md
+++ b/docs/experiments/BENCH_M4_CK.md
@@ -412,7 +412,7 @@ with any cell that lands below 1.0× M3 best.
 
 ## Files added / modified
 
-```
+```text
 NEW  csrc/quantization/w8a8/int8/ck/CMakeLists.txt
 NEW  csrc/quantization/w8a8/int8/ck/ck_int8_gemm.h
 NEW  csrc/quantization/w8a8/int8/ck/ck_int8_gemm_dispatch.hip
@@ -624,7 +624,7 @@ default for these shapes):
 | `w8a8_tp1_c1_coding` | +2.18% | -29.32% | **-13.56%** | TP=1, prefill-heavy (M ∈ [16, 4096]); CK registered, dispatched, wins on every latency metric. |
 | `w8a8_tp1_c4_coding` | **+4.11%** | **-21.58%** | **-3.50%** | Headline coding-prefill cell: highest CK throughput uplift **and** p99_ttft improves vs M3-best (CK=1378 ms vs M3-heur=1428 ms). Mean prefill latency drops by 21.58%. |
 | `w8a8_tp4_c1_coding` | +2.14% | **-18.75%** | **-15.49%** | TP=4, c=1, prefill-heavy. Despite the TP=4 sharded shapes not being CK-registered, the unsharded prefill on the column-parallel out_proj path picks CK and wins on latency. |
-| `w8a8_tp4_c4_coding` | **+5.54%** | +5.06% | _+16.71%_ | Best CK lever on TP=4 on the throughput axis (+5.54% tput, +8.40% req_tput, -3.42% mean_tpot vs M3-best). Mean and p99 TTFT regress vs the M3-heur low-water mark — p99_ttft is the documented exception above (suspected `_get_tp_rank` dispatcher overhead). |
+| `w8a8_tp4_c4_coding` | **+5.54%** | +5.06% | *+16.71%* | Best CK lever on TP=4 on the throughput axis (+5.54% tput, +8.40% req_tput, -3.42% mean_tpot vs M3-best). Mean and p99 TTFT regress vs the M3-heur low-water mark — p99_ttft is the documented exception above (suspected `_get_tp_rank` dispatcher overhead). |
 
 Net per-cell `tput` winners across the 12 cells (post-rerun): 4× M4-CK,
 5× M4-noCk, 3× M3-heur. The CK wins concentrate on the prefill-heavy

--- a/docs/experiments/BENCH_M5_ISA.md
+++ b/docs/experiments/BENCH_M5_ISA.md
@@ -238,9 +238,9 @@ current `vllm/_rocm_C.abi3.so` contains zero `v_smfmac_*` and zero
 ## Evidence pointers
 
 - M1 omniperf-equivalent roofline:
-  - `/root/bench-int8-w4a16/baseline/profile/omniperf/omniperf_summary_w8a8.json`
-  - `/root/bench-int8-w4a16/baseline/profile/omniperf/omniperf_summary_w4a16.json`
-  - `/root/bench-int8-w4a16/baseline/profile/omniperf/pmc_1/`, `pmc_2/`
+    - `/root/bench-int8-w4a16/baseline/profile/omniperf/omniperf_summary_w8a8.json`
+    - `/root/bench-int8-w4a16/baseline/profile/omniperf/omniperf_summary_w4a16.json`
+    - `/root/bench-int8-w4a16/baseline/profile/omniperf/pmc_1/`, `pmc_2/`
 - M1 hot-shape catalog: `/root/bench-int8-w4a16/baseline/hot_shapes.json`
 - M4 four-way grid + per-cell exceptions: `BENCH_M4_CK.md`
 - M4 result JSONs: `/root/bench-int8-w4a16/m4/w8a8/{ck,noCk}/{synthetic,coding}/`

--- a/docs/experiments/BENCH_MOE_HANDKERNEL_GEMV_2026_06.md
+++ b/docs/experiments/BENCH_MOE_HANDKERNEL_GEMV_2026_06.md
@@ -5,6 +5,7 @@ Follow-up to `RESEARCH_MOE_HANDKERNEL_FEASIBILITY_2026_06.md`. We ran the #58
 loop to completion **including integration**, which is where the story turns.
 
 **Two-line verdict:**
+
 1. **Microbench: WIN.** A `tl.dot`/MFMA kernel with split-K beats the in-tree
    `fused_moe_kernel_gptq_awq` at M=1 decode — 1.63× gate_up, 1.22× down, **1.51×
    combined GEMM** (44.7 → 29.6 µs/layer), head-to-head, same CUDA-graph harness,
@@ -55,10 +56,12 @@ same shapes, same harness, full 10-active-expert M=1 decode:
 ## Why it wins — the occupancy fix, confirmed by profile
 
 rocprof, hand v3 (gate_up) vs in-tree:
-```
+
+```text
 in-tree : grid=20480  -> 80  workgroups, VGPR=108, dur=54 µs (rocprof) / 34 µs (graph)
 hand v3 : grid=81920  -> 320 workgroups, VGPR=76,  dur=39 µs (rocprof) / 21 µs (graph)
 ```
+
 Split-K does exactly what the diagnosis predicted: **80 → 320 workgroups** (fills
 the previously-idle ⅓ of CUs) and **VGPR 108 → 76** (room for more waves/CU),
 *while keeping MFMA*. The kernel is still ~8× above the HBM roofline (M=1 can't
@@ -114,6 +117,7 @@ time) remain the larger untouched pool, addressable only by fusion.
   produced the table above).
 
 ### The deeper lesson: isolated wins must clear the integration tax
+
 The 1.5× isolated-GEMM result was real, but an isolated microbench omits three
 real costs that erased it: the **workspace-zeroing launch** the atomic needs,
 the **unaffected sibling GEMM** (down-proj), and the **M≥2 regime** where the

--- a/docs/experiments/BENCH_MOE_RETUNE_FROM_SCRATCH_2026_06.md
+++ b/docs/experiments/BENCH_MOE_RETUNE_FROM_SCRATCH_2026_06.md
@@ -12,11 +12,14 @@ meaningful tuning headroom for the int4_w4a16 MoE kernel at decode sizes.**
 ### 1. The stock tuner crashes ~50 configs in (uncatchable C++ abort)
 
 `benchmarks/kernels/benchmark_moe.py` dies mid-search on this stack:
-```
+
+```text
 at::cuda::CUDAGraph::~CUDAGraph() -> c10_cuda_check_implementation() -> abort()
 ray.exceptions.ActorDiedError: ... Worker exit type: SYSTEM_ERROR
 ```
+
 Ruled out, by experiment:
+
 - **Not a single bad config** — every individual tile (incl. `BLOCK_K=256`,
   `num_warps=1`) runs fine in isolation (~450 us).
 - **Not OOM, not the device-guard, not the cache-clear interval** — the crash
@@ -31,6 +34,7 @@ Ruled out, by experiment:
 
 Built `/root/fp16-bench/moe_tune_isolated.py`: a parent orchestrator that tunes
 each batch size in short-lived **worker subprocesses**, each of which
+
 - times configs eagerly (new `VLLM_MOE_TUNE_NO_CUDAGRAPH=1` path added to
   `benchmark_moe.py` so faults are catchable `RuntimeError`s, not graph-dtor
   aborts),
@@ -61,6 +65,7 @@ within a few us across hundreds of tile shapes).
 
 The `int4_w4a16` decode kernel at small M is **fixed-overhead-bound, not
 tile-efficiency-bound**:
+
 - 512 experts with top-10 routing → the gather/scatter + per-expert dispatch and
   the wna16 dequant path dominate the ~450 us, and those costs are independent
   of `BLOCK_SIZE_*` / `num_warps`.

--- a/docs/experiments/BENCH_MOE_TUNED_CONFIG_NEGATIVE_2026_06.md
+++ b/docs/experiments/BENCH_MOE_TUNED_CONFIG_NEGATIVE_2026_06.md
@@ -10,7 +10,7 @@ at the MoE kernel, not compute.
 
 Both MoE servers (fp16 35B and W4A16 512e) logged, every run:
 
-```
+```text
 WARNING fused_moe.py:1091 Using default MoE config. Performance might be
 sub-optimal! Config file not found at .../configs/
 E=512,N=128,device_name=AMD_Instinct_MI100,dtype=int4_w4a16.json
@@ -101,6 +101,7 @@ register-spills / occupancy-starves on our **Triton 3.5.1 / ROCm 7.12** stack.
    are Triton/ROCm-version-sensitive and must be re-validated per stack.
 
 ## Reproduction
+
 ```bash
 /root/fp16-bench/run_qmoe_config_ab.sh   # toggles the config file, default vs tuned
 # results: /root/fp16-bench/qmoe_config_ab/{default,tuned}_tp4_c{1,2,4}/raw.json

--- a/docs/experiments/BENCH_W4A16_AB_VERDICT.md
+++ b/docs/experiments/BENCH_W4A16_AB_VERDICT.md
@@ -23,7 +23,7 @@
 ## (a) Premise — why the W4A16 codepath is expected to be inert
 
 PR #38 ships three fused activation-quant epilogues (issues #26 / #33 /
-#11). None of the three is registered on the W4A16 dispatch path:
+\#11). None of the three is registered on the W4A16 dispatch path
 
 | Fusion | Quant | Wire-in site | Reads W4A16? |
 |---|---|---|---|

--- a/docs/experiments/ISSUE_DRAFT_MOE_ROUTING_GLUE_FUSION_GFX908.md
+++ b/docs/experiments/ISSUE_DRAFT_MOE_ROUTING_GLUE_FUSION_GFX908.md
@@ -125,8 +125,7 @@ touching the GEMM tiles — and only if a quick prototype clears a few % net.
 ## References in-repo
 
 - `PERF_GFX908.md` — hardware model, the loop, the decode triage (§6).
-- `BENCH_MOE_HANDKERNEL_GEMV_2026_06.md` — the GEMM split-K story (microbench win
-    - integration reality).
+- `BENCH_MOE_HANDKERNEL_GEMV_2026_06.md` — the GEMM split-K story (microbench win + integration reality).
 - `bench_scripts/moe_int4_gemv_bench.py`, `bench_scripts/decode_profile.py` —
   microbench + whole-model profiler templates.
 

--- a/docs/experiments/ISSUE_DRAFT_MOE_ROUTING_GLUE_FUSION_GFX908.md
+++ b/docs/experiments/ISSUE_DRAFT_MOE_ROUTING_GLUE_FUSION_GFX908.md
@@ -27,6 +27,7 @@ actually matter), per layer at M=1:
 | **total glue** | **~21** | **34%** | **~5.4% TPOT (unreachable)** | — |
 
 Key facts that sink the value case:
+
 - **act_and_mul can't sit in the gate_up GEMM epilogue cheaply.** `silu_and_mul`
   computes `out[i] = silu(c1[i]) * c1[i+N]`; the gate half (cols 0..N) and up half
   (cols N..2N) live in *different* N-tiles, so a program computing one tile lacks
@@ -85,6 +86,7 @@ expected value / risk:
    down-GEMM epilogue / store, avoiding a separate reduce launch.
 
 Each fusion must:
+
 - Keep a non-gfx908 fallback (gate on `on_mi100()` or make the fused kernel arch-
   neutral and just default-on if it's a pure win everywhere).
 - Pass correctness vs the current multi-kernel path (rel-err ≤ 1e-3) across M =
@@ -97,6 +99,7 @@ Each fusion must:
 The sibling split-K GEMM effort got a **1.5× isolated-GEMM microbench win that
 did NOT survive integration** (net ~1.0× at M=1, regressions at M≥2). Root
 causes that will also threaten this work:
+
 - **Launch overhead is the enemy at M=1.** Any *added* kernel (e.g. a separate
   zeroing or reduction pass) costs a fixed ~7 µs launch that can erase the win.
   Fusion is attractive precisely because it *removes* launches — but do not
@@ -120,9 +123,10 @@ align+count(+act) kernel** that removes multiple launches at once *without*
 touching the GEMM tiles — and only if a quick prototype clears a few % net.
 
 ## References in-repo
+
 - `PERF_GFX908.md` — hardware model, the loop, the decode triage (§6).
 - `BENCH_MOE_HANDKERNEL_GEMV_2026_06.md` — the GEMM split-K story (microbench win
-  + integration reality).
+    - integration reality).
 - `bench_scripts/moe_int4_gemv_bench.py`, `bench_scripts/decode_profile.py` —
   microbench + whole-model profiler templates.
 

--- a/docs/experiments/PERF_GFX908.md
+++ b/docs/experiments/PERF_GFX908.md
@@ -153,6 +153,7 @@ CUDA-graph timing + roofline + occupancy).
 | 2026-06 | **Hand int4 MoE GEMM, MFMA + split-K** (keep `tl.dot`, fix occupancy) | **microbench 1.51× WIN** isolated GEMM (1.63× gate_up, 1.22× down), rel-err <4e-4; 80→320 WG, VGPR 108→76 — **BUT integration NEGATIVE: ~1.0× at M=1, 0.67–0.74× regress at M=4–8** (atomic needs `zero_()` ~7 µs launch ≈ cancels saving; baseline already CU-filled at M≥2). **Reverted, not shipped.** | `BENCH_MOE_HANDKERNEL_GEMV_*` + `RESEARCH_MOE_HANDKERNEL_FEASIBILITY_*` |
 
 ### Distilled rules from the ledger
+
 - **torch.compile is the biggest realized win on gfx908** (~10% on MoE serving).
   Enable for MoE; concurrency-gate for dense.
 - **Don't tile-tune the int4 MoE decode GEMM** (±2% = noise). Split-K *does* win
@@ -175,6 +176,7 @@ CUDA-graph timing + roofline + occupancy).
   was not.
 
 ### Open / unexplored (candidate next work)
+
 - **MoE routing-glue fusion — DE-PRIORITIZED (2026-06).** The "~37% glue" was an
   *eager* rocprof inflated by launch gaps. **Graph-timed** (real serving), per
   layer at M=1: GEMM 43.7 µs (66%), `moe_align` 7.2 µs (11%), `reduce` 4.9 µs
@@ -231,6 +233,7 @@ generic `tl.dot` tile kernel) and so launched just 80 workgroups.
    well-occupied and either memory-bound or trivially small; no roofline gap.
 
 ### Triage rule (add to the loop)
+>
 > Before hand-building any decode kernel, check whether it already routes through
 > **`wvSplitK`/`wvSplitKQ`** (dense GEMM) or a well-occupied attention kernel.
 > If it does, it's already CU-filled — stop. The hand-kernel opportunity on
@@ -243,6 +246,7 @@ validation bug in the in-process `LLM()` API on this stack — use a
 Llama-family model for the dense triage, or profile Qwen via the server path.)
 
 ### Standing conclusion (2026-06)
+
 The MoE decode well is **mostly dry** at the kernel level: the int4 expert GEMM
 is already occupancy-optimal (split-K wins isolated but not integrated), the
 dense paths already use `wvSplitK`, and the routing/glue is ~34% of MoE GPU time

--- a/docs/experiments/RESEARCH_FP16_OPTS_AND_QUANT_FIT.md
+++ b/docs/experiments/RESEARCH_FP16_OPTS_AND_QUANT_FIT.md
@@ -1,6 +1,7 @@
 # Research: FP16-path optimizations + weight-only quant that fits the FP16 path (gfx908/MI100)
 
 Companion to `BENCH_FP16_VS_QUANT_2026_06.md`. Two questions:
+
 1. What can still speed up the **FP16 decode path** on gfx908?
 2. What quant format keeps the **fast FP16 compute path** while shrinking weights so we can fit **larger models**?
 
@@ -36,6 +37,7 @@ Ranked by expected payoff on gfx908. "Shipping" = already in our production FP16
 config (`/root/launch-vllm-optimized.sh`).
 
 ### 1.1 torch.compile + PIECEWISE graphs — **highest-upside, contested**
+
 - **Status:** our `rocm.py` *disables* torch.compile and forces
   `FULL_DECODE_ONLY` on MI100 (`vllm/platforms/rocm.py:745-799`), citing a
   −9.7% c=8 regression on REAP-172B-AWQ and Inductor fusions being unavailable
@@ -53,6 +55,7 @@ config (`/root/launch-vllm-optimized.sh`).
   experiment with the biggest potential upside; gated behind an existing flag.
 
 ### 1.2 AITER Triton RoPE/attention — **untested in our stack, shipping in community's**
+
 - **Status:** `VLLM_ROCM_USE_AITER` is read by our `rocm.py` but the FP16 launch
   script does **not** set it. Community runs `VLLM_ROCM_USE_AITER=1` by default
   on gfx908 (Triton RoPE + attention; CK/FP8/UA auto-disabled).
@@ -63,11 +66,13 @@ config (`/root/launch-vllm-optimized.sh`).
   only. Low risk; measure decode delta.
 
 ### 1.3 Attention backend explicit pin (`TRITON_ATTN`)
+
 - Community explicitly pins `--attention-backend TRITON_ATTN` as the stable
   gfx908 choice. We rely on auto-selection. Worth pinning for reproducibility +
   to avoid any UA/CK auto-dispatch surprise. Near-zero risk.
 
 ### 1.4 Already shipping (no further action, documented for completeness)
+
 - Skinny GEMM (`__gfx908__` guard) — biggest FP16 win after CUDA graphs.
 - Adaptive Flash-Decoding split-K — sweep already confirmed optimal
   (`BENCH_HBM_FA_TUNING.md`).
@@ -75,6 +80,7 @@ config (`/root/launch-vllm-optimized.sh`).
 - Triton tile tuning, block-size 32, custom all-reduce + FULL_DECODE_ONLY graph.
 
 ### 1.5 Low-yield / proven-negative (do not re-attempt)
+
 - **Marlin-style repack:** verified **−28%** on gfx908 — no `cp.async`, decode is
   issue-bound (`BENCH_W4A16_MARLIN_REPACK.md`). Settled.
 - **Hand-ISA GEMM:** declined, HBM/issue-bound ceiling (`BENCH_M5_ISA.md`).
@@ -111,6 +117,7 @@ and 8-bit"** as their primary recommendation, with curated GPTQ providers
 
 **The biggest unexploited lever for "larger models that keep quality" is
 8-bit weight-only (W8A16 / INT8-weight GPTQ)**, which we have **not** benched:
+
 - ~2× capacity vs FP16 (10–11 GB) at near-FP16 quality (8-bit >> 4-bit fidelity).
 - Community reports **Qwen3.6-35B-A3B GPTQ-8bit** as a top performer on 4×MI100
   (1365 tok/s aggregate). Our largest tested is 9B.
@@ -130,6 +137,7 @@ same 4×MI100 hardware — these are the concrete "larger model" targets quant
 unlocks for us, and both keep the FP16 activation path.
 
 ### 2.4 MoE tuning is required for these larger models
+
 The community's `Model_Reports` note that the big wins come with **per-model
 fused-MoE configs** (e.g. `int8_w8a16` E=256/N=128 tune for 35B-8bit;
 `int4_w4a16` E=256/N=256 for 122B-4bit). We already merged gfx908 fused-MoE

--- a/docs/experiments/RESEARCH_MOE_HANDKERNEL_FEASIBILITY_2026_06.md
+++ b/docs/experiments/RESEARCH_MOE_HANDKERNEL_FEASIBILITY_2026_06.md
@@ -17,7 +17,8 @@ diagnostic half) and makes a go/no-go call **before** writing a kernel.
 
 ## Important context vs #57/#58
 
-#57's win was **gfx900 (Vega10), which has NO MFMA**: `tl.dot` at M=1 lowered to
+\#57's win was **gfx900 (Vega10), which has NO MFMA**: `tl.dot` at M=1 lowered to
+
 a padded FP32 GEMM, so a hand GEMV (no `tl.dot`) was 2–3× faster. **Our gfx908
 (MI100/CDNA1) HAS MFMA**, so that exact win does not transfer. The question is
 whether a *different* structural problem exists on gfx908.
@@ -78,6 +79,7 @@ occupancy, could plausibly approach roofline.
 ## Step 9 (done upfront) — end-to-end ceiling
 
 Honest accounting against the measured decode budget:
+
 - 48 MoE layers × ~90 us = **~4,320 us** of the **18,464 us** TPOT = **~23%** of
   decode is the MoE fused path.
 - The int4 GEMM specifically: 48 × ~57 us = ~2,740 us = **~15% of decode**.
@@ -94,11 +96,12 @@ series with real structural headroom (unlike tile-tuning, which was ±2%). But
 the difficulty and risks are substantial and must be stated:
 
 Risks / hard parts:
+
 1. **MFMA changes the game vs #57.** The win here is occupancy + split-K, not
    "avoid tl.dot." A naive GEMV may *lose* to the existing MFMA-capable kernel;
    the hand kernel must out-occupy it, which is subtle on CDNA1.
 2. **Correctness surface is large.** Must match the exact AWQ/gptq int4 packing
-   + group-scale + reverse-order unpack, top-k routing, and silu fusion, then
+   - group-scale + reverse-order unpack, top-k routing, and silu fusion, then
    pass rel-err ≤1e-3 vs the in-tree kernel (#58 step 4).
 3. **Integration gate.** Must dispatch only on gfx908 + M≤~8 + this expert shape,
    falling back everywhere else (#58 step 8), and the microbench win must survive
@@ -109,6 +112,7 @@ Risks / hard parts:
    eventual config sweep.
 
 Recommended next steps if pursued (in #58 order):
+
 1. Standalone Triton int4 MoE-GEMV microbench at the real shape; establish
    correctness vs `fused_moe_kernel_gptq_awq` first.
 2. Structural iteration: split-K across CUs for the M=1 active-expert GEMVs;
@@ -118,6 +122,7 @@ Recommended next steps if pursued (in #58 order):
    and re-run the decode A/B.
 
 ## Reproduction
+
 - rocprof breakdown: `rocprofv3 --kernel-trace` on `/tmp/moe_prof.py` (real
   shape), parsed for per-kernel duration + launch geometry.
 - E-scaling + occupancy probes: inline scripts in the session log (CUDA-graph

--- a/docs/experiments/SYNC_CONFLICTS.md
+++ b/docs/experiments/SYNC_CONFLICTS.md
@@ -4,7 +4,8 @@
 **Sync branch:** `upstream-sync-2026-05-28`
 **Base (ours):** `3d9de886d` (`origin/mi100-fixes` HEAD at mission start)
 **Theirs:** `upstream/main` = `5b115bb8a33d72820075450ecefcd292607bfe57`
-  - "[Attention][AMD] Standardize kv layout to blocks first for AMD (#43660)"
+
+- "[Attention][AMD] Standardize kv layout to blocks first for AMD (#43660)"
 **Commits behind upstream/main:** 770
 
 ## Dry-run merge command
@@ -150,5 +151,3 @@ The following upstream feature areas arrive **passively** via the merge and are 
 | `vllm/model_executor/kernels/configs/gfx908/*.json` (26 files) | **ours, unchanged** | M1-F2 pinned Triton autotune JSONs byte-identical to pre-sync-baseline. |
 | `docker/entrypoints/test_vllm_nonroot_entrypoint.sh` (M1-F5 targeted fix) | **theirs + symmetric root-guard added** | upstream's case3 (unwritable HOME under root) fails identically to the case7 DAC-override condition; applied symmetric root-skip guard so the hook passes under our root build env without weakening non-root deployment coverage. |
 | All other auto-merged files | per audit table above | clean; MI100 marker counts unchanged vs baseline. |
-
-

--- a/docs/turboquant-production-recommendation.md
+++ b/docs/turboquant-production-recommendation.md
@@ -23,6 +23,7 @@ Use the optimized baseline without TurboQuant:
 ```
 
 **Configuration:**
+
 - FULL_DECODE_ONLY HIP graph mode
 - Prefix caching enabled
 - Tensor parallelism: 4
@@ -84,44 +85,58 @@ TurboQuant may provide benefits under these conditions:
 ## Validation Contract Evidence
 
 ### VAL-BENCH-001: Synthetic Benchmark TQ Capture Only vs Baseline
-**Status: PASS**
+
+Status: **PASS**
+
 - Benchmarks completed at c=1,2,4
 - TQ capture_only shows 3.5-11% throughput regression
 - Files: `tq_capture_only_graph_synthetic_c{1,2,4}_20260330.json`
 
 ### VAL-BENCH-002: Synthetic Benchmark TQ Hybrid vs Baseline
-**Status: PASS**
+
+Status: **PASS**
+
 - Benchmarks completed at c=1,2,4
 - TQ hybrid shows 6-11% throughput regression
 - Files: `tq_hybrid_graph_synthetic_c{1,2,4}_20260330.json`
 
 ### VAL-BENCH-003: Coding Agent Benchmark TQ Hybrid
-**Status: PASS**
+
+Status: **PASS**
+
 - Benchmarks completed at c=1,2,4
 - TQ hybrid shows 42-49% aggregate throughput regression
 - Files: `tq_hybrid_graph_coding_c1.json`, `tq_hybrid_coding_c{2,4}_20260330.json`
 
 ### VAL-BENCH-004: VRAM Usage Comparison
-**Status: PASS**
+
+Status: **PASS**
+
 - Baseline: 93.3% VRAM
 - TQ Hybrid: 82.5% VRAM
 - Savings: 10.8%
 - Files: `baseline_optimized_vram_20260330.json`, `tq_hybrid_graph_vram_20260331_083315.json`
 
 ### VAL-BENCH-005: Comprehensive Comparison Report
-**Status: PASS**
+
+Status: **PASS**
+
 - Report file: `tq-comparison-report.json`
 - Contains throughput, TPOT, TTFT, VRAM for all configs
 - Percentage changes documented
 
 ### VAL-CROSS-002: TQ + Prefix Caching Interaction
-**Status: PASS**
+
+Status: **PASS**
+
 - Prefix caching still provides TTFT reduction with TQ active
 - Existing test: `prefix_caching_test.json` shows 99.1% TTFT reduction
 - Both systems work together correctly
 
 ### VAL-CROSS-003: Production Recommendation
-**Status: PASS**
+
+Status: **PASS**
+
 - This document provides data-backed recommendation
 - Recommendation: Do NOT enable TQ for Qwen3.5-9B on MI100
 - Production config documented: `/root/launch-vllm-optimized.sh`

--- a/examples/deployment/quantize_w8a8_mi100.py
+++ b/examples/deployment/quantize_w8a8_mi100.py
@@ -97,8 +97,9 @@ def main():
         print("It must live in a DEDICATED venv (not the vLLM serving env),")
         print("because it pins transformers<=4.57 / compressed-tensors==0.16:")
         print("  uv venv --python 3.12 /opt/llmcompressor-env")
-        print("  uv pip install --python /opt/llmcompressor-env/bin/python "
-              "llmcompressor")
+        print(
+            "  uv pip install --python /opt/llmcompressor-env/bin/python llmcompressor"
+        )
         print("Then run this script with /opt/llmcompressor-env/bin/python")
         sys.exit(1)
 

--- a/examples/disaggregated/p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
+++ b/examples/disaggregated/p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
@@ -46,7 +46,7 @@ def _listen_for_register(poller, router_socket):
                 global prefill_instances
                 global prefill_cv
                 with prefill_cv:
-                    node = prefill_instances.get(data["http_address"], None)
+                    node = prefill_instances.get(data["http_address"])
                     prefill_instances[data["http_address"]] = (
                         data["zmq_address"],
                         time.time() + DEFAULT_PING_SECONDS,
@@ -57,7 +57,7 @@ def _listen_for_register(poller, router_socket):
                 global decode_instances
                 global decode_cv
                 with decode_cv:
-                    node = decode_instances.get(data["http_address"], None)
+                    node = decode_instances.get(data["http_address"])
                     decode_instances[data["http_address"]] = (
                         data["zmq_address"],
                         time.time() + DEFAULT_PING_SECONDS,

--- a/library/bench-delta/README.md
+++ b/library/bench-delta/README.md
@@ -37,5 +37,6 @@ Because zero cells exceed any threshold (max throughput regression
 is −1.12 %, max latency uplift is +0.19 %, HBM is −0.003 %), no
 per-upstream-PR bisection was triggered. The hot-file conflict
 upstream PR set referenced in `benchmark-worker` SKILL (#42095, #43660,
-#42080, #41434, #40327, #43731, #40687) all merged cleanly into the
+\#42080, #41434, #40327, #43731, #40687) all merged cleanly into the
+
 sync branch without measurable MI100 perf impact under this harness.

--- a/library/bench-delta/compute_deltas.py
+++ b/library/bench-delta/compute_deltas.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """M3-F2 per-cell delta aggregator.
 
 Compares library/bench-post-sync/ vs library/bench-baseline/ across:
@@ -19,21 +21,24 @@ Writes:
   library/bench-delta/d4-hbm-delta.json
   library/bench-delta/summary.json (top-line verdict, per-cell verdicts)
 """
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
-ROOT = Path("/home/aimeme/Desktop/vllm-gfx908/.emdash/worktrees/vllm-gfx908/emdash/loose-rats-clean-phm2k")
+ROOT = Path(
+    "/home/aimeme/Desktop/vllm-gfx908/.emdash/worktrees/vllm-gfx908/emdash/loose-rats-clean-phm2k"  # noqa: E501
+)
 BASE = ROOT / "library" / "bench-baseline"
 POST = ROOT / "library" / "bench-post-sync"
 DELT = ROOT / "library" / "bench-delta"
 DELT.mkdir(parents=True, exist_ok=True)
 
 # Thresholds
-THR_REG_PCT = -3.0       # D1, D2 throughput
-LAT_REG_PCT = +2.0       # D3 latency
-HBM_REG_PCT = +2.0       # D4 HBM bytes
+THR_REG_PCT = -3.0  # D1, D2 throughput
+LAT_REG_PCT = +2.0  # D3 latency
+HBM_REG_PCT = +2.0  # D4 HBM bytes
 
 
 def pct(post: float, base: float) -> float:
@@ -52,7 +57,7 @@ def load_grid(path: Path) -> dict:
 
 
 def aggregate_postsync_grid() -> dict:
-    """Build a post-sync grid JSON mirroring baseline schema by reading per-cell files."""
+    """Build a post-sync grid JSON mirroring baseline schema from per-cell files."""
     cells = []
     for wl in ("synthetic", "coding"):
         d = POST / "grid" / wl
@@ -93,29 +98,36 @@ def compute_grid_deltas() -> dict:
         verdict = "PASS"
         if d_tput < THR_REG_PCT:
             verdict = "REGRESSION"
-            regressions.append({
+            regressions.append(
+                {
+                    "cell": key,
+                    "metric": "output_throughput_toks_s",
+                    "baseline": b_tput,
+                    "postsync": p_tput,
+                    "delta_pct": d_tput,
+                }
+            )
+        rows.append(
+            {
                 "cell": key,
-                "metric": "output_throughput_toks_s",
-                "baseline": b_tput,
-                "postsync": p_tput,
-                "delta_pct": d_tput,
-            })
-        rows.append({
-            "cell": key,
-            "baseline_tput": b_tput,
-            "postsync_tput": p_tput,
-            "delta_tput_pct": d_tput,
-            "baseline_ttft_ms": b_ttft,
-            "postsync_ttft_ms": p_ttft,
-            "delta_ttft_pct": d_ttft,
-            "baseline_tpot_ms": b_tpot,
-            "postsync_tpot_ms": p_tpot,
-            "delta_tpot_pct": d_tpot,
-            "verdict": verdict,
-        })
-    return {"rows": rows, "regressions": regressions,
-            "threshold_pct": THR_REG_PCT,
-            "metric": "output_throughput_toks_s"}
+                "baseline_tput": b_tput,
+                "postsync_tput": p_tput,
+                "delta_tput_pct": d_tput,
+                "baseline_ttft_ms": b_ttft,
+                "postsync_ttft_ms": p_ttft,
+                "delta_ttft_pct": d_ttft,
+                "baseline_tpot_ms": b_tpot,
+                "postsync_tpot_ms": p_tpot,
+                "delta_tpot_pct": d_tpot,
+                "verdict": verdict,
+            }
+        )
+    return {
+        "rows": rows,
+        "regressions": regressions,
+        "threshold_pct": THR_REG_PCT,
+        "metric": "output_throughput_toks_s",
+    }
 
 
 def compute_d2() -> dict:
@@ -148,15 +160,27 @@ def compute_d3() -> dict:
     for k in ("avg_latency",):
         b, p = base[k], post[k]
         d = pct(p, b)
-        rows[k] = {"baseline_s": b, "postsync_s": p, "delta_pct": d,
-                   "verdict": "REGRESSION" if d > LAT_REG_PCT else "PASS"}
+        rows[k] = {
+            "baseline_s": b,
+            "postsync_s": p,
+            "delta_pct": d,
+            "verdict": "REGRESSION" if d > LAT_REG_PCT else "PASS",
+        }
     for pk in ("50", "90", "99"):
         b = base["percentiles"][pk]
         p = post["percentiles"][pk]
         d = pct(p, b)
-        rows[f"p{pk}"] = {"baseline_s": b, "postsync_s": p, "delta_pct": d,
-                          "verdict": "REGRESSION" if d > LAT_REG_PCT else "PASS"}
-    verdict = "REGRESSION" if any(r["verdict"] == "REGRESSION" for r in rows.values()) else "PASS"
+        rows[f"p{pk}"] = {
+            "baseline_s": b,
+            "postsync_s": p,
+            "delta_pct": d,
+            "verdict": "REGRESSION" if d > LAT_REG_PCT else "PASS",
+        }
+    verdict = (
+        "REGRESSION"
+        if any(r["verdict"] == "REGRESSION" for r in rows.values())
+        else "PASS"
+    )
     return {"metrics": rows, "threshold_pct": LAT_REG_PCT, "verdict": verdict}
 
 
@@ -167,14 +191,30 @@ def compute_d4() -> dict:
         return {"status": "MISSING_POST"}
     post = json.loads(post_path.read_text())
     rows = {}
-    for k in ("hbm_bytes_per_output_token", "hbm_bytes_per_total_token", "total_hbm_bytes"):
+    for k in (
+        "hbm_bytes_per_output_token",
+        "hbm_bytes_per_total_token",
+        "total_hbm_bytes",
+    ):
         b, p = base[k], post[k]
         d = pct(p, b)
-        rows[k] = {"baseline": b, "postsync": p, "delta_pct": d,
-                   "verdict": "REGRESSION" if d > HBM_REG_PCT else "PASS"}
-    verdict = "REGRESSION" if rows["hbm_bytes_per_output_token"]["verdict"] == "REGRESSION" else "PASS"
-    return {"metrics": rows, "threshold_pct": HBM_REG_PCT, "verdict": verdict,
-            "primary_metric": "hbm_bytes_per_output_token"}
+        rows[k] = {
+            "baseline": b,
+            "postsync": p,
+            "delta_pct": d,
+            "verdict": "REGRESSION" if d > HBM_REG_PCT else "PASS",
+        }
+    verdict = (
+        "REGRESSION"
+        if rows["hbm_bytes_per_output_token"]["verdict"] == "REGRESSION"
+        else "PASS"
+    )
+    return {
+        "metrics": rows,
+        "threshold_pct": HBM_REG_PCT,
+        "verdict": verdict,
+        "primary_metric": "hbm_bytes_per_output_token",
+    }
 
 
 def main() -> int:
@@ -204,6 +244,7 @@ def main() -> int:
     # regressions are mild (>= -5% throughput, <= +5% latency/HBM); FAIL otherwise.
     def is_mild_thr(p):
         return p > -5.0
+
     def is_mild_lat(p):
         return p < +5.0
 

--- a/library/bench-delta/compute_deltas.py
+++ b/library/bench-delta/compute_deltas.py
@@ -27,9 +27,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-ROOT = Path(
-    "/home/aimeme/Desktop/vllm-gfx908/.emdash/worktrees/vllm-gfx908/emdash/loose-rats-clean-phm2k"  # noqa: E501
-)
+ROOT = Path(__file__).resolve().parents[2]
 BASE = ROOT / "library" / "bench-baseline"
 POST = ROOT / "library" / "bench-post-sync"
 DELT = ROOT / "library" / "bench-delta"

--- a/library/correctness-gates.md
+++ b/library/correctness-gates.md
@@ -14,7 +14,7 @@
 > **Use `library/correctness-gates-resync.md` as the canonical post-rebuild
 > correctness-gate record for the sync PR body and the validation contract.**
 > The numbers below are kept for forensic comparison only.
-
+>
 > Surface C of the upstream-sync mission validation contract on the post-sync tip.
 > Single-GPU MI100 (gfx908), CUDA_VISIBLE_DEVICES=0. Engine and harness commands
 > captured verbatim below for reproducibility (per AGENTS.md §"Bench reproducibility").

--- a/library/env-repoint.md
+++ b/library/env-repoint.md
@@ -16,7 +16,7 @@ against the wrong code:
 
 ## Before
 
-```
+```text
 MAPPING: {'vllm': '/home/aimeme/Desktop/vllm-gfx908/.emdash/worktrees/vllm-gfx908/emdash/fuzzy-hornets-see-szfl4/vllm'}
 direct_url.json: file:///home/aimeme/.../fuzzy-hornets-see-szfl4
 
@@ -55,7 +55,7 @@ vllm._rocm_C  -> .../fuzzy-hornets-see-szfl4/vllm/_rocm_C.abi3.so
 
 ## After
 
-```
+```text
 MAPPING: {'vllm': '/home/aimeme/Desktop/vllm-gfx908/.emdash/worktrees/vllm-gfx908/emdash/loose-rats-clean-phm2k/vllm'}
 direct_url.json: file:///home/aimeme/.../loose-rats-clean-phm2k
 

--- a/library/post-merge-fixes-2026-06-05.md
+++ b/library/post-merge-fixes-2026-06-05.md
@@ -42,7 +42,7 @@ shows `Using ROCM_CK_FA backend (selected via --attention-backend)` (see
 **Symptom.** Serving `/models/Qwen3.5-9B-w8a8` crashed during multimodal
 processor construction:
 
-```
+```text
 TypeError: Received a CachedPreTrainedTokenizerFast for argument tokenizer,
 but a ('Qwen2Tokenizer', 'Qwen2TokenizerFast') was expected.
 ```
@@ -61,6 +61,7 @@ the *vendored* Step3 processors) enforces a strict
 the generic class.
 
 Upstream does not hit this because:
+
 - it does not carry `qwen3_5` in the override set, and
 - its own override entries (`step3_vl`, `step3p7`) use vLLM-vendored
   processors that do not do the strict transformers isinstance check.

--- a/library/quality-gates.md
+++ b/library/quality-gates.md
@@ -109,7 +109,7 @@ Needle@32768: 5/5 (gate PASS)
 
 ---
 
-# M1 Quality Gates — W4A16 AWQ-vs-GPTQ A/B (3-path comparison)
+## M1 Quality Gates — W4A16 AWQ-vs-GPTQ A/B (3-path comparison)
 
 **Feature**: M1-F4 (gate_summary.json synthesis)
 **Run date**: 2026-05-27

--- a/library/v5-upgrade/transformers-v5-upgrade.md
+++ b/library/v5-upgrade/transformers-v5-upgrade.md
@@ -51,6 +51,7 @@ HSA_OVERRIDE_GFX_VERSION=9.0.8 VLLM_WORKER_MULTIPROC_METHOD=spawn
 PYTORCH_ROCM_ARCH=gfx908 ROCM_PATH=/opt/rocm/core-7.12`
 
 ### Serve smoke — all PASS on transformers 5.10.2
+
 | model | result |
 |---|---|
 | Llama-2-7b-hf | ✅ "...a city of contrasts. The city is home to the Eiffel Tower" |
@@ -62,6 +63,7 @@ confirmed working on v5: the concrete `Qwen2TokenizerFast` is loaded, cached,
 and passes `Qwen3VLProcessor`'s strict isinstance check.
 
 ### Benchmarks (Llama-2-7b, gfx908, single GPU)
+
 | bench | pre-v5 (4.57.3) | v5 (5.10.2) | note |
 |---|---|---|---|
 | throughput (in1024/out256, 100 prompts) | 1404.8 tok/s | **1538.3 tok/s** | +9.5%, no regression |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ lora_hf_hub_resolver = "vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_
 where = ["."]
 include = ["vllm*"]
 
+[tool.ruff]
+# Vendored third-party sources are kept byte-for-byte; do not lint or reformat.
+extend-exclude = ["vllm/third_party/**"]
+
 [tool.ruff.lint.per-file-ignores]
 "vllm/third_party/**" = ["ALL"]
 "vllm/version.py" = ["F401"]
@@ -130,7 +134,9 @@ extend-exclude = ["tests/models/fixtures/*", "tests/prompts/*", "tests/tokenizer
     "tests/v1/engine/test_fast_incdec_prefix_err.py", ".git/*", "csrc/cpu/sgl-kernels/*",
     "rust/src/chat/src/renderer/deepseek_v32/fixtures/*",
     "rust/src/tool-parser/src/gemma4.rs", "rust/src/text/src/output/decoded.rs",
-    "rust/src/tokenizer/src/incremental.rs", "rust/src/reasoning-parser/src/tests.rs"]
+    "rust/src/tokenizer/src/incremental.rs", "rust/src/reasoning-parser/src/tests.rs",
+    # gfx908 fork: captured machine-generated install/smoke logs
+    "*.log"]
 ignore-hidden = false
 
 [tool.typos.default]
@@ -144,6 +150,9 @@ cudaDevAttrMaxSharedMemoryPerBlockOptin = "cudaDevAttrMaxSharedMemoryPerBlockOpt
 sharedMemPerBlockOptin = "sharedMemPerBlockOptin"
 
 depthwise_seperable_out_channel = "depthwise_seperable_out_channel"
+# gfx908 fork: TensileLite kernel-trace SHA digests (hex, not words)
+b686daa25aa593a7 = "b686daa25aa593a7"
+2a4d5ded1e5934ef = "2a4d5ded1e5934ef"
 pard_token = "pard_token"
 ptd_token_id = "ptd_token_id"
 ser_de = "ser_de"
@@ -184,6 +193,10 @@ wht = "wht"
 WHT = "WHT"
 # Huawei Compute Architecture for Neural Networks
 CANN = "CANN"
+# gfx908 fork: local code identifiers / test fixtures, not misspellings
+relm = "relm"
+DELT = "DELT"
+abd = "abd"
 
 [tool.uv]
 no-build-isolation-package = ["torch"]

--- a/scripts/aggregate_final_grid.py
+++ b/scripts/aggregate_final_grid.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """M6 — aggregate the full Pareto grid across milestones.
 
 Emits two artifacts:
@@ -21,6 +22,7 @@ W4A16 does NOT have a TensileLite column (M2 was W8A8-only) nor a CK column
 Missing cells are emitted with `null` and an explicit reason captured in
 ``final_grid_reasons.json``.
 """  # noqa: E501
+
 from __future__ import annotations
 
 import csv
@@ -82,7 +84,9 @@ METRICS = [
 ]
 
 
-def resolve_path(root: Path, label: str, model: str, tp: int, c: int, wl: str) -> Path | None:  # noqa: E501
+def resolve_path(
+    root: Path, label: str, model: str, tp: int, c: int, wl: str
+) -> Path | None:  # noqa: E501
     """Resolve milestone cell JSON path. Returns None if column N/A."""
     if root is None:
         return None
@@ -112,7 +116,9 @@ def load(p: Path | None) -> dict | None:
         return None
 
 
-def pick_winner(values: dict[str, float | None], higher_better: bool) -> tuple[str, float] | None:  # noqa: E501
+def pick_winner(
+    values: dict[str, float | None], higher_better: bool
+) -> tuple[str, float] | None:  # noqa: E501
     """Pick the column with the best value. Skips None/NaN entries.
 
     Tie-break: prefer the earlier column in COLUMNS list (i.e. simpler path
@@ -124,7 +130,11 @@ def pick_winner(values: dict[str, float | None], higher_better: bool) -> tuple[s
         v = values.get(label)
         if v is None:
             continue
-        if best is None or (higher_better and v > best[1]) or (not higher_better and v < best[1]):  # noqa: E501
+        if (
+            best is None
+            or (higher_better and v > best[1])
+            or (not higher_better and v < best[1])
+        ):  # noqa: E501
             best = (label, v)
     return best
 
@@ -142,7 +152,9 @@ def main() -> int:
             if model not in applies:
                 cell_values[label] = None
                 continue
-            cell_values[label] = load(resolve_path(path_prefix, label, model, tp, c, wl))  # noqa: E501
+            cell_values[label] = load(
+                resolve_path(path_prefix, label, model, tp, c, wl)
+            )  # noqa: E501
 
         for key, label_metric, higher_better in METRICS:
             values: dict[str, float | None] = {}

--- a/scripts/aggregate_pmc.py
+++ b/scripts/aggregate_pmc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Aggregate rocprofv3 counter_collection.csv into omniperf-equivalent
 roofline numbers for the given hot kernel.
@@ -17,6 +18,7 @@ Peaks (gfx908 / MI100):
   * FP16/INT8 MFMA peak: 184.6 TFLOPS / 184.6 TOPS
   * HBM2 peak: 1228.8 GB/s
 """
+
 from __future__ import annotations
 
 import argparse
@@ -65,10 +67,17 @@ def aggregate(csv_path: Path, kernel_substring: str) -> dict:
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--counter-csv", action="append", required=True,
-                    help="path to counter_collection.csv (may repeat)")
-    ap.add_argument("--kernel-substring", required=True,
-                    help="substring of kernel name to filter on, e.g. scaled_mm_kernel")
+    ap.add_argument(
+        "--counter-csv",
+        action="append",
+        required=True,
+        help="path to counter_collection.csv (may repeat)",
+    )
+    ap.add_argument(
+        "--kernel-substring",
+        required=True,
+        help="substring of kernel name to filter on, e.g. scaled_mm_kernel",
+    )
     ap.add_argument("--quant", required=True)
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
@@ -119,9 +128,7 @@ def main():
         ),
         "achieved_HBM_GB_s": ach_hbm,
         "peak_HBM_GB_s_gfx908": PEAK_HBM_GB_S,
-        "percent_of_peak_hbm": (
-            100.0 * ach_hbm / PEAK_HBM_GB_S if ach_hbm else None
-        ),
+        "percent_of_peak_hbm": (100.0 * ach_hbm / PEAK_HBM_GB_S if ach_hbm else None),
         "raw_counters": dict(merged_counters),
         "input_files": list(args.counter_csv),
         "note": (

--- a/scripts/build_coding_agent_dataset.py
+++ b/scripts/build_coding_agent_dataset.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Build /root/bench-int8-w4a16/datasets/coding_agent.jsonl.
 
@@ -20,6 +21,7 @@ Qwen3.5 tokenizer (close enough for the +/-20 % tolerance the
 contract allows). The resulting JSONL is consumed by
 `vllm bench serve --dataset-name custom`.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -129,7 +131,7 @@ CODING_PROMPTS: list[dict] = [
         ),
         "context": (
             "def login(username, password):\n"
-            "    query = f\"SELECT * FROM users WHERE"
+            '    query = f"SELECT * FROM users WHERE'
             " username='{username}' AND password='{password}'\"\n"
             "    result = db.execute(query)\n"
             "    return result.fetchone()"
@@ -238,8 +240,9 @@ def _pad_context(base_context: str, target_tokens: int) -> str:
         "\n\n# additional related code (for context)\n"
         + base_context
         + "\n\n# additional related logs\n"
-        + "\n".join(f"[INFO] step {i}: validated input dict and output schema"
-                    for i in range(5))
+        + "\n".join(
+            f"[INFO] step {i}: validated input dict and output schema" for i in range(5)
+        )
         + "\n"
     )
     out = base_context
@@ -310,11 +313,11 @@ def main() -> int:
     print(f"wrote {len(items)} prompts to {args.out}")
     print(
         f"  input tokens (approx): min={in_lens[0]}, "
-        f"p50={in_lens[len(in_lens)//2]}, max={in_lens[-1]}"
+        f"p50={in_lens[len(in_lens) // 2]}, max={in_lens[-1]}"
     )
     print(
         f"  output tokens         : min={out_lens[0]}, "
-        f"p50={out_lens[len(out_lens)//2]}, max={out_lens[-1]}"
+        f"p50={out_lens[len(out_lens) // 2]}, max={out_lens[-1]}"
     )
     return 0
 

--- a/scripts/canary_diff.py
+++ b/scripts/canary_diff.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Compare two W8A8 TP=1 c=1 synthetic result JSONs and emit
 canary_diff.json with the throughput delta percent.
@@ -8,6 +9,7 @@ Usage:
     canary_diff.py --runA <path> --runB <path> \
         --out /root/bench-int8-w4a16/baseline/canary_diff.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -29,16 +31,18 @@ def main() -> int:
 
     runs = []
     for label, d in (("runA", a), ("runB", b)):
-        runs.append({
-            "label": label,
-            "source": str(args.runA if label == "runA" else args.runB),
-            "output_throughput_toks_s": float(d["output_throughput_toks_s"]),
-            "p50_ttft_ms": float(d["p50_ttft_ms"]),
-            "p50_tpot_ms": float(d["p50_tpot_ms"]),
-            "vllm_commit": d.get("vllm_commit"),
-            "harness_commit": d.get("harness_commit"),
-            "timestamp": d.get("timestamp"),
-        })
+        runs.append(
+            {
+                "label": label,
+                "source": str(args.runA if label == "runA" else args.runB),
+                "output_throughput_toks_s": float(d["output_throughput_toks_s"]),
+                "p50_ttft_ms": float(d["p50_ttft_ms"]),
+                "p50_tpot_ms": float(d["p50_tpot_ms"]),
+                "vllm_commit": d.get("vllm_commit"),
+                "harness_commit": d.get("harness_commit"),
+                "timestamp": d.get("timestamp"),
+            }
+        )
 
     a_t = runs[0]["output_throughput_toks_s"]
     b_t = runs[1]["output_throughput_toks_s"]

--- a/scripts/check_default_pareto.py
+++ b/scripts/check_default_pareto.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """VAL-CROSS-003 — no kernel becomes default if it loses any cell.
 
 A kernel is the *unconditional default* only if it is ≥ every alternative
@@ -25,6 +26,7 @@ Documented gates (already in tree):
 Exit code is 0 if every winning-but-not-always-best path has at least
 one documented gate, non-zero otherwise.
 """
+
 from __future__ import annotations
 
 import csv
@@ -102,10 +104,14 @@ def main(argv: list[str]) -> int:
         present = per_path_present.get(path, 0)
         lost = per_path_lost.get(path, 0)
         if wins == 0 or present == 0:
-            print(f"  {path:11s}: never selected as winner — no default-claim possible.")  # noqa: E501
+            print(
+                f"  {path:11s}: never selected as winner — no default-claim possible."
+            )  # noqa: E501
             continue
         if lost == 0:
-            print(f"  {path:11s}: wins every measured cell — eligible to be unconditional default.")  # noqa: E501
+            print(
+                f"  {path:11s}: wins every measured cell — eligible to be unconditional default."  # noqa: E501
+            )
             continue
         gates = GATES.get(path, [])
         if not gates:
@@ -120,8 +126,9 @@ def main(argv: list[str]) -> int:
                 f"{', '.join(gates)}; safe to ship as dispatcher-priority path."
             )
     print()
-    print(f"VAL-CROSS-003: {'PASS' if fail == 0 else 'FAIL'} "
-          f"(missing-gate paths: {fail})")
+    print(
+        f"VAL-CROSS-003: {'PASS' if fail == 0 else 'FAIL'} (missing-gate paths: {fail})"
+    )
     return 0 if fail == 0 else 1
 
 

--- a/scripts/check_default_pareto.py
+++ b/scripts/check_default_pareto.py
@@ -106,11 +106,12 @@ def main(argv: list[str]) -> int:
         if wins == 0 or present == 0:
             print(
                 f"  {path:11s}: never selected as winner — no default-claim possible."
-            )  # noqa: E501
+            )
             continue
         if lost == 0:
             print(
-                f"  {path:11s}: wins every measured cell — eligible to be unconditional default."  # noqa: E501
+                f"  {path:11s}: wins every measured cell — "
+                "eligible to be unconditional default."
             )
             continue
         gates = GATES.get(path, [])

--- a/scripts/eval_needle.py
+++ b/scripts/eval_needle.py
@@ -91,7 +91,7 @@ def insert_at_depth(haystack: str, needle_phrase: str, depth_pct: int) -> str:
 
 def chat(
     system: str, user: str, model: str, max_tokens: int = 768, timeout: float = 900.0
-) -> str:  # noqa: E501
+) -> str:
     body = json.dumps(
         {
             "model": model,
@@ -160,7 +160,8 @@ def main() -> int:
                 }
             )
             print(
-                f"  [{i + 1}/{needle_count}] {needle['key']} depth={depth}% — FAIL ({exc})"  # noqa: E501
+                f"  [{i + 1}/{needle_count}] {needle['key']} "
+                f"depth={depth}% — FAIL ({exc})"
             )
             continue
         ok = needle["value"].lower() in response.lower()
@@ -175,7 +176,8 @@ def main() -> int:
         )
         passes += int(ok)
         print(
-            f"  [{i + 1}/{needle_count}] {needle['key']} depth={depth}% — {'PASS' if ok else 'FAIL'}"  # noqa: E501
+            f"  [{i + 1}/{needle_count}] {needle['key']} "
+            f"depth={depth}% — {'PASS' if ok else 'FAIL'}"
         )
     elapsed = time.time() - t0
 
@@ -196,7 +198,8 @@ def main() -> int:
     )
 
     print(
-        f"\nNeedle@{args.ctx}: {passes}/{needle_count} (gate {'PASS' if passes == needle_count else 'FAIL'})"  # noqa: E501
+        f"\nNeedle@{args.ctx}: {passes}/{needle_count} "
+        f"(gate {'PASS' if passes == needle_count else 'FAIL'})"
     )
     print(f"Wrote {args.out}")
     return 0 if passes == needle_count else 1

--- a/scripts/eval_needle.py
+++ b/scripts/eval_needle.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """VAL-FINAL-004 — needle-in-haystack at 32k context.
 
 Plants 5 needles at fixed depths (10/30/50/70/90 %) inside a 32k-token
@@ -14,6 +15,7 @@ ctx=32768. The system-message guardrail keeps the model from emitting
 "Thinking Process:" preamble that otherwise eats the token budget at
 large contexts.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -87,17 +89,21 @@ def insert_at_depth(haystack: str, needle_phrase: str, depth_pct: int) -> str:
     return haystack[:pos] + " " + needle_phrase + " " + haystack[pos:]
 
 
-def chat(system: str, user: str, model: str, max_tokens: int = 768, timeout: float = 900.0) -> str:  # noqa: E501
-    body = json.dumps({
-        "model": model,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        "temperature": 0.0,
-        "max_tokens": max_tokens,
-        "seed": 0,
-    }).encode()
+def chat(
+    system: str, user: str, model: str, max_tokens: int = 768, timeout: float = 900.0
+) -> str:  # noqa: E501
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "temperature": 0.0,
+            "max_tokens": max_tokens,
+            "seed": 0,
+        }
+    ).encode()
     req = urllib.request.Request(
         f"{SERVER}/v1/chat/completions",
         data=body,
@@ -143,40 +149,55 @@ def main() -> int:
         try:
             response = chat(SYSTEM, question, model)
         except Exception as exc:
-            results.append({
+            results.append(
+                {
+                    "label": needle["key"],
+                    "depth_pct": depth,
+                    "expected": needle["value"],
+                    "ok": False,
+                    "error": str(exc),
+                    "answer": "",
+                }
+            )
+            print(
+                f"  [{i + 1}/{needle_count}] {needle['key']} depth={depth}% — FAIL ({exc})"  # noqa: E501
+            )
+            continue
+        ok = needle["value"].lower() in response.lower()
+        results.append(
+            {
                 "label": needle["key"],
                 "depth_pct": depth,
                 "expected": needle["value"],
-                "ok": False,
-                "error": str(exc),
-                "answer": "",
-            })
-            print(f"  [{i+1}/{needle_count}] {needle['key']} depth={depth}% — FAIL ({exc})")  # noqa: E501
-            continue
-        ok = needle["value"].lower() in response.lower()
-        results.append({
-            "label": needle["key"],
-            "depth_pct": depth,
-            "expected": needle["value"],
-            "answer": response,
-            "ok": ok,
-        })
+                "answer": response,
+                "ok": ok,
+            }
+        )
         passes += int(ok)
-        print(f"  [{i+1}/{needle_count}] {needle['key']} depth={depth}% — {'PASS' if ok else 'FAIL'}")  # noqa: E501
+        print(
+            f"  [{i + 1}/{needle_count}] {needle['key']} depth={depth}% — {'PASS' if ok else 'FAIL'}"  # noqa: E501
+        )
     elapsed = time.time() - t0
 
-    args.out.write_text(json.dumps({
-        "model": model,
-        "ctx": args.ctx,
-        "depths": DEPTHS[:needle_count],
-        "passes": passes,
-        "total": needle_count,
-        "gate_5_of_5": passes == needle_count,
-        "elapsed_s": elapsed,
-        "results": results,
-    }, indent=2))
+    args.out.write_text(
+        json.dumps(
+            {
+                "model": model,
+                "ctx": args.ctx,
+                "depths": DEPTHS[:needle_count],
+                "passes": passes,
+                "total": needle_count,
+                "gate_5_of_5": passes == needle_count,
+                "elapsed_s": elapsed,
+                "results": results,
+            },
+            indent=2,
+        )
+    )
 
-    print(f"\nNeedle@{args.ctx}: {passes}/{needle_count} (gate {'PASS' if passes == needle_count else 'FAIL'})")  # noqa: E501
+    print(
+        f"\nNeedle@{args.ctx}: {passes}/{needle_count} (gate {'PASS' if passes == needle_count else 'FAIL'})"  # noqa: E501
+    )
     print(f"Wrote {args.out}")
     return 0 if passes == needle_count else 1
 

--- a/scripts/m0_coherence_check.py
+++ b/scripts/m0_coherence_check.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 M0 Coherence Check (VAL-M0-004).
 
@@ -17,13 +19,13 @@ Usage:
         --prompts /root/bench-int8-w4a16/baseline/prompts_coding.jsonl \
         --out /root/bench-int8-w4a16/baseline/coherence_w8a8_tp1.json
 """
+
 from __future__ import annotations
 
 import argparse
 import contextlib
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -31,6 +33,7 @@ import tempfile
 import time
 from pathlib import Path
 
+import regex as re
 import requests
 
 # ---- repetition heuristic ----
@@ -96,21 +99,24 @@ def syntax_check(code: str, lang: str) -> tuple[bool, str]:
         if lang == "python":
             r = subprocess.run(
                 [sys.executable, "-m", "py_compile", path],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
         else:
             node = shutil.which("node")
             if node is None:
                 # If node isn't installed, fall back to a permissive check:
                 # require balanced braces and the keyword "function" or "=>".
-                ok = (
-                    code.count("{") == code.count("}")
-                    and ("function" in code or "=>" in code)
+                ok = code.count("{") == code.count("}") and (
+                    "function" in code or "=>" in code
                 )
                 return ok, "node-not-installed; permissive check"
             r = subprocess.run(
                 [node, "--check", path],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
         ok = r.returncode == 0
         msg = r.stderr.strip() if not ok else "ok"
@@ -122,8 +128,9 @@ def syntax_check(code: str, lang: str) -> tuple[bool, str]:
             os.unlink(path)
 
 
-def chat_complete(base_url: str, model: str, prompt: str, max_tokens: int = 512,
-                  timeout: int = 120) -> str:
+def chat_complete(
+    base_url: str, model: str, prompt: str, max_tokens: int = 512, timeout: int = 120
+) -> str:
     """Send a single chat completion request; returns the text content."""
     url = base_url.rstrip("/") + "/chat/completions"
     payload = {
@@ -159,14 +166,19 @@ def main() -> int:
     for p in prompts:
         t0 = time.time()
         try:
-            text = chat_complete(args.base_url, args.model, p["prompt"],
-                                 args.max_tokens)
+            text = chat_complete(
+                args.base_url, args.model, p["prompt"], args.max_tokens
+            )
         except Exception as e:
-            results.append({
-                "id": p["id"], "lang": p["lang"], "ok": False,
-                "error": f"{type(e).__name__}: {e}",
-                "elapsed_s": round(time.time() - t0, 2),
-            })
+            results.append(
+                {
+                    "id": p["id"],
+                    "lang": p["lang"],
+                    "ok": False,
+                    "error": f"{type(e).__name__}: {e}",
+                    "elapsed_s": round(time.time() - t0, 2),
+                }
+            )
             nonempty_fail += 1
             continue
         elapsed = round(time.time() - t0, 2)
@@ -186,18 +198,21 @@ def main() -> int:
         if ok:
             syntax_pass += 1
 
-        results.append({
-            "id": p["id"], "lang": p["lang"],
-            "len_chars": len(text),
-            "len_tokens_approx": len(toks),
-            "ngram20_coverage": round(coverage, 3),
-            "repeated_ngram": repeated,
-            "nonempty": nonempty,
-            "syntax_ok": ok,
-            "syntax_msg": msg,
-            "elapsed_s": elapsed,
-            "preview": text[:300],
-        })
+        results.append(
+            {
+                "id": p["id"],
+                "lang": p["lang"],
+                "len_chars": len(text),
+                "len_tokens_approx": len(toks),
+                "ngram20_coverage": round(coverage, 3),
+                "repeated_ngram": repeated,
+                "nonempty": nonempty,
+                "syntax_ok": ok,
+                "syntax_msg": msg,
+                "elapsed_s": elapsed,
+                "preview": text[:300],
+            }
+        )
 
     summary = {
         "label": args.label,
@@ -208,9 +223,7 @@ def main() -> int:
         "repetition_fail": repetition_fail,
         "nonempty_fail": nonempty_fail,
         "passes_gate": (
-            nonempty_fail == 0
-            and repetition_fail == 0
-            and syntax_pass >= 8
+            nonempty_fail == 0 and repetition_fail == 0 and syntax_pass >= 8
         ),
         "results": results,
     }
@@ -219,9 +232,11 @@ def main() -> int:
     with open(args.out, "w") as f:
         json.dump(summary, f, indent=2)
 
-    print(f"[m0_coherence] {args.label} -> syntax={syntax_pass}/{len(prompts)} "
-          f"repetition_fail={repetition_fail} nonempty_fail={nonempty_fail} "
-          f"gate={'PASS' if summary['passes_gate'] else 'FAIL'}")
+    print(
+        f"[m0_coherence] {args.label} -> syntax={syntax_pass}/{len(prompts)} "
+        f"repetition_fail={repetition_fail} nonempty_fail={nonempty_fail} "
+        f"gate={'PASS' if summary['passes_gate'] else 'FAIL'}"
+    )
     return 0 if summary["passes_gate"] else 1
 
 

--- a/scripts/m0_determinism.py
+++ b/scripts/m0_determinism.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 M0 Determinism / no-NaN/Inf check (VAL-M0-007).
 
@@ -14,6 +16,7 @@ Usage:
         --model /models/Qwen3.5-9B-w8a8 \
         --out /root/bench-int8-w4a16/baseline/determinism_w8a8.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -84,11 +87,11 @@ def main() -> int:
     lp0 = runs[0]["top_logprobs_0"]
     lp1 = runs[1]["top_logprobs_0"]
     lp_keys_match = sorted(lp0.keys()) == sorted(lp1.keys())
-    lp_values_match = all(
-        abs(float(lp0[k]) - float(lp1[k])) < 1e-6
-        for k in lp0
-        if k in lp1
-    ) if lp_keys_match else False
+    lp_values_match = (
+        all(abs(float(lp0[k]) - float(lp1[k])) < 1e-6 for k in lp0 if k in lp1)
+        if lp_keys_match
+        else False
+    )
 
     nan_inf = has_nan_or_inf(lp0) or has_nan_or_inf(lp1)
 
@@ -108,9 +111,11 @@ def main() -> int:
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w") as f:
         json.dump(summary, f, indent=2)
-    print(f"[m0_determinism] {args.label} top1_match={top1_match} "
-          f"logprobs_match={lp_keys_match and lp_values_match} "
-          f"nan_inf={nan_inf} gate={'PASS' if passes else 'FAIL'}")
+    print(
+        f"[m0_determinism] {args.label} top1_match={top1_match} "
+        f"logprobs_match={lp_keys_match and lp_values_match} "
+        f"nan_inf={nan_inf} gate={'PASS' if passes else 'FAIL'}"
+    )
     return 0 if passes else 1
 
 

--- a/scripts/m0_niah.py
+++ b/scripts/m0_niah.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 M0 Needle-in-a-Haystack at 8k context (VAL-M0-005).
 
@@ -15,6 +17,7 @@ Usage:
         --depths 10,30,50,70,90 \
         --out /root/bench-int8-w4a16/baseline/niah_w8a8.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -56,9 +59,7 @@ NEEDLES = [
     {
         "key": "Coral fish species",
         "value": "1582",
-        "phrase": (
-            "Exactly 1582 coral fish species were catalogued in the registry."
-        ),
+        "phrase": ("Exactly 1582 coral fish species were catalogued in the registry."),
     },
     {
         "key": "Captain's birthday",
@@ -81,8 +82,14 @@ def insert_at_depth(haystack: str, needle_phrase: str, depth_pct: int) -> str:
     return haystack[:pos] + " " + needle_phrase + " " + haystack[pos:]
 
 
-def chat_complete(base_url: str, model: str, system: str, user: str,
-                  max_tokens: int = 768, timeout: int = 300) -> str:
+def chat_complete(
+    base_url: str,
+    model: str,
+    system: str,
+    user: str,
+    max_tokens: int = 768,
+    timeout: int = 300,
+) -> str:
     url = base_url.rstrip("/") + "/chat/completions"
     payload = {
         "model": model,
@@ -103,9 +110,13 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
     ap.add_argument("--model", required=True)
-    ap.add_argument("--ctx", type=int, default=8192,
-                    help="Approximate target context tokens. We size the "
-                         "haystack body so total prompt fits inside.")
+    ap.add_argument(
+        "--ctx",
+        type=int,
+        default=8192,
+        help="Approximate target context tokens. We size the "
+        "haystack body so total prompt fits inside.",
+    )
     ap.add_argument("--depths", default="10,30,50,70,90")
     ap.add_argument("--out", required=True)
     ap.add_argument("--label", default="")
@@ -136,24 +147,34 @@ def main() -> int:
             f"in the passage? Answer with the exact value as written."
         )
         try:
-            ans = chat_complete(args.base_url, args.model, system, question,
-                                max_tokens=768)
+            ans = chat_complete(
+                args.base_url, args.model, system, question, max_tokens=768
+            )
         except Exception as e:
-            results.append({
-                "needle": needle["key"], "depth_pct": depth,
-                "ok": False, "error": f"{type(e).__name__}: {e}",
-                "elapsed_s": round(time.time() - t0, 2),
-            })
+            results.append(
+                {
+                    "needle": needle["key"],
+                    "depth_pct": depth,
+                    "ok": False,
+                    "error": f"{type(e).__name__}: {e}",
+                    "elapsed_s": round(time.time() - t0, 2),
+                }
+            )
             continue
         ok = needle["value"] in ans
         if ok:
             passes += 1
-        results.append({
-            "needle": needle["key"], "depth_pct": depth,
-            "expected": needle["value"], "answer": ans[:1000],
-            "answer_len": len(ans),
-            "ok": ok, "elapsed_s": round(time.time() - t0, 2),
-        })
+        results.append(
+            {
+                "needle": needle["key"],
+                "depth_pct": depth,
+                "expected": needle["value"],
+                "answer": ans[:1000],
+                "answer_len": len(ans),
+                "ok": ok,
+                "elapsed_s": round(time.time() - t0, 2),
+            }
+        )
 
     summary = {
         "label": args.label,
@@ -168,8 +189,10 @@ def main() -> int:
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w") as f:
         json.dump(summary, f, indent=2)
-    print(f"[m0_niah] {args.label} -> {passes}/{len(NEEDLES)} "
-          f"gate={'PASS' if summary['gate_5_of_5'] else 'FAIL'}")
+    print(
+        f"[m0_niah] {args.label} -> {passes}/{len(NEEDLES)} "
+        f"gate={'PASS' if summary['gate_5_of_5'] else 'FAIL'}"
+    )
     return 0 if summary["gate_5_of_5"] else 1
 
 

--- a/scripts/m0_perplexity.py
+++ b/scripts/m0_perplexity.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 M0 Perplexity (VAL-M0-006) — server-mode.
 
@@ -21,6 +23,7 @@ Usage:
         --chunks 50 --chunk-tokens 512 --seed 0 \
         --out /root/bench-int8-w4a16/baseline/ppl_w8a8.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -48,13 +51,14 @@ def load_wikitext_token_ids(tokenizer_path: str) -> list[int]:
     return tok(blob, add_special_tokens=False)["input_ids"]
 
 
-def build_chunks(token_ids: list[int], num_chunks: int, chunk_tokens: int,
-                 seed: int) -> list[list[int]]:
+def build_chunks(
+    token_ids: list[int], num_chunks: int, chunk_tokens: int, seed: int
+) -> list[list[int]]:
     start = (seed * 17) % max(1, chunk_tokens)
     chunks = []
     pos = start
     while len(chunks) < num_chunks and pos + chunk_tokens <= len(token_ids):
-        chunks.append(token_ids[pos:pos + chunk_tokens])
+        chunks.append(token_ids[pos : pos + chunk_tokens])
         pos += chunk_tokens
     if len(chunks) < num_chunks:
         raise RuntimeError(
@@ -64,8 +68,9 @@ def build_chunks(token_ids: list[int], num_chunks: int, chunk_tokens: int,
     return chunks
 
 
-def score_chunk(base_url: str, model: str, ids: list[int],
-                timeout: int = 600) -> tuple[float, int]:
+def score_chunk(
+    base_url: str, model: str, ids: list[int], timeout: int = 600
+) -> tuple[float, int]:
     """Returns (sum_neg_logp, n_tokens_scored) for the given prompt token ids.
 
     Uses /v1/completions with echo=true, logprobs=1, max_tokens=0 — vLLM
@@ -74,10 +79,10 @@ def score_chunk(base_url: str, model: str, ids: list[int],
     url = base_url.rstrip("/") + "/completions"
     payload = {
         "model": model,
-        "prompt": ids,         # token-id prompt is supported by vLLM
-        "max_tokens": 1,       # Some servers refuse max_tokens=0; ask for 1.
-        "echo": True,          # Return prompt token logprobs as well.
-        "logprobs": 0,         # 0 = just include logprobs of the chosen tokens.
+        "prompt": ids,  # token-id prompt is supported by vLLM
+        "max_tokens": 1,  # Some servers refuse max_tokens=0; ask for 1.
+        "echo": True,  # Return prompt token logprobs as well.
+        "logprobs": 0,  # 0 = just include logprobs of the chosen tokens.
         "temperature": 0.0,
         "seed": 0,
     }
@@ -106,10 +111,12 @@ def score_chunk(base_url: str, model: str, ids: list[int],
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
-    ap.add_argument("--model", required=True,
-                    help="Model id served by vLLM (must match /v1/models)")
-    ap.add_argument("--tokenizer", required=True,
-                    help="Path to tokenizer (usually same as --model)")
+    ap.add_argument(
+        "--model", required=True, help="Model id served by vLLM (must match /v1/models)"
+    )
+    ap.add_argument(
+        "--tokenizer", required=True, help="Path to tokenizer (usually same as --model)"
+    )
     ap.add_argument("--chunks", type=int, default=50)
     ap.add_argument("--chunk-tokens", type=int, default=512)
     ap.add_argument("--seed", type=int, default=0)
@@ -119,8 +126,10 @@ def main() -> int:
 
     ids = load_wikitext_token_ids(args.tokenizer)
     chunks = build_chunks(ids, args.chunks, args.chunk_tokens, args.seed)
-    print(f"[m0_perplexity] tokenized blob: {len(ids)} tokens; "
-          f"using {len(chunks)} chunks of {args.chunk_tokens} tokens")
+    print(
+        f"[m0_perplexity] tokenized blob: {len(ids)} tokens; "
+        f"using {len(chunks)} chunks of {args.chunk_tokens} tokens"
+    )
 
     t0 = time.time()
     sum_nll = 0.0
@@ -130,13 +139,16 @@ def main() -> int:
         s, n = score_chunk(args.base_url, args.model, ids_chunk)
         sum_nll += s
         total_n += n
-        per_chunk.append({
-            "chunk": ci, "tokens": n,
-            "mean_nll": s / n if n else float("nan"),
-        })
+        per_chunk.append(
+            {
+                "chunk": ci,
+                "tokens": n,
+                "mean_nll": s / n if n else float("nan"),
+            }
+        )
         if ci % 10 == 0:
             elapsed = time.time() - t0
-            print(f"  chunk {ci+1}/{len(chunks)} tokens={n} elapsed={elapsed:.1f}s")
+            print(f"  chunk {ci + 1}/{len(chunks)} tokens={n} elapsed={elapsed:.1f}s")
 
     elapsed = round(time.time() - t0, 1)
     mean_nll = sum_nll / max(1, total_n)
@@ -156,8 +168,10 @@ def main() -> int:
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w") as f:
         json.dump(summary, f, indent=2)
-    print(f"[m0_perplexity] {args.label} ppl={ppl:.4f} "
-          f"({total_n} tokens scored in {elapsed}s)")
+    print(
+        f"[m0_perplexity] {args.label} ppl={ppl:.4f} "
+        f"({total_n} tokens scored in {elapsed}s)"
+    )
     return 0
 
 

--- a/scripts/mi100/aggregate_m2_threeway.py
+++ b/scripts/mi100/aggregate_m2_threeway.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Aggregate W8A8 cells across three grids:
   * M1 baseline (May-7)
@@ -18,6 +19,7 @@ Emits a markdown table with the canonical metrics per cell, plus deltas:
 This is the comparison the m2-rebaseline-and-fill-grid feature
 requires (see mission features.json).
 """
+
 from __future__ import annotations
 
 import json
@@ -32,18 +34,18 @@ CELLS = [
 ]
 
 ROOTS = {
-    "M1":  Path("/root/bench-int8-w4a16/baseline"),
+    "M1": Path("/root/bench-int8-w4a16/baseline"),
     "M1r": Path("/root/bench-int8-w4a16/m1-rebaseline"),
-    "M2":  Path("/root/bench-int8-w4a16/m2"),
+    "M2": Path("/root/bench-int8-w4a16/m2"),
 }
 
 METRICS = [
-    ("output_throughput_toks_s", "tput",     "higher_better"),
+    ("output_throughput_toks_s", "tput", "higher_better"),
     ("request_throughput_req_s", "req_tput", "higher_better"),
-    ("mean_ttft_ms",             "mean_ttft","lower_better"),
-    ("p99_ttft_ms",              "p99_ttft", "lower_better"),
-    ("mean_tpot_ms",             "mean_tpot","lower_better"),
-    ("p99_tpot_ms",              "p99_tpot", "lower_better"),
+    ("mean_ttft_ms", "mean_ttft", "lower_better"),
+    ("p99_ttft_ms", "p99_ttft", "lower_better"),
+    ("mean_tpot_ms", "mean_tpot", "lower_better"),
+    ("p99_tpot_ms", "p99_tpot", "lower_better"),
 ]
 
 
@@ -67,13 +69,11 @@ def fmt_delta(d: float, direction: str, threshold: float = 3.0) -> str:
         return "—"
     sign = "+" if d > 0 else ""
     s = f"{sign}{d:.2f}%"
-    is_improvement = (
-        (direction == "higher_better" and d >= threshold) or
-        (direction == "lower_better" and d <= -threshold)
+    is_improvement = (direction == "higher_better" and d >= threshold) or (
+        direction == "lower_better" and d <= -threshold
     )
-    is_regression = (
-        (direction == "higher_better" and d <= -1.0) or
-        (direction == "lower_better" and d >= 1.0)
+    is_regression = (direction == "higher_better" and d <= -1.0) or (
+        direction == "lower_better" and d >= 1.0
     )
     if is_improvement:
         return f"**{s}**"
@@ -94,14 +94,18 @@ def main() -> int:
     out.append("> the merged TensileLite logic; M1-rebaseline does NOT (so")
     out.append("> hipBLASLt uses its prebuilt I8I8 default kernel).")
     out.append("")
-    out.append("Markup: **bold** = Pareto improvement ≥ 3% on this metric, "
-               "_italic_ = regression > 1%.")
+    out.append(
+        "Markup: **bold** = Pareto improvement ≥ 3% on this metric, "
+        "_italic_ = regression > 1%."
+    )
     out.append("")
     out.append("## Per-cell results (W8A8)")
     out.append("")
-    out.append("| Cell | Workload | Metric | M1 (May-7) | M1-rebaseline | M2 | "
-               "Δ M1→M2 | Δ M1→M1rb (lib-swap) | "
-               "Δ M1rb→M2 (**tuning**) |")
+    out.append(
+        "| Cell | Workload | Metric | M1 (May-7) | M1-rebaseline | M2 | "
+        "Δ M1→M2 | Δ M1→M1rb (lib-swap) | "
+        "Δ M1rb→M2 (**tuning**) |"
+    )
     out.append("| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |")
 
     summary: list[dict] = []
@@ -110,8 +114,9 @@ def main() -> int:
         cells = {k: load_cell(r, model, tp, c, wl) for k, r in ROOTS.items()}
         if any(v is None for v in cells.values()):
             missing = [k for k, v in cells.items() if v is None]
-            print(f"  [warn] {model}_tp{tp}_c{c}_{wl}: missing {missing}",
-                  file=sys.stderr)
+            print(
+                f"  [warn] {model}_tp{tp}_c{c}_{wl}: missing {missing}", file=sys.stderr
+            )
             continue
         cell_id = f"{model}_tp{tp}_c{c}"
         for key, label, direction in METRICS:
@@ -131,29 +136,36 @@ def main() -> int:
                 f"{fmt_delta(d_m1_m1r, direction)} | "
                 f"{fmt_delta(d_m1r_m2, direction)} |"
             )
-            summary.append({
-                "cell": cell_id, "workload": wl, "metric": label,
-                "direction": direction,
-                "M1": m1, "M1r": m1r, "M2": m2,
-                "d_M1_M2": d_m1_m2,
-                "d_M1_M1r": d_m1_m1r,
-                "d_M1r_M2": d_m1r_m2,
-            })
+            summary.append(
+                {
+                    "cell": cell_id,
+                    "workload": wl,
+                    "metric": label,
+                    "direction": direction,
+                    "M1": m1,
+                    "M1r": m1r,
+                    "M2": m2,
+                    "d_M1_M2": d_m1_m2,
+                    "d_M1_M1r": d_m1_m1r,
+                    "d_M1r_M2": d_m1r_m2,
+                }
+            )
 
     out.append("")
     out.append("## Headline analysis: tuning gain (Δ M1rb→M2)")
     out.append("")
-    out.append("Cells where the **tuning** column shows ≥ +3% gain "
-               "(throughput) or ≤ -3% latency reduction:")
+    out.append(
+        "Cells where the **tuning** column shows ≥ +3% gain "
+        "(throughput) or ≤ -3% latency reduction:"
+    )
     out.append("")
     out.append("| Cell | Workload | Metric | M1rb | M2 | Δ M1rb→M2 |")
     out.append("| --- | --- | --- | ---: | ---: | ---: |")
     n_pareto = 0
     for r in summary:
         d = r["d_M1r_M2"]
-        is_improvement = (
-            (r["direction"] == "higher_better" and d >= 3.0) or
-            (r["direction"] == "lower_better" and d <= -3.0)
+        is_improvement = (r["direction"] == "higher_better" and d >= 3.0) or (
+            r["direction"] == "lower_better" and d <= -3.0
         )
         if is_improvement:
             n_pareto += 1
@@ -171,13 +183,13 @@ def main() -> int:
     # Identify prefill-dominated cells
     out.append("## Prefill-dominated improvement check (gate)")
     out.append("")
-    out.append("Mission gate: at least one **prefill-dominated** cell improves ≥ 3% "
-               "in the M2-vs-M1-rebaselined column. Prefill dominance is highest "
-               "on TP=1 c≥2 synthetic (large M batches) and on TP=4 c=4 synthetic.")
+    out.append(
+        "Mission gate: at least one **prefill-dominated** cell improves ≥ 3% "
+        "in the M2-vs-M1-rebaselined column. Prefill dominance is highest "
+        "on TP=1 c≥2 synthetic (large M batches) and on TP=4 c=4 synthetic."
+    )
     out.append("")
-    prefill_cells = {
-        "w8a8_tp1_c2", "w8a8_tp1_c4", "w8a8_tp4_c4"
-    }
+    prefill_cells = {"w8a8_tp1_c2", "w8a8_tp1_c4", "w8a8_tp4_c4"}
     prefill_metrics = {"mean_ttft", "p99_ttft"}
     prefill_pass = []
     for r in summary:
@@ -202,11 +214,15 @@ def main() -> int:
         out.append("| — | — | — | — | — | (no prefill-dominated cell ≥ 3%) |")
     out.append("")
     if prefill_pass:
-        out.append(f"**GATE PASS:** {len(prefill_pass)} prefill-dominated metric(s) "
-                   "improved ≥ 3% in M2 vs M1-rebaselined.")
+        out.append(
+            f"**GATE PASS:** {len(prefill_pass)} prefill-dominated metric(s) "
+            "improved ≥ 3% in M2 vs M1-rebaselined."
+        )
     else:
-        out.append("**GATE FAIL:** no prefill-dominated metric improved ≥ 3% "
-                   "in M2 vs M1-rebaselined.")
+        out.append(
+            "**GATE FAIL:** no prefill-dominated metric improved ≥ 3% "
+            "in M2 vs M1-rebaselined."
+        )
     out.append("")
 
     print("\n".join(out))

--- a/scripts/mi100/aggregate_m3.py
+++ b/scripts/mi100/aggregate_m3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Aggregate M3 grid results into a markdown table.
 
 Compares:
@@ -11,6 +12,7 @@ Outputs a table per quant scheme + pareto gate verdict.
 Usage:
     /opt/vllm-env/bin/python3 scripts/mi100/aggregate_m3.py > BENCH_INT8_W4A16_M3.md
 """
+
 from __future__ import annotations
 
 import json
@@ -31,23 +33,23 @@ W4A16_CELLS = [
 ]
 
 ROOTS_W8A8 = {
-    "M1rb":      Path("/root/bench-int8-w4a16/m1-rebaseline"),
-    "M3-auto":   Path("/root/bench-int8-w4a16/m3/w8a8/autotune"),
-    "M3-heur":   Path("/root/bench-int8-w4a16/m3/w8a8/heuristic"),
+    "M1rb": Path("/root/bench-int8-w4a16/m1-rebaseline"),
+    "M3-auto": Path("/root/bench-int8-w4a16/m3/w8a8/autotune"),
+    "M3-heur": Path("/root/bench-int8-w4a16/m3/w8a8/heuristic"),
 }
 ROOTS_W4A16 = {
-    "M1":         Path("/root/bench-int8-w4a16/baseline"),
-    "M3-mi100":   Path("/root/bench-int8-w4a16/m3/w4a16/mi100"),
+    "M1": Path("/root/bench-int8-w4a16/baseline"),
+    "M3-mi100": Path("/root/bench-int8-w4a16/m3/w4a16/mi100"),
     "M3-generic": Path("/root/bench-int8-w4a16/m3/w4a16/generic"),
 }
 
 METRICS = [
-    ("output_throughput_toks_s", "tput",     "higher_better"),
+    ("output_throughput_toks_s", "tput", "higher_better"),
     ("request_throughput_req_s", "req_tput", "higher_better"),
-    ("mean_ttft_ms",             "mean_ttft","lower_better"),
-    ("p99_ttft_ms",              "p99_ttft", "lower_better"),
-    ("mean_tpot_ms",             "mean_tpot","lower_better"),
-    ("p99_tpot_ms",              "p99_tpot", "lower_better"),
+    ("mean_ttft_ms", "mean_ttft", "lower_better"),
+    ("p99_ttft_ms", "p99_ttft", "lower_better"),
+    ("mean_tpot_ms", "mean_tpot", "lower_better"),
+    ("p99_tpot_ms", "p99_tpot", "lower_better"),
 ]
 
 
@@ -73,13 +75,11 @@ def fmt_delta(d: float, direction: str, threshold: float = 3.0) -> str:
         return "—"
     sign = "+" if d > 0 else ""
     s = f"{sign}{d:.2f}%"
-    is_improvement = (
-        (direction == "higher_better" and d >= threshold) or
-        (direction == "lower_better" and d <= -threshold)
+    is_improvement = (direction == "higher_better" and d >= threshold) or (
+        direction == "lower_better" and d <= -threshold
     )
-    is_regression = (
-        (direction == "higher_better" and d <= -1.0) or
-        (direction == "lower_better" and d >= 1.0)
+    is_regression = (direction == "higher_better" and d <= -1.0) or (
+        direction == "lower_better" and d >= 1.0
     )
     if is_improvement:
         return f"**{s}**"
@@ -103,14 +103,11 @@ def write_w8a8(out: list[str]) -> tuple[int, int]:
         "| Cell | Workload | Metric | M1-rb | M3-heur | M3-auto | "
         "Δ heur→auto | Δ M1rb→auto (**gate**) |"
     )
-    out.append(
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |"
-    )
+    out.append("| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |")
     n_pareto = 0
     n_regression = 0
     for model, tp, c, wl in W8A8_CELLS:
-        cells = {k: load_cell(r, model, tp, c, wl)
-                 for k, r in ROOTS_W8A8.items()}
+        cells = {k: load_cell(r, model, tp, c, wl) for k, r in ROOTS_W8A8.items()}
         if any(v is None for v in cells.values()):
             continue
         cell_id = f"{model}_tp{tp}_c{c}"
@@ -126,13 +123,11 @@ def write_w8a8(out: list[str]) -> tuple[int, int]:
                 f"{fmt_delta(d_h_a, direction)} | "
                 f"{fmt_delta(d_m1rb_auto, direction)} |"
             )
-            is_imp = (
-                (direction == "higher_better" and d_m1rb_auto >= 3.0) or
-                (direction == "lower_better" and d_m1rb_auto <= -3.0)
+            is_imp = (direction == "higher_better" and d_m1rb_auto >= 3.0) or (
+                direction == "lower_better" and d_m1rb_auto <= -3.0
             )
-            is_reg5 = (
-                (direction == "higher_better" and d_m1rb_auto <= -5.0) or
-                (direction == "lower_better" and d_m1rb_auto >= 5.0)
+            is_reg5 = (direction == "higher_better" and d_m1rb_auto <= -5.0) or (
+                direction == "lower_better" and d_m1rb_auto >= 5.0
             )
             if is_imp:
                 n_pareto += 1
@@ -159,13 +154,10 @@ def write_w4a16(out: list[str]) -> int:
         "| Cell | Workload | Metric | M1 | M3-generic | M3-mi100 | "
         "Δ generic→mi100 | Δ M1→mi100 |"
     )
-    out.append(
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |"
-    )
+    out.append("| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |")
     n_pareto = 0
     for model, tp, c, wl in W4A16_CELLS:
-        cells = {k: load_cell(r, model, tp, c, wl)
-                 for k, r in ROOTS_W4A16.items()}
+        cells = {k: load_cell(r, model, tp, c, wl) for k, r in ROOTS_W4A16.items()}
         if any(v is None for v in cells.values()):
             continue
         cell_id = f"{model}_tp{tp}_c{c}"
@@ -181,16 +173,13 @@ def write_w4a16(out: list[str]) -> int:
                 f"{fmt_delta(d_g_m, direction)} | "
                 f"{fmt_delta(d_m1_m, direction)} |"
             )
-            is_imp = (
-                (direction == "higher_better" and d_g_m >= 3.0) or
-                (direction == "lower_better" and d_g_m <= -3.0)
+            is_imp = (direction == "higher_better" and d_g_m >= 3.0) or (
+                direction == "lower_better" and d_g_m <= -3.0
             )
             if is_imp:
                 n_pareto += 1
     out.append("")
-    out.append(
-        f"**Pareto bar (≥3% gain generic→mi100):** {n_pareto} metric(s)"
-    )
+    out.append(f"**Pareto bar (≥3% gain generic→mi100):** {n_pareto} metric(s)")
     out.append("")
     return n_pareto
 
@@ -201,14 +190,16 @@ def write_perplexity(out: list[str]) -> None:
     out.append("| Run | Perplexity | Δ vs reference |")
     out.append("| --- | ---: | ---: |")
     files = [
-        ("M1-rebaseline (W8A8 reference)",
-         Path("/root/bench-int8-w4a16/m1-rebaseline/ppl_w8a8_m1rb.json")),
-        ("M3-autotune W8A8",
-         Path("/root/bench-int8-w4a16/m3/ppl_w8a8_m3.json")),
-        ("M0 baseline (W4A16 reference)",
-         Path("/root/bench-int8-w4a16/baseline/ppl_w4a16.json")),
-        ("M3-mi100 W4A16",
-         Path("/root/bench-int8-w4a16/m3/ppl_w4a16_m3.json")),
+        (
+            "M1-rebaseline (W8A8 reference)",
+            Path("/root/bench-int8-w4a16/m1-rebaseline/ppl_w8a8_m1rb.json"),
+        ),
+        ("M3-autotune W8A8", Path("/root/bench-int8-w4a16/m3/ppl_w8a8_m3.json")),
+        (
+            "M0 baseline (W4A16 reference)",
+            Path("/root/bench-int8-w4a16/baseline/ppl_w4a16.json"),
+        ),
+        ("M3-mi100 W4A16", Path("/root/bench-int8-w4a16/m3/ppl_w4a16_m3.json")),
     ]
     ref_w8a8 = None
     ref_w4a16 = None
@@ -263,8 +254,7 @@ def main() -> int:
     out.append("")
     out.append("```")
     out.append(
-        "# Autotune configs already in"
-        " vllm/model_executor/kernels/configs/gfx908/"
+        "# Autotune configs already in vllm/model_executor/kernels/configs/gfx908/"
     )
     out.append("scripts/mi100/run_grid.sh m3-w8a8-autotune w8a8_")
     out.append("scripts/mi100/run_grid.sh m3-w8a8-heuristic w8a8_")
@@ -294,9 +284,7 @@ def main() -> int:
         f"- W8A8 M3-autotune-vs-M1rb: {n_pareto_w8a8} metric(s) ≥ 3% gain; "
         f"{n_reg_w8a8} metric(s) regress > 5%."
     )
-    out.append(
-        f"- W4A16 mi100-vs-generic: {n_pareto_w4a16} metric(s) ≥ 3% gain."
-    )
+    out.append(f"- W4A16 mi100-vs-generic: {n_pareto_w4a16} metric(s) ≥ 3% gain.")
     out.append("")
     out.append("## Files")
     out.append("")
@@ -316,9 +304,7 @@ def main() -> int:
         "- W4A16 generic cells: "
         "`/root/bench-int8-w4a16/m3/w4a16/generic/{synthetic,coding}/`"
     )
-    out.append(
-        "- Pareto exceptions: `/root/bench-int8-w4a16/m3/pareto_exceptions.md`"
-    )
+    out.append("- Pareto exceptions: `/root/bench-int8-w4a16/m3/pareto_exceptions.md`")
     out.append("")
 
     print("\n".join(out))

--- a/scripts/mi100/aggregate_m4.py
+++ b/scripts/mi100/aggregate_m4.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Aggregate M4 W8A8 grid results into a markdown table.
 
 Compares the M4 W8A8 W8A8 path under two settings:
@@ -17,6 +18,7 @@ verdict).
 Usage:
     /opt/vllm-env/bin/python3 scripts/mi100/aggregate_m4.py > _m4_grid.md
 """
+
 from __future__ import annotations
 
 import json
@@ -33,18 +35,18 @@ W8A8_CELLS = [
 ROOTS = {
     "M3-auto": Path("/root/bench-int8-w4a16/m3/w8a8/autotune"),
     "M3-heur": Path("/root/bench-int8-w4a16/m3/w8a8/heuristic"),
-    "M4-CK":   Path("/root/bench-int8-w4a16/m4/w8a8/ck"),
+    "M4-CK": Path("/root/bench-int8-w4a16/m4/w8a8/ck"),
     "M4-noCk": Path("/root/bench-int8-w4a16/m4/w8a8/noCk"),
 }
 
 # (key, label, direction)
 METRICS = [
-    ("output_throughput_toks_s", "tput",      "higher_better"),
-    ("request_throughput_req_s", "req_tput",  "higher_better"),
-    ("mean_ttft_ms",             "mean_ttft", "lower_better"),
-    ("p99_ttft_ms",              "p99_ttft",  "lower_better"),
-    ("mean_tpot_ms",             "mean_tpot", "lower_better"),
-    ("p99_tpot_ms",              "p99_tpot",  "lower_better"),
+    ("output_throughput_toks_s", "tput", "higher_better"),
+    ("request_throughput_req_s", "req_tput", "higher_better"),
+    ("mean_ttft_ms", "mean_ttft", "lower_better"),
+    ("p99_ttft_ms", "p99_ttft", "lower_better"),
+    ("mean_tpot_ms", "mean_tpot", "lower_better"),
+    ("p99_tpot_ms", "p99_tpot", "lower_better"),
 ]
 
 
@@ -70,13 +72,11 @@ def fmt_delta(d: float, direction: str, threshold: float = 3.0) -> str:
         return "—"
     sign = "+" if d > 0 else ""
     s = f"{sign}{d:.2f}%"
-    is_imp = (
-        (direction == "higher_better" and d >= threshold)
-        or (direction == "lower_better" and d <= -threshold)
+    is_imp = (direction == "higher_better" and d >= threshold) or (
+        direction == "lower_better" and d <= -threshold
     )
-    is_reg = (
-        (direction == "higher_better" and d <= -1.0)
-        or (direction == "lower_better" and d >= 1.0)
+    is_reg = (direction == "higher_better" and d <= -1.0) or (
+        direction == "lower_better" and d >= 1.0
     )
     if is_imp:
         return f"**{s}**"
@@ -111,9 +111,7 @@ def write_grid(out: list[str]) -> dict:
         "| Cell | Workload | Metric | M3-auto | M3-heur | M4-noCk | "
         "M4-CK | Δ noCk→CK | Δ M3-auto→CK (**gate**) | Δ M3-best→CK |"
     )
-    out.append(
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
-    )
+    out.append("| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
 
     n_pareto_gate = 0
     n_reg5_gate = 0
@@ -160,13 +158,11 @@ def write_grid(out: list[str]) -> dict:
                 f"{fmt_delta(d_b_c, direction)} |"
             )
 
-            is_imp = (
-                (direction == "higher_better" and d_a_c >= 3.0)
-                or (direction == "lower_better" and d_a_c <= -3.0)
+            is_imp = (direction == "higher_better" and d_a_c >= 3.0) or (
+                direction == "lower_better" and d_a_c <= -3.0
             )
-            is_reg5 = (
-                (direction == "higher_better" and d_a_c <= -5.0)
-                or (direction == "lower_better" and d_a_c >= 5.0)
+            is_reg5 = (direction == "higher_better" and d_a_c <= -5.0) or (
+                direction == "lower_better" and d_a_c >= 5.0
             )
             if is_imp:
                 n_pareto_gate += 1
@@ -178,7 +174,7 @@ def write_grid(out: list[str]) -> dict:
             ("M3-auto", m3a["output_throughput_toks_s"]),
             ("M3-heur", m3h["output_throughput_toks_s"]),
             ("M4-noCk", m4n["output_throughput_toks_s"]),
-            ("M4-CK",   m4c["output_throughput_toks_s"]),
+            ("M4-CK", m4c["output_throughput_toks_s"]),
             key=lambda x: x[1],
         )
         cell_winners[f"{cell_id}_{wl}"] = winner_throughput[0]
@@ -197,9 +193,7 @@ def write_grid(out: list[str]) -> dict:
         f"**Pareto bar (≥3% gain M3-auto → M4-CK on any metric):** "
         f"{n_pareto_gate} metric(s)"
     )
-    out.append(
-        f"**>5% regressions (M3-auto → M4-CK):** {n_reg5_gate} metric(s)"
-    )
+    out.append(f"**>5% regressions (M3-auto → M4-CK):** {n_reg5_gate} metric(s)")
     out.append("")
     out.append(
         f"**Throughput geomean M4-CK / M3-auto:** "
@@ -234,12 +228,12 @@ def write_perplexity(out: list[str]) -> None:
     out.append("| Run | Perplexity | Δ vs M1-rebaseline |")
     out.append("| --- | ---: | ---: |")
     files = [
-        ("M1-rebaseline (W8A8 reference)",
-         Path("/root/bench-int8-w4a16/m1-rebaseline/ppl_w8a8_m1rb.json")),
-        ("M3-autotune W8A8",
-         Path("/root/bench-int8-w4a16/m3/ppl_w8a8_m3.json")),
-        ("M4-CK W8A8",
-         Path("/root/bench-int8-w4a16/m4/ppl_w8a8_m4_ck.json")),
+        (
+            "M1-rebaseline (W8A8 reference)",
+            Path("/root/bench-int8-w4a16/m1-rebaseline/ppl_w8a8_m1rb.json"),
+        ),
+        ("M3-autotune W8A8", Path("/root/bench-int8-w4a16/m3/ppl_w8a8_m3.json")),
+        ("M4-CK W8A8", Path("/root/bench-int8-w4a16/m4/ppl_w8a8_m4_ck.json")),
     ]
     ref = None
     for label, p in files:
@@ -297,16 +291,10 @@ def main() -> int:
     )
     out.append("")
     out.append("```")
-    out.append(
-        "# CK path (default, CK > hipBLASLt > Triton)"
-    )
-    out.append(
-        "NUM_PROMPTS=200 scripts/mi100/run_grid.sh m4-w8a8-ck w8a8_"
-    )
+    out.append("# CK path (default, CK > hipBLASLt > Triton)")
+    out.append("NUM_PROMPTS=200 scripts/mi100/run_grid.sh m4-w8a8-ck w8a8_")
     out.append("# noCk path (VLLM_DISABLE_CK=1, hipBLASLt > Triton)")
-    out.append(
-        "NUM_PROMPTS=200 scripts/mi100/run_grid.sh m4-w8a8-noCk w8a8_"
-    )
+    out.append("NUM_PROMPTS=200 scripts/mi100/run_grid.sh m4-w8a8-noCk w8a8_")
     out.append("```")
     out.append("")
 
@@ -342,23 +330,13 @@ def main() -> int:
     out.append("")
     out.append("## Files")
     out.append("")
+    out.append("- M4-CK cells: `/root/bench-int8-w4a16/m4/w8a8/ck/{synthetic,coding}/`")
     out.append(
-        "- M4-CK cells: "
-        "`/root/bench-int8-w4a16/m4/w8a8/ck/{synthetic,coding}/`"
+        "- M4-noCk cells: `/root/bench-int8-w4a16/m4/w8a8/noCk/{synthetic,coding}/`"
     )
-    out.append(
-        "- M4-noCk cells: "
-        "`/root/bench-int8-w4a16/m4/w8a8/noCk/{synthetic,coding}/`"
-    )
-    out.append(
-        "- Perplexity: `/root/bench-int8-w4a16/m4/ppl_w8a8_m4_ck.json`"
-    )
-    out.append(
-        "- TP=4 startup: `/root/bench-int8-w4a16/m4/tp4_w8a8_startup.json`"
-    )
-    out.append(
-        "- Pareto exceptions: `/root/bench-int8-w4a16/m4/pareto_exceptions.md`"
-    )
+    out.append("- Perplexity: `/root/bench-int8-w4a16/m4/ppl_w8a8_m4_ck.json`")
+    out.append("- TP=4 startup: `/root/bench-int8-w4a16/m4/tp4_w8a8_startup.json`")
+    out.append("- Pareto exceptions: `/root/bench-int8-w4a16/m4/pareto_exceptions.md`")
     out.append("")
 
     print("\n".join(out))

--- a/scripts/mi100/autotune_sweep.py
+++ b/scripts/mi100/autotune_sweep.py
@@ -39,6 +39,7 @@ log, and the resulting "best config" gets persisted to:
 with full provenance (timestamp, vllm git SHA, ROCm version, hash of the
 kernel source file).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -139,9 +140,7 @@ def _prune_w8a8(cfg: SweepConfig, M: int, N: int, K: int) -> str | None:
         return "block_n_gt_N"
     if cfg.BLOCK_K > K:
         return "block_k_gt_K"
-    if cfg.matrix_instr_nonkdim == 32 and (
-        cfg.BLOCK_M < 32 or cfg.BLOCK_N < 32
-    ):
+    if cfg.matrix_instr_nonkdim == 32 and (cfg.BLOCK_M < 32 or cfg.BLOCK_N < 32):
         return "nonkdim32_needs_>=32_tiles"
     return None
 
@@ -160,9 +159,7 @@ def _prune_w4a16(
         return f"lds_overflow_{a_bytes + b_bytes}B"
     if cfg.BLOCK_N > N:
         return "block_n_gt_N"
-    if cfg.matrix_instr_nonkdim == 32 and (
-        cfg.BLOCK_M < 32 or cfg.BLOCK_N < 32
-    ):
+    if cfg.matrix_instr_nonkdim == 32 and (cfg.BLOCK_M < 32 or cfg.BLOCK_N < 32):
         return "nonkdim32_needs_>=32_tiles"
     return None
 
@@ -172,6 +169,7 @@ def _next_pow2(x: int) -> int:
 
 
 # --------------------------- W8A8 path ---------------------------------------
+
 
 def _bench_w8a8_one_config(
     cfg: SweepConfig, M: int, N: int, K: int, trials: int
@@ -208,11 +206,21 @@ def _bench_w8a8_one_config(
 
     def _launch():
         mi100_int8_scaled_mm_kernel[grid](
-            a, b, sa, sb, out, None,
-            M, N, K,
-            a.stride(0), a.stride(1),
-            b.stride(0), b.stride(1),
-            out.stride(0), out.stride(1),
+            a,
+            b,
+            sa,
+            sb,
+            out,
+            None,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            out.stride(0),
+            out.stride(1),
             BLOCK_SIZE_M=cfg.BLOCK_M,
             BLOCK_SIZE_N=cfg.BLOCK_N,
             BLOCK_SIZE_K=cfg.BLOCK_K,
@@ -226,14 +234,14 @@ def _bench_w8a8_one_config(
     try:
         for _ in range(WARMUP_ITERS):
             _launch()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         # Time `trials` runs and return the median in ms.
         timings: list[float] = []
         for _ in range(trials):
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             t0 = time.perf_counter()
             _launch()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             timings.append((time.perf_counter() - t0) * 1000.0)
         timings.sort()
         return timings[len(timings) // 2], None
@@ -242,6 +250,7 @@ def _bench_w8a8_one_config(
 
 
 # --------------------------- W4A16 path --------------------------------------
+
 
 def _bench_w4a16_one_config(
     cfg: SweepConfig, M: int, N: int, K: int, group_size: int, trials: int
@@ -257,8 +266,7 @@ def _bench_w4a16_one_config(
     b_packed = torch.randint(
         0, 0x7FFFFFFF, (K, N // 8), dtype=torch.int32, device="cuda"
     )
-    scales = torch.rand((K // group_size, N), dtype=torch.float16,
-                        device="cuda") * 0.01
+    scales = torch.rand((K // group_size, N), dtype=torch.float16, device="cuda") * 0.01
     out = torch.empty((M, N), dtype=torch.float16, device="cuda")
     grid = (triton.cdiv(M, cfg.BLOCK_M), triton.cdiv(N, cfg.BLOCK_N))
 
@@ -274,11 +282,20 @@ def _bench_w4a16_one_config(
 
     def _launch():
         mi100_w4a16_gemm_kernel[grid](
-            a, b_packed, scales, b_packed, out,  # zeros_ptr=dummy when no zp
-            M, N, K,
-            a.stride(0), a.stride(1),
-            b_packed.stride(0), b_packed.stride(1),
-            out.stride(0), out.stride(1),
+            a,
+            b_packed,
+            scales,
+            b_packed,
+            out,  # zeros_ptr=dummy when no zp
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b_packed.stride(0),
+            b_packed.stride(1),
+            out.stride(0),
+            out.stride(1),
             group_size=group_size,
             HAS_ZP=False,
             ZP_BIAS=8,
@@ -292,13 +309,13 @@ def _bench_w4a16_one_config(
     try:
         for _ in range(WARMUP_ITERS):
             _launch()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         timings: list[float] = []
         for _ in range(trials):
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             t0 = time.perf_counter()
             _launch()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             timings.append((time.perf_counter() - t0) * 1000.0)
         timings.sort()
         return timings[len(timings) // 2], None
@@ -307,6 +324,7 @@ def _bench_w4a16_one_config(
 
 
 # --------------------------- Driver ------------------------------------------
+
 
 def _git_sha() -> str:
     try:
@@ -320,13 +338,9 @@ def _git_sha() -> str:
 
 def _kernel_source_sha(kernel: str) -> str:
     if kernel == "w8a8":
-        path = (
-            REPO / "vllm/model_executor/kernels/linear/scaled_mm/mi100_int8.py"
-        )
+        path = REPO / "vllm/model_executor/kernels/linear/scaled_mm/mi100_int8.py"
     elif kernel == "w4a16":
-        path = (
-            REPO / "vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16.py"
-        )
+        path = REPO / "vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16.py"
     else:
         return ""
     if not path.exists():
@@ -335,8 +349,15 @@ def _kernel_source_sha(kernel: str) -> str:
 
 
 def _persist_best(
-    kernel: str, M: int, N: int, K: int, group_size: int | None,
-    best_cfg: SweepConfig, best_ms: float, evaluated: int, pruned: int,
+    kernel: str,
+    M: int,
+    N: int,
+    K: int,
+    group_size: int | None,
+    best_cfg: SweepConfig,
+    best_ms: float,
+    evaluated: int,
+    pruned: int,
     out_dir: Path,
     cartesian_total: int = 0,
     legal_subset: int = 0,
@@ -358,7 +379,9 @@ def _persist_best(
         "schema_version": 1,
         "kernel": config_key,
         "shape": {
-            "M": M, "N": N, "K": K,
+            "M": M,
+            "N": N,
+            "K": K,
             "group_size": group_size,
         },
         "config": {
@@ -391,27 +414,35 @@ def _persist_best(
     return fpath
 
 
-def _shapes_for_kernel(kernel: str, hot_path: Path,
-                       extra: list[tuple[int, int, int, int | None]]
-                       ) -> list[tuple[int, int, int, int | None]]:
+def _shapes_for_kernel(
+    kernel: str, hot_path: Path, extra: list[tuple[int, int, int, int | None]]
+) -> list[tuple[int, int, int, int | None]]:
     """Return (M, N, K, group_size_or_None) tuples to tune."""
     if extra:
         return extra
     # Curated shapes for Qwen3.5-9B that matter on TP=1 and TP=4.
     # Hidden=4096, FFN=12288.
     # TP=1 prefill (M ~= 512), TP=4 prefill (M ~= 512), decode (M ~= 1).
-    qkv_tp1 = (4096, 10240)   # qkv
-    o_tp1 = (4096, 4096)      # o_proj
+    qkv_tp1 = (4096, 10240)  # qkv
+    o_tp1 = (4096, 4096)  # o_proj
     gate_up_tp1 = (4096, 24576)  # gate_up
     down_tp1 = (12288, 4096)  # down_proj
-    qkv_tp4 = (4096, 2560)    # qkv sharded by 4
-    o_tp4 = (1024, 4096)      # o_proj K sharded
+    qkv_tp4 = (4096, 2560)  # qkv sharded by 4
+    o_tp4 = (1024, 4096)  # o_proj K sharded
     gate_up_tp4 = (4096, 6144)
     down_tp4 = (3072, 4096)
 
-    layers = [qkv_tp1, o_tp1, gate_up_tp1, down_tp1,
-              qkv_tp4, o_tp4, gate_up_tp4, down_tp4]
-    Ms = [1, 32, 128, 512]    # decode + prefill regimes
+    layers = [
+        qkv_tp1,
+        o_tp1,
+        gate_up_tp1,
+        down_tp1,
+        qkv_tp4,
+        o_tp4,
+        gate_up_tp4,
+        down_tp4,
+    ]
+    Ms = [1, 32, 128, 512]  # decode + prefill regimes
 
     out: list[tuple[int, int, int, int | None]] = []
     for M in Ms:
@@ -433,15 +464,21 @@ def main() -> int:
     p.add_argument("--log-dir", default=str(DEFAULT_LOG))
     p.add_argument("--trials-per-config", type=int, default=TIMING_ITERS)
     p.add_argument(
-        "--max-configs", type=int, default=0,
+        "--max-configs",
+        type=int,
+        default=0,
         help="Debug: cap cartesian product (0 = full sweep).",
     )
     p.add_argument(
-        "--shape", action="append", default=[],
+        "--shape",
+        action="append",
+        default=[],
         help='Debug: tune one shape "M,N,K[,group]".',
     )
     p.add_argument(
-        "--max-shapes", type=int, default=0,
+        "--max-shapes",
+        type=int,
+        default=0,
         help="Debug: cap number of shapes processed (0 = all).",
     )
     args = p.parse_args()
@@ -455,9 +492,7 @@ def main() -> int:
     for raw in args.shape:
         parts = raw.split(",")
         if len(parts) == 3:
-            extra_shapes.append(
-                (int(parts[0]), int(parts[1]), int(parts[2]), None)
-            )
+            extra_shapes.append((int(parts[0]), int(parts[1]), int(parts[2]), None))
         elif len(parts) == 4:
             extra_shapes.append(
                 (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
@@ -465,9 +500,7 @@ def main() -> int:
         else:
             raise SystemExit(f"--shape malformed: {raw}")
 
-    shapes = _shapes_for_kernel(
-        args.kernel, Path(args.shapes_json), extra_shapes
-    )
+    shapes = _shapes_for_kernel(args.kernel, Path(args.shapes_json), extra_shapes)
     if args.max_shapes > 0:
         shapes = shapes[: args.max_shapes]
 
@@ -509,18 +542,13 @@ def main() -> int:
                 reason = _prune_w4a16(cfg, M, N, K, group_size or 128)
             if reason is not None:
                 pruned += 1
-                log_fh.write(
-                    f"PRUNED {cfg.as_launch_kwargs()} reason={reason}\n"
-                )
+                log_fh.write(f"PRUNED {cfg.as_launch_kwargs()} reason={reason}\n")
                 continue
             if args.kernel == "w8a8":
-                ms, err = _bench_w8a8_one_config(
-                    cfg, M, N, K, args.trials_per_config
-                )
+                ms, err = _bench_w8a8_one_config(cfg, M, N, K, args.trials_per_config)
             else:
                 ms, err = _bench_w4a16_one_config(
-                    cfg, M, N, K,
-                    group_size or 128, args.trials_per_config
+                    cfg, M, N, K, group_size or 128, args.trials_per_config
                 )
             evaluated += 1
             row = {
@@ -556,12 +584,15 @@ def main() -> int:
         # different shape could legitimately use it.
         if args.kernel == "w8a8":
             hard_invariants = {
-                "lds_overflow", "nonkdim32_needs_>=32_tiles",
+                "lds_overflow",
+                "nonkdim32_needs_>=32_tiles",
             }
         else:
             hard_invariants = {
-                "block_k_gt_group", "block_n_not_multiple_of_8",
-                "lds_overflow", "nonkdim32_needs_>=32_tiles",
+                "block_k_gt_group",
+                "block_n_not_multiple_of_8",
+                "lds_overflow",
+                "nonkdim32_needs_>=32_tiles",
             }
         legal_subset = 0
         eliminated_by_hard_invariant = 0
@@ -576,28 +607,30 @@ def main() -> int:
             # Check whether this prune reason is a hard invariant
             # (would also eliminate the config for any other
             # shape) vs a shape-specific filter.
-            is_hard = any(
-                r.startswith(inv) for inv in hard_invariants
-            )
+            is_hard = any(r.startswith(inv) for inv in hard_invariants)
             if is_hard:
                 eliminated_by_hard_invariant += 1
             else:
                 legal_subset += 1
-        legal_pct = (
-            (evaluated / legal_subset) * 100.0 if legal_subset else 0.0
-        )
+        legal_pct = (evaluated / legal_subset) * 100.0 if legal_subset else 0.0
         logger.info(
             "best %s: %s @ %.4f ms",
-            prefix, best_cfg.as_launch_kwargs(), best_ms,
+            prefix,
+            best_cfg.as_launch_kwargs(),
+            best_ms,
         )
         logger.info(
             "  cartesian-coverage: evaluated %d/%d = %.1f%%",
-            evaluated, cart_total, evaluated_pct,
+            evaluated,
+            cart_total,
+            evaluated_pct,
         )
         logger.info(
             "  legal-coverage:     evaluated %d/%d = %.1f%% "
             "(eliminated by hard invariants: %d)",
-            evaluated, legal_subset, legal_pct,
+            evaluated,
+            legal_subset,
+            legal_pct,
             eliminated_by_hard_invariant,
         )
         log_fh.write(
@@ -609,8 +642,16 @@ def main() -> int:
         )
 
         out_path = _persist_best(
-            args.kernel, M, N, K, group_size,
-            best_cfg, best_ms, evaluated, pruned, out_dir,
+            args.kernel,
+            M,
+            N,
+            K,
+            group_size,
+            best_cfg,
+            best_ms,
+            evaluated,
+            pruned,
+            out_dir,
             cartesian_total=cart_total,
             legal_subset=legal_subset,
             eliminated_by_hard_invariant=eliminated_by_hard_invariant,
@@ -635,12 +676,8 @@ def main() -> int:
     # is verifiable without re-deriving numbers from per-shape JSONs.
     cart_total_global = len(_enumerate_configs())
     if summary_rows:
-        legal_avg = sum(r["legal_subset"] for r in summary_rows) / len(
-            summary_rows
-        )
-        cov_avg = sum(r["legal_coverage_pct"] for r in summary_rows) / len(
-            summary_rows
-        )
+        legal_avg = sum(r["legal_subset"] for r in summary_rows) / len(summary_rows)
+        cov_avg = sum(r["legal_coverage_pct"] for r in summary_rows) / len(summary_rows)
     else:
         legal_avg = 0.0
         cov_avg = 0.0
@@ -663,14 +700,19 @@ def main() -> int:
     }
 
     summary_path = log_dir / f"sweep_{args.kernel}_summary.json"
-    summary_path.write_text(json.dumps({
-        "kernel": args.kernel,
-        "shapes": summary_rows,
-        "cartesian_total": cart_total_global,
-        "coverage_summary": coverage_summary,
-        "trials_per_config": args.trials_per_config,
-        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
-    }, indent=2))
+    summary_path.write_text(
+        json.dumps(
+            {
+                "kernel": args.kernel,
+                "shapes": summary_rows,
+                "cartesian_total": cart_total_global,
+                "coverage_summary": coverage_summary,
+                "trials_per_config": args.trials_per_config,
+                "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+            },
+            indent=2,
+        )
+    )
 
     logger.info("=" * 70)
     logger.info("Sweep coverage summary (kernel=%s):", args.kernel)
@@ -683,11 +725,14 @@ def main() -> int:
             shape_str,
             r["legal_subset"],
             r["evaluated"],
-            r["evaluated"], r["legal_subset"], r["legal_coverage_pct"],
+            r["evaluated"],
+            r["legal_subset"],
+            r["legal_coverage_pct"],
         )
     logger.info(
         "  average legal-coverage   = %.1f%% across %d shapes",
-        cov_avg, len(summary_rows),
+        cov_avg,
+        len(summary_rows),
     )
     logger.info("=" * 70)
     logger.info("summary written to %s", summary_path)

--- a/scripts/mi100/backfill_legal_coverage.py
+++ b/scripts/mi100/backfill_legal_coverage.py
@@ -15,6 +15,7 @@ predicates used in ``scripts/mi100/autotune_sweep.py`` and writes the
 extra fields into each config JSON without re-running the costly bench
 loop.
 """
+
 from __future__ import annotations
 
 import json
@@ -34,13 +35,16 @@ CONFIG_DIR = REPO / "vllm/model_executor/kernels/configs/gfx908"
 
 W8A8_HARD = ("lds_overflow", "nonkdim32_needs_>=32_tiles")
 W4A16_HARD = (
-    "block_k_gt_group", "block_n_not_multiple_of_8",
-    "lds_overflow", "nonkdim32_needs_>=32_tiles",
+    "block_k_gt_group",
+    "block_n_not_multiple_of_8",
+    "lds_overflow",
+    "nonkdim32_needs_>=32_tiles",
 )
 
 
-def _legal_for_shape(kernel: str, M: int, N: int, K: int,
-                     group_size: int | None) -> tuple[int, int, int]:
+def _legal_for_shape(
+    kernel: str, M: int, N: int, K: int, group_size: int | None
+) -> tuple[int, int, int]:
     cart_total = 0
     legal = 0
     eliminated_hard = 0
@@ -76,9 +80,7 @@ def main() -> int:
         gs = shape.get("group_size")
         if not (kernel and M and N and K):
             continue
-        cart_total, legal, hard_eliminated = _legal_for_shape(
-            kernel, M, N, K, gs
-        )
+        cart_total, legal, hard_eliminated = _legal_for_shape(kernel, M, N, K, gs)
         evaluated = blob.get("autotune_runs_evaluated", 0)
         legal_pct = (evaluated / legal * 100.0) if legal else 0.0
         blob["autotune_cartesian_total"] = cart_total

--- a/scripts/mi100/coding_agent_eval.py
+++ b/scripts/mi100/coding_agent_eval.py
@@ -1,4 +1,6 @@
 #!/opt/vllm-env/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Self-contained coding-agent eval for a live vLLM OpenAI server.
 
 Reconstructs the legacy ``/root/benchmark-scripts/coding_agent_bench.py``
@@ -36,15 +38,17 @@ scored generically via ``test`` / ``canonical_solution`` / ``expected`` keys.
 """
 
 import argparse
+import contextlib
 import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
 import time
 import urllib.error
 import urllib.request
+
+import regex as re
 
 DEFAULT_TIMEOUT = 600
 SANDBOX_TIMEOUT = 10
@@ -175,8 +179,7 @@ CODING_TASKS: list[dict] = [
         "id": "count_vowels",
         "prompt": _prompt(
             "def count_vowels(s: str) -> int:",
-            "Return the number of vowels (a, e, i, o, u, case-insensitive) "
-            "in `s`.",
+            "Return the number of vowels (a, e, i, o, u, case-insensitive) in `s`.",
         ),
         "test": (
             "assert count_vowels('hello world') == 3\n"
@@ -208,9 +211,7 @@ CODING_TASKS: list[dict] = [
         # ([4, -1, 2, 1]). This fixture deliberately asserts 7, an upstream
         # artifact preserved so the locked baseline reference stays honest. A
         # correct Kadane implementation will (correctly) fail this assertion.
-        "test": (
-            "assert max_subarray([-2, 1, -3, 4, -1, 2, 1, -5, 4]) == 7\n"
-        ),
+        "test": ("assert max_subarray([-2, 1, -3, 4, -1, 2, 1, -5, 4]) == 7\n"),
     },
 ]
 
@@ -287,10 +288,8 @@ def run_in_sandbox(source):
     except Exception:  # noqa: BLE001 - timeout / spawn failure => not a pass
         return False
     finally:
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(tmp_path)
-        except OSError:
-            pass
 
 
 def score_task(task, completion):
@@ -368,7 +367,11 @@ def main():
         tasks = load_tasks(args.tasks, args.limit)
         source = args.tasks
     else:
-        tasks = CODING_TASKS[: args.limit] if args.limit and args.limit > 0 else CODING_TASKS
+        tasks = (
+            CODING_TASKS[: args.limit]
+            if args.limit and args.limit > 0
+            else CODING_TASKS
+        )
         source = "embedded"
 
     per_prompt = []

--- a/scripts/mi100/coding_agent_eval.py
+++ b/scripts/mi100/coding_agent_eval.py
@@ -14,7 +14,7 @@ loading itself -- run it against an ALREADY-RUNNING vLLM OpenAI server (for the
 M0 reference: legacy W4A16, marlin OFF).
 
 Interpreter: /opt/vllm-env/bin/python3 (NOT uv/.venv).
-Dependencies: Python stdlib only.
+Dependencies: Python stdlib + regex.
 
 Prompt set / scoring
 --------------------

--- a/scripts/mi100/gen_tensilelite_configs.py
+++ b/scripts/mi100/gen_tensilelite_configs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Generate per-shape TensileLite tuning YAMLs for gfx908 INT8 W8A8 GEMMs.
 
@@ -19,6 +20,7 @@ The YAML emitted here matches that contraction. Per-host gotchas:
     v_mfma_i32_32x32x8i8. We tune over a small grid of MT/DepthU
     combinations targeting the W8A8 hot shapes.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -120,13 +122,13 @@ LibraryClient:
 # Macro tile = MFMA_M * ThreadTileM * WGM (etc).
 MATRIX_INSTRUCTIONS = [
     # mfma 16x16x16i8 — flexible, smaller waves, good for skinny prefill.
-    [16, 16, 16, 1, 1, 1, 1, 4, 1],   # MT 64 x 64
-    [16, 16, 16, 1, 1, 2, 2, 4, 1],   # MT 128 x 128
-    [16, 16, 16, 1, 1, 1, 2, 4, 1],   # MT 64 x 128
-    [16, 16, 16, 1, 1, 2, 1, 4, 1],   # MT 128 x 64
+    [16, 16, 16, 1, 1, 1, 1, 4, 1],  # MT 64 x 64
+    [16, 16, 16, 1, 1, 2, 2, 4, 1],  # MT 128 x 128
+    [16, 16, 16, 1, 1, 1, 2, 4, 1],  # MT 64 x 128
+    [16, 16, 16, 1, 1, 2, 1, 4, 1],  # MT 128 x 64
     # mfma 32x32x8i8 — bigger MFMA, fewer waves; good for fat M shapes.
-    [32, 32, 8, 1, 1, 1, 1, 2, 1],    # MT 64 x 64
-    [32, 32, 8, 1, 1, 2, 2, 2, 1],    # MT 128 x 128
+    [32, 32, 8, 1, 1, 1, 1, 2, 1],  # MT 64 x 64
+    [32, 32, 8, 1, 1, 2, 2, 2, 1],  # MT 128 x 128
 ]
 
 
@@ -139,10 +141,15 @@ def render_matrix_instr_block() -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--shapes-json", type=Path, required=True,
-                    help="Manifest from select_w8a8_tuning_shapes.py")
-    ap.add_argument("--out-dir", type=Path, required=True,
-                    help="Where to write per-shape YAMLs.")
+    ap.add_argument(
+        "--shapes-json",
+        type=Path,
+        required=True,
+        help="Manifest from select_w8a8_tuning_shapes.py",
+    )
+    ap.add_argument(
+        "--out-dir", type=Path, required=True, help="Where to write per-shape YAMLs."
+    )
     args = ap.parse_args()
 
     manifest = json.loads(args.shapes_json.read_text())
@@ -154,15 +161,19 @@ def main() -> int:
     for s in shapes:
         M, N, K = int(s["M"]), int(s["N"]), int(s["K"])
         out = args.out_dir / f"tune_M{M}_N{N}_K{K}.yaml"
-        out.write_text(TUNING_YAML_TMPL.format(
-            M=M, N=N, K=K, matrix_instr_block=matrix_block,
-        ))
+        out.write_text(
+            TUNING_YAML_TMPL.format(
+                M=M,
+                N=N,
+                K=K,
+                matrix_instr_block=matrix_block,
+            )
+        )
         written.append(str(out))
         print(f"wrote {out}")
 
     index = args.out_dir / "INDEX.json"
-    index.write_text(json.dumps({"yamls": written,
-                                 "shapes": shapes}, indent=2))
+    index.write_text(json.dumps({"yamls": written, "shapes": shapes}, indent=2))
     print(f"index: {index}")
     return 0
 

--- a/scripts/mi100/quality_eval.py
+++ b/scripts/mi100/quality_eval.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """W4A16 quality reference: WikiText-2 perplexity + needle-in-haystack.
 
 RUN ON THE gfx908 HOST BY THE ORCHESTRATOR, against an already-running vLLM
@@ -20,6 +21,7 @@ Example:
     --ppl-tokens 8192 --max-len 2048 --needle-depths 5 --needle-max-ctx 4096 \
     --out-pretty
 """
+
 from __future__ import annotations
 
 import argparse
@@ -32,7 +34,8 @@ import urllib.request
 def _post(url: str, payload: dict, timeout: float = 90.0) -> dict:
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"})
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
@@ -44,13 +47,15 @@ def _load_wikitext(path: str | None) -> str:
             lines = [ln.strip() for ln in f if ln.strip()]
         return "\n".join(lines)
     from datasets import load_dataset
+
     ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
     lines = [t.strip() for t in ds["text"] if t and t.strip()]
     return "\n".join(lines)
 
 
-def measure_perplexity(base_url: str, model: str, text: str,
-                       ppl_tokens: int, max_len_chars: int) -> dict:
+def measure_perplexity(
+    base_url: str, model: str, text: str, ppl_tokens: int, max_len_chars: int
+) -> dict:
     """Teacher-forced perplexity via a SINGLE batched echo+logprobs request.
 
     ``max_len_chars`` windows the raw text by characters (an approximation of
@@ -68,50 +73,81 @@ def measure_perplexity(base_url: str, model: str, text: str,
     windows = []
     pos = 0
     while pos < n and len(windows) < n_windows:
-        w = text[pos:pos + max_len_chars]
+        w = text[pos : pos + max_len_chars]
         pos += max_len_chars
         if w.strip():
             windows.append(w)
     if not windows:
-        return {"perplexity": None, "mean_nll": None, "scored_tokens": 0,
-                "windows": 0, "n_failed_windows": 0, "error": "no text"}
+        return {
+            "perplexity": None,
+            "mean_nll": None,
+            "scored_tokens": 0,
+            "windows": 0,
+            "n_failed_windows": 0,
+            "error": "no text",
+        }
     try:
         t0 = time.time()
-        r = _post(url, {
-            "model": model, "prompt": windows, "max_tokens": 0,
-            "echo": True, "logprobs": 1, "temperature": 0,
-        }, timeout=600.0)
+        r = _post(
+            url,
+            {
+                "model": model,
+                "prompt": windows,
+                "max_tokens": 0,
+                "echo": True,
+                "logprobs": 1,
+                "temperature": 0,
+            },
+            timeout=600.0,
+        )
         total_nll = 0.0
         scored = 0
         for ch in r["choices"]:
-            vals = [x for x in ch["logprobs"]["token_logprobs"]
-                    if x is not None]
+            vals = [x for x in ch["logprobs"]["token_logprobs"] if x is not None]
             total_nll += -sum(vals)
             scored += len(vals)
-        print(f"[ppl] {len(windows)} windows, scored {scored} tok, "
-              f"{time.time()-t0:.1f}s", flush=True)
+        print(
+            f"[ppl] {len(windows)} windows, scored {scored} tok, "
+            f"{time.time() - t0:.1f}s",
+            flush=True,
+        )
     except Exception as e:  # noqa: BLE001
-        return {"perplexity": None, "mean_nll": None, "scored_tokens": 0,
-                "windows": len(windows), "n_failed_windows": len(windows),
-                "error": f"batched echo request failed: {e}"}
+        return {
+            "perplexity": None,
+            "mean_nll": None,
+            "scored_tokens": 0,
+            "windows": len(windows),
+            "n_failed_windows": len(windows),
+            "error": f"batched echo request failed: {e}",
+        }
     if scored == 0:
-        return {"perplexity": None, "mean_nll": None, "scored_tokens": 0,
-                "windows": len(windows), "n_failed_windows": len(windows),
-                "error": "no tokens scored (echo+logprobs unsupported?)"}
+        return {
+            "perplexity": None,
+            "mean_nll": None,
+            "scored_tokens": 0,
+            "windows": len(windows),
+            "n_failed_windows": len(windows),
+            "error": "no tokens scored (echo+logprobs unsupported?)",
+        }
     mean_nll = total_nll / scored
-    return {"perplexity": math.exp(mean_nll), "mean_nll": mean_nll,
-            "scored_tokens": scored, "windows": len(windows),
-            "n_failed_windows": 0}
+    return {
+        "perplexity": math.exp(mean_nll),
+        "mean_nll": mean_nll,
+        "scored_tokens": scored,
+        "windows": len(windows),
+        "n_failed_windows": 0,
+    }
 
 
-def measure_needle(base_url: str, model: str, depths: int,
-                   max_ctx_chars: int) -> dict:
+def measure_needle(base_url: str, model: str, depths: int, max_ctx_chars: int) -> dict:
     """Insert a unique passcode at N evenly-spaced depths; check recall."""
     url = base_url.rstrip("/") + "/v1/completions"
     secret = "BLUE-WHALE-42"
     needle = f" The secret passcode is {secret}. "
-    filler = ("The garden was quiet in the early morning light. "
-              "Birds moved between the old oak branches. ")
+    filler = (
+        "The garden was quiet in the early morning light. "
+        "Birds moved between the old oak branches. "
+    )
     base = (filler * ((max_ctx_chars // len(filler)) + 1))[:max_ctx_chars]
     results = []
     passed = 0
@@ -122,14 +158,19 @@ def measure_needle(base_url: str, model: str, depths: int,
         frac = 0.0 if depths == 1 else i / (depths - 1)
         cut = int(len(base) * frac)
         hay = base[:cut] + needle + base[cut:]
-        prompt = (hay + "\n\nQuestion: What is the secret passcode?\n"
-                  "Answer:")
+        prompt = hay + "\n\nQuestion: What is the secret passcode?\nAnswer:"
         ok = False
         try:
-            r = _post(url, {
-                "model": model, "prompt": prompt, "max_tokens": 24,
-                "temperature": 0,
-            }, timeout=120.0)
+            r = _post(
+                url,
+                {
+                    "model": model,
+                    "prompt": prompt,
+                    "max_tokens": 24,
+                    "temperature": 0,
+                },
+                timeout=120.0,
+            )
             ok = secret.lower() in r["choices"][0].get("text", "").lower()
         except Exception as e:  # noqa: BLE001
             print(f"[needle] depth {frac:.2f} failed: {e}", flush=True)
@@ -144,11 +185,18 @@ def main() -> None:
     ap.add_argument("--base-url", required=True)
     ap.add_argument("--model", required=True)
     ap.add_argument("--out", required=True)
-    ap.add_argument("--wikitext", default=None,
-                    help="optional path; default loads HF wikitext-2-raw test")
+    ap.add_argument(
+        "--wikitext",
+        default=None,
+        help="optional path; default loads HF wikitext-2-raw test",
+    )
     ap.add_argument("--ppl-tokens", type=int, default=8192)
-    ap.add_argument("--max-len", type=int, default=2048,
-                    help="per-window length (chars approx tokens)")
+    ap.add_argument(
+        "--max-len",
+        type=int,
+        default=2048,
+        help="per-window length (chars approx tokens)",
+    )
     ap.add_argument("--needle-depths", type=int, default=5)
     ap.add_argument("--needle-max-ctx", type=int, default=4096)
     ap.add_argument("--out-pretty", action="store_true")
@@ -158,19 +206,27 @@ def main() -> None:
     # LAST because this vLLM build can wedge the engine on a request that
     # *follows* an echo+logprobs request. Each metric issues a single batched
     # request (see measure_* docstrings).
-    needle = measure_needle(args.base_url, args.model, args.needle_depths,
-                            args.needle_max_ctx)
+    needle = measure_needle(
+        args.base_url, args.model, args.needle_depths, args.needle_max_ctx
+    )
     print(f"[quality] needle={needle['passed']}/{needle['total']}")
     text = _load_wikitext(args.wikitext)
     print(f"[quality] wikitext chars={len(text)}")
-    ppl = measure_perplexity(args.base_url, args.model, text,
-                             args.ppl_tokens, args.max_len)
-    print(f"[quality] perplexity={ppl.get('perplexity')} "
-          f"scored={ppl.get('scored_tokens')}")
+    ppl = measure_perplexity(
+        args.base_url, args.model, text, args.ppl_tokens, args.max_len
+    )
+    print(
+        f"[quality] perplexity={ppl.get('perplexity')} "
+        f"scored={ppl.get('scored_tokens')}"
+    )
 
-    out = {**ppl, "needle": needle, "model": args.model,
-           "base_url": args.base_url,
-           "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())}
+    out = {
+        **ppl,
+        "needle": needle,
+        "model": args.model,
+        "base_url": args.base_url,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
     with open(args.out, "w", encoding="utf-8") as f:
         json.dump(out, f, indent=1 if args.out_pretty else None)
     print(f"[quality] wrote {args.out}")

--- a/scripts/mi100/regen_sweep_summary.py
+++ b/scripts/mi100/regen_sweep_summary.py
@@ -7,6 +7,7 @@ The original summary files predate the VAL-TRITON-003 amendment. This
 regenerates them from the per-shape JSONs in configs/gfx908/ so the
 coverage block is available without rerunning the bench loop.
 """
+
 from __future__ import annotations
 
 import datetime as dt
@@ -23,32 +24,36 @@ def _shapes_for(kernel: str) -> list[dict]:
     for path in sorted(CONFIG_DIR.glob(f"{kernel}_M*.json")):
         blob = json.loads(path.read_text())
         shape = blob["shape"]
-        rows.append({
-            "shape": [
-                shape["M"], shape["N"], shape["K"],
-                shape.get("group_size"),
-            ],
-            "best_ms": blob.get("measured_ms_per_iter"),
-            "best_cfg": {
-                k: v for k, v in blob["config"].items()
-                if k not in {"GROUP_SIZE_M", "num_warps"}
-            },
-            "evaluated": blob.get("autotune_runs_evaluated", 0),
-            "pruned": blob.get("autotune_runs_pruned", 0),
-            "cartesian_total": blob.get("autotune_cartesian_total", 0),
-            "evaluated_pct_of_cart": (
-                blob.get("autotune_runs_evaluated", 0)
-                / blob.get("autotune_cartesian_total", 1) * 100.0
-            ),
-            "legal_subset": blob.get("autotune_legal_subset", 0),
-            "legal_coverage_pct": blob.get(
-                "autotune_legal_coverage_pct", 0.0
-            ),
-            "hard_invariant_eliminated": blob.get(
-                "autotune_hard_invariant_eliminated", 0
-            ),
-            "out_path": str(path),
-        })
+        rows.append(
+            {
+                "shape": [
+                    shape["M"],
+                    shape["N"],
+                    shape["K"],
+                    shape.get("group_size"),
+                ],
+                "best_ms": blob.get("measured_ms_per_iter"),
+                "best_cfg": {
+                    k: v
+                    for k, v in blob["config"].items()
+                    if k not in {"GROUP_SIZE_M", "num_warps"}
+                },
+                "evaluated": blob.get("autotune_runs_evaluated", 0),
+                "pruned": blob.get("autotune_runs_pruned", 0),
+                "cartesian_total": blob.get("autotune_cartesian_total", 0),
+                "evaluated_pct_of_cart": (
+                    blob.get("autotune_runs_evaluated", 0)
+                    / blob.get("autotune_cartesian_total", 1)
+                    * 100.0
+                ),
+                "legal_subset": blob.get("autotune_legal_subset", 0),
+                "legal_coverage_pct": blob.get("autotune_legal_coverage_pct", 0.0),
+                "hard_invariant_eliminated": blob.get(
+                    "autotune_hard_invariant_eliminated", 0
+                ),
+                "out_path": str(path),
+            }
+        )
     return rows
 
 
@@ -80,14 +85,20 @@ def _emit(kernel: str) -> None:
     sweep_kernel = name_map[kernel]
     out = LOG_DIR / f"sweep_{sweep_kernel}_summary.json"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps({
-        "kernel": sweep_kernel,
-        "shapes": rows,
-        "cartesian_total": cart_total_global,
-        "coverage_summary": coverage_summary,
-        "regenerated_from": "per-shape config JSONs",
-        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
-    }, indent=2) + "\n")
+    out.write_text(
+        json.dumps(
+            {
+                "kernel": sweep_kernel,
+                "shapes": rows,
+                "cartesian_total": cart_total_global,
+                "coverage_summary": coverage_summary,
+                "regenerated_from": "per-shape config JSONs",
+                "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
     print(f"wrote {out}")
     # Pretty-print summary line for the validator log.
     for r in rows:
@@ -98,9 +109,7 @@ def _emit(kernel: str) -> None:
             f"legal-coverage = {r['evaluated']}/{r['legal_subset']} = "
             f"{r['legal_coverage_pct']:.1f}%"
         )
-    print(
-        f"  average legal-coverage = {cov_avg:.1f}% across {len(rows)} shapes"
-    )
+    print(f"  average legal-coverage = {cov_avg:.1f}% across {len(rows)} shapes")
 
 
 def main() -> int:

--- a/scripts/mi100/select_w8a8_tuning_shapes.py
+++ b/scripts/mi100/select_w8a8_tuning_shapes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Pick a small set of representative W8A8 (M, N, K) shapes to drive the
 TensileLite tuning campaign and the dispatcher allowlist.
@@ -15,6 +16,7 @@ Outputs:
   - tuning manifest JSON (sorted, keyed by (M, N, K))
   - human-readable shape catalog markdown
 """
+
 from __future__ import annotations
 
 import argparse
@@ -25,16 +27,33 @@ from pathlib import Path
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--in-csv", type=Path, required=True,
-                    help="Aggregated CSV from dump_gemm_shapes.py")
-    ap.add_argument("--out-json", type=Path, required=True,
-                    help="Path to write the tuning shape manifest.")
-    ap.add_argument("--catalog-md", type=Path, required=True,
-                    help="Human-readable markdown catalog.")
-    ap.add_argument("--top-per-cluster", type=int, default=2,
-                    help="Number of top-M values to keep per (N, K).")
-    ap.add_argument("--max-shapes", type=int, default=8,
-                    help="Total cap on selected shapes.")
+    ap.add_argument(
+        "--in-csv",
+        type=Path,
+        required=True,
+        help="Aggregated CSV from dump_gemm_shapes.py",
+    )
+    ap.add_argument(
+        "--out-json",
+        type=Path,
+        required=True,
+        help="Path to write the tuning shape manifest.",
+    )
+    ap.add_argument(
+        "--catalog-md",
+        type=Path,
+        required=True,
+        help="Human-readable markdown catalog.",
+    )
+    ap.add_argument(
+        "--top-per-cluster",
+        type=int,
+        default=2,
+        help="Number of top-M values to keep per (N, K).",
+    )
+    ap.add_argument(
+        "--max-shapes", type=int, default=8, help="Total cap on selected shapes."
+    )
     args = ap.parse_args()
 
     rows = []
@@ -45,8 +64,12 @@ def main() -> int:
             if len(parts) < 4:
                 continue
             try:
-                M, N, K, n = (int(parts[0]), int(parts[1]), int(parts[2]),
-                              int(parts[3]))
+                M, N, K, n = (
+                    int(parts[0]),
+                    int(parts[1]),
+                    int(parts[2]),
+                    int(parts[3]),
+                )
             except ValueError:
                 continue
             rows.append({"M": M, "N": N, "K": K, "n_calls": n})
@@ -60,16 +83,19 @@ def main() -> int:
 
     selected: list[dict] = []
     cluster_summaries = []
-    for (N, K), entries in sorted(clusters.items(),
-                                  key=lambda kv: -sum(e["n_calls"] for e
-                                                      in kv[1])):
+    for (N, K), entries in sorted(
+        clusters.items(), key=lambda kv: -sum(e["n_calls"] for e in kv[1])
+    ):
         entries.sort(key=lambda e: -e["n_calls"])
         cluster_total_calls = sum(e["n_calls"] for e in entries)
-        cluster_summaries.append({
-            "N": N, "K": K,
-            "total_calls": cluster_total_calls,
-            "n_unique_M": len(entries),
-        })
+        cluster_summaries.append(
+            {
+                "N": N,
+                "K": K,
+                "total_calls": cluster_total_calls,
+                "n_unique_M": len(entries),
+            }
+        )
         for e in entries[: args.top_per_cluster]:
             selected.append(e)
         if len(selected) >= args.max_shapes:
@@ -79,28 +105,39 @@ def main() -> int:
     selected.sort(key=lambda e: (-e["n_calls"], e["M"], e["N"], e["K"]))
 
     args.out_json.parent.mkdir(parents=True, exist_ok=True)
-    args.out_json.write_text(json.dumps({
-        "schema_version": 1,
-        "source_csv": str(args.in_csv),
-        "shape_count": len(selected),
-        "shapes": selected,
-        "cluster_summary": cluster_summaries[:8],
-    }, indent=2))
+    args.out_json.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source_csv": str(args.in_csv),
+                "shape_count": len(selected),
+                "shapes": selected,
+                "cluster_summary": cluster_summaries[:8],
+            },
+            indent=2,
+        )
+    )
 
-    md = ["# W8A8 TensileLite tuning shape catalog",
-          "",
-          f"Source: `{args.in_csv}`",
-          f"Selected {len(selected)} (M, N, K) tuples for tuning.",
-          "",
-          "## Top (N, K) clusters by call count",
-          "",
-          "| N | K | total_calls | unique_M |",
-          "| --- | --- | --- | --- |"]
+    md = [
+        "# W8A8 TensileLite tuning shape catalog",
+        "",
+        f"Source: `{args.in_csv}`",
+        f"Selected {len(selected)} (M, N, K) tuples for tuning.",
+        "",
+        "## Top (N, K) clusters by call count",
+        "",
+        "| N | K | total_calls | unique_M |",
+        "| --- | --- | --- | --- |",
+    ]
     for c in cluster_summaries[:8]:
-        md.append(f"| {c['N']} | {c['K']} | {c['total_calls']} | "
-                  f"{c['n_unique_M']} |")
-    md += ["", "## Selected shapes for tuning", "",
-           "| M | N | K | n_calls |", "| --- | --- | --- | --- |"]
+        md.append(f"| {c['N']} | {c['K']} | {c['total_calls']} | {c['n_unique_M']} |")
+    md += [
+        "",
+        "## Selected shapes for tuning",
+        "",
+        "| M | N | K | n_calls |",
+        "| --- | --- | --- | --- |",
+    ]
     for r in selected:
         md.append(f"| {r['M']} | {r['N']} | {r['K']} | {r['n_calls']} |")
     args.catalog_md.parent.mkdir(parents=True, exist_ok=True)
@@ -108,8 +145,7 @@ def main() -> int:
 
     print(f"Selected {len(selected)} shapes -> {args.out_json}")
     for r in selected:
-        print(f"  M={r['M']:5d} N={r['N']:5d} K={r['K']:5d} "
-              f"n_calls={r['n_calls']}")
+        print(f"  M={r['M']:5d} N={r['N']:5d} K={r['K']:5d} n_calls={r['n_calls']}")
     return 0
 
 

--- a/scripts/mi100/triton_flash_decode_sweep.py
+++ b/scripts/mi100/triton_flash_decode_sweep.py
@@ -774,7 +774,7 @@ def main() -> int:
         torch.accelerator.set_device_index(device.index)
 
     gpu_name = (
-        torch.cuda.get_device_name(device)  # noqa: TID — informational only
+        torch.cuda.get_device_name(device)  # informational only
         if hasattr(torch.cuda, "get_device_name")
         else "unknown"
     )

--- a/scripts/select_hot_shapes.py
+++ b/scripts/select_hot_shapes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Pick the top 1-2 hot GEMM shapes per (regime, quant scheme) from the
 profile traces and write ``hot_shapes.json`` for downstream consumption
@@ -22,6 +23,7 @@ Usage:
         --top 2 --regimes tp1c1,tp4c4 \
         --out /root/bench-int8-w4a16/baseline/hot_shapes.json
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/top_gemm_shapes.py
+++ b/scripts/top_gemm_shapes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Aggregate top GEMM kernels from rocprofv3 kernel-trace CSVs.
 
@@ -18,15 +19,17 @@ Usage:
         --out-md /root/bench-int8-w4a16/baseline/top_gemm_shapes.md \
         --out-csv /root/bench-int8-w4a16/baseline/top_gemm_shapes.csv
 """
+
 from __future__ import annotations
 
 import argparse
 import csv
 import json
-import re
 import sys
 from collections import defaultdict
 from pathlib import Path
+
+import regex as re
 
 GEMM_PATTERNS = [
     r"gemm",
@@ -133,7 +136,9 @@ def main() -> int:
     p.add_argument("--out-md", type=Path, default=None)
     p.add_argument("--out-csv", type=Path, default=None)
     p.add_argument(
-        "--out-json", type=Path, default=None,
+        "--out-json",
+        type=Path,
+        default=None,
         help="Per-trace structured JSON for downstream consumers",
     )
     args = p.parse_args()
@@ -147,8 +152,7 @@ def main() -> int:
 
     per_trace: dict[str, dict] = {}
     global_stats: dict[str, dict] = defaultdict(
-        lambda: {"ns_total": 0, "n_calls": 0, "shape": None,
-                 "appears_in": set()}
+        lambda: {"ns_total": 0, "n_calls": 0, "shape": None, "appears_in": set()}
     )
     grand_busy_ns = 0
     for t in traces:
@@ -169,19 +173,17 @@ def main() -> int:
             g["appears_in"].add(cell)
 
     # Filter to GEMM-like kernels
-    gemm_only = {
-        k: v for k, v in global_stats.items() if GEMM_RE.search(k)
-    }
+    gemm_only = {k: v for k, v in global_stats.items() if GEMM_RE.search(k)}
     if not gemm_only:
         # If nothing matches, fall back to all kernels (still report top N
         # so the worker can adjust the regex).
-        print("[warn] no kernels matched GEMM regex; falling back to all kernels",
-              file=sys.stderr)
+        print(
+            "[warn] no kernels matched GEMM regex; falling back to all kernels",
+            file=sys.stderr,
+        )
         gemm_only = dict(global_stats)
 
-    sorted_k = sorted(
-        gemm_only.items(), key=lambda kv: kv[1]["ns_total"], reverse=True
-    )
+    sorted_k = sorted(gemm_only.items(), key=lambda kv: kv[1]["ns_total"], reverse=True)
     top_n = sorted_k[: args.top]
     cum_ns = sum(v["ns_total"] for _, v in top_n)
     pct_top = 100.0 * cum_ns / max(1, grand_busy_ns)
@@ -202,14 +204,12 @@ def main() -> int:
     # Stdout summary
     print(
         f"\n=== Top {args.top} GEMM kernels (across {len(traces)} traces, "
-        f"grand busy={grand_busy_ns/1e6:.1f} ms) ==="
+        f"grand busy={grand_busy_ns / 1e6:.1f} ms) ==="
     )
-    print(
-        f"{'rank':>4}  {'pct_busy':>8}  {'total_ms':>10}  {'n_calls':>7}  kernel"
-    )
+    print(f"{'rank':>4}  {'pct_busy':>8}  {'total_ms':>10}  {'n_calls':>7}  kernel")
     for i, r in enumerate(rows):
         print(
-            f"{i+1:>4}  {r['pct_of_busy']:>7.2f}%  {r['total_ms']:>9.2f}  "
+            f"{i + 1:>4}  {r['pct_of_busy']:>7.2f}%  {r['total_ms']:>9.2f}  "
             f"{r['n_calls']:>7}  {r['kernel_name'][:90]}"
         )
     print(f"\nTop-{args.top} cumulative coverage: {pct_top:.2f}% of GPU busy time")
@@ -219,15 +219,28 @@ def main() -> int:
         with open(args.out_csv, "w", newline="") as f:
             w = csv.writer(f)
             w.writerow(
-                ["rank", "kernel_name", "shape", "n_calls", "total_ms",
-                 "pct_of_busy", "appears_in"]
+                [
+                    "rank",
+                    "kernel_name",
+                    "shape",
+                    "n_calls",
+                    "total_ms",
+                    "pct_of_busy",
+                    "appears_in",
+                ]
             )
             for i, r in enumerate(rows):
-                w.writerow([
-                    i + 1, r["kernel_name"], r["shape"], r["n_calls"],
-                    f"{r['total_ms']:.3f}", f"{r['pct_of_busy']:.3f}",
-                    ";".join(r["appears_in"]),
-                ])
+                w.writerow(
+                    [
+                        i + 1,
+                        r["kernel_name"],
+                        r["shape"],
+                        r["n_calls"],
+                        f"{r['total_ms']:.3f}",
+                        f"{r['pct_of_busy']:.3f}",
+                        ";".join(r["appears_in"]),
+                    ]
+                )
         print(f"wrote {args.out_csv}")
 
     if args.out_md:
@@ -236,7 +249,7 @@ def main() -> int:
             f"# Top {args.top} GEMM Shapes (M1 Baseline)",
             "",
             f"- Traces analyzed: {len(traces)}",
-            f"- Grand GPU busy time: {grand_busy_ns/1e6:.2f} ms",
+            f"- Grand GPU busy time: {grand_busy_ns / 1e6:.2f} ms",
             f"- Top-{args.top} cumulative coverage: **{pct_top:.2f}%**",
             "",
             "| Rank | %busy | Total ms | Calls | Shape | Kernel |",
@@ -246,7 +259,7 @@ def main() -> int:
             kern = r["kernel_name"]
             kern = kern.replace("|", "\\|")
             lines.append(
-                f"| {i+1} | {r['pct_of_busy']:.2f}% | {r['total_ms']:.2f} | "
+                f"| {i + 1} | {r['pct_of_busy']:.2f}% | {r['total_ms']:.2f} | "
                 f"{r['n_calls']} | {r['shape']} | `{kern[:80]}` |"
             )
         lines.append("")
@@ -257,7 +270,7 @@ def main() -> int:
         for cell, info in sorted(per_trace.items()):
             lines.append(
                 f"| {cell} | {info['n_kernels_total']} | "
-                f"{info['n_records']} | {info['busy_ns']/1e6:.2f} |"
+                f"{info['n_records']} | {info['busy_ns'] / 1e6:.2f} |"
             )
         args.out_md.write_text("\n".join(lines))
         print(f"wrote {args.out_md}")

--- a/tests/kernels/attention/test_flash_decoding_splitk.py
+++ b/tests/kernels/attention/test_flash_decoding_splitk.py
@@ -175,14 +175,14 @@ def ref_paged_attn(
 # Decode-specific test cases: query_len=1, varying KV lengths
 DECODE_SEQ_LENS = [
     # (query_len, kv_len) tuples
-    [(1, 128)],                               # Short sequence
-    [(1, 512)],                               # Medium sequence
-    [(1, 2048)],                              # Long sequence
-    [(1, 8192)],                              # Very long sequence
-    [(1, 16384)],                             # Extra long sequence
-    [(1, 256), (1, 1024), (1, 4096)],         # Mixed batch
-    [(1, 128)] * 4,                           # Small batch, short seqs
-    [(1, 8192)] * 2,                          # Small batch, long seqs
+    [(1, 128)],  # Short sequence
+    [(1, 512)],  # Medium sequence
+    [(1, 2048)],  # Long sequence
+    [(1, 8192)],  # Very long sequence
+    [(1, 16384)],  # Extra long sequence
+    [(1, 256), (1, 1024), (1, 4096)],  # Mixed batch
+    [(1, 128)] * 4,  # Small batch, short seqs
+    [(1, 8192)] * 2,  # Small batch, long seqs
 ]
 
 NUM_HEADS = [(4, 4), (8, 2)]
@@ -232,9 +232,9 @@ def test_flash_decoding_splitk_correctness(
         num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
     )
     value_cache = torch.randn_like(key_cache)
-    cu_query_lens = torch.tensor(
-        [0] + query_lens, dtype=torch.int32
-    ).cumsum(dim=0, dtype=torch.int32)
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
     kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
 
     max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
@@ -297,9 +297,10 @@ def test_flash_decoding_splitk_correctness(
     )
 
     atol, rtol = 1.5e-2, 1e-2
-    torch.testing.assert_close(
-        output, ref_output, atol=atol, rtol=rtol
-    ), f"max diff: {torch.max(torch.abs(output - ref_output))}"
+    (
+        torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol),
+        f"max diff: {torch.max(torch.abs(output - ref_output))}",
+    )
 
 
 @pytest.mark.parametrize(
@@ -345,9 +346,9 @@ def test_flash_decoding_adaptive_vs_fixed(
         num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
     )
     value_cache = torch.randn_like(key_cache)
-    cu_query_lens = torch.tensor(
-        [0] + query_lens, dtype=torch.int32
-    ).cumsum(dim=0, dtype=torch.int32)
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
     kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
     max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
     block_tables = torch.randint(
@@ -442,9 +443,10 @@ def test_flash_decoding_adaptive_vs_fixed(
     )
 
     atol, rtol = 1.5e-2, 1e-2
-    torch.testing.assert_close(
-        output_fixed, output_adaptive, atol=atol, rtol=rtol
-    ), (
-        f"Fixed vs adaptive mismatch (adaptive_splits={adaptive_splits}): "
-        f"max diff: {torch.max(torch.abs(output_fixed - output_adaptive))}"
+    (
+        torch.testing.assert_close(output_fixed, output_adaptive, atol=atol, rtol=rtol),
+        (
+            f"Fixed vs adaptive mismatch (adaptive_splits={adaptive_splits}): "
+            f"max diff: {torch.max(torch.abs(output_fixed - output_adaptive))}"
+        ),
     )

--- a/tests/kernels/quantization/test_ck_int8_correctness.py
+++ b/tests/kernels/quantization/test_ck_int8_correctness.py
@@ -56,14 +56,14 @@ def _reference_int8_gemm(a, b, scale_a, scale_b):
 def test_ck_int8_gemm_matches_pytorch_reference(ck_int8_gemm, shape, seed):
     M, N, K = shape
     g = torch.Generator(device="cuda").manual_seed(seed)
-    a = torch.randint(-100, 101, (M, K), generator=g, device="cuda",
-                      dtype=torch.int8)
-    b = torch.randint(-100, 101, (N, K), generator=g, device="cuda",
-                      dtype=torch.int8)
-    scale_a = torch.rand((M,), generator=g, device="cuda",
-                         dtype=torch.float32) * 0.01 + 0.001
-    scale_b = torch.rand((N,), generator=g, device="cuda",
-                         dtype=torch.float32) * 0.01 + 0.001
+    a = torch.randint(-100, 101, (M, K), generator=g, device="cuda", dtype=torch.int8)
+    b = torch.randint(-100, 101, (N, K), generator=g, device="cuda", dtype=torch.int8)
+    scale_a = (
+        torch.rand((M,), generator=g, device="cuda", dtype=torch.float32) * 0.01 + 0.001
+    )
+    scale_b = (
+        torch.rand((N,), generator=g, device="cuda", dtype=torch.float32) * 0.01 + 0.001
+    )
 
     out_ck = ck_int8_gemm(a, b, scale_a, scale_b, None, 1)
     _, out_ref = _reference_int8_gemm(a, b, scale_a, scale_b)
@@ -80,4 +80,5 @@ def test_ck_int8_gemm_matches_pytorch_reference(ck_int8_gemm, shape, seed):
     # output value), so we use the spec's rel-err gate as the binding check.
     assert max_rel <= 1e-2, (
         f"shape={shape} seed={seed}: max_rel_err={max_rel:.4e} "
-        f"max_abs_err={max_abs:.4e} exceeds 1e-2 (VAL-CK-005)")
+        f"max_abs_err={max_abs:.4e} exceeds 1e-2 (VAL-CK-005)"
+    )

--- a/tests/kernels/quantization/test_ck_int8_smoke.py
+++ b/tests/kernels/quantization/test_ck_int8_smoke.py
@@ -30,7 +30,8 @@ def ck_int8_gemm():
             "torch.ops._rocm_C.ck_int8_gemm is unavailable. The vllm "
             "build was made with VLLM_BUILD_CK=OFF or on a non-gfx908 "
             "target. Re-run install with GPU_TARGETS=gfx908 + "
-            "VLLM_BUILD_CK=ON to enable.")
+            "VLLM_BUILD_CK=ON to enable."
+        )
     return op
 
 

--- a/tests/kernels/quantization/test_config_loader.py
+++ b/tests/kernels/quantization/test_config_loader.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for the gfx908 autotune-config loader (VAL-TRITON-004)."""
+
 from __future__ import annotations
 
 import json
@@ -20,8 +21,15 @@ def tmp_config(monkeypatch, tmp_path):
     config_loader.reset_cache()
 
 
-def _write_cfg(dirpath: Path, kernel: str, M: int, N: int, K: int,
-               group_size: int | None, block_m: int) -> Path:
+def _write_cfg(
+    dirpath: Path,
+    kernel: str,
+    M: int,
+    N: int,
+    K: int,
+    group_size: int | None,
+    block_m: int,
+) -> Path:
     if group_size is not None:
         fname = f"{kernel}_M{M}_N{N}_K{K}_g{group_size}.json"
     else:
@@ -70,9 +78,7 @@ def test_load_groupsize_keyed(tmp_config):
     _write_cfg(tmp_config, "mi100_w4a16", 16, 4096, 4096, 32, block_m=32)
     config_loader.reset_cache()
     a = config_loader.load_config("mi100_w4a16", 16, 4096, 4096, group_size=32)
-    b = config_loader.load_config(
-        "mi100_w4a16", 16, 4096, 4096, group_size=128
-    )
+    b = config_loader.load_config("mi100_w4a16", 16, 4096, 4096, group_size=128)
     assert a is not None and b is not None
     assert a["BLOCK_M"] == 32
     assert b["BLOCK_M"] == 16

--- a/tests/kernels/quantization/test_hipblaslt_int8_correctness.py
+++ b/tests/kernels/quantization/test_hipblaslt_int8_correctness.py
@@ -12,6 +12,7 @@ shape blocks Milestone 2 (VAL-TENSILE-005).
 
 Tests are skipped when not running on a gfx908 GPU.
 """
+
 from __future__ import annotations
 
 import json
@@ -20,9 +21,7 @@ from pathlib import Path
 import pytest
 import torch
 
-pytest.importorskip(
-    "vllm.model_executor.kernels.linear.scaled_mm.mi100_hipblaslt"
-)
+pytest.importorskip("vllm.model_executor.kernels.linear.scaled_mm.mi100_hipblaslt")
 
 from vllm.model_executor.kernels.linear.scaled_mm.mi100_hipblaslt import (  # noqa: E402,E501
     mi100_hipblaslt_scaled_mm,
@@ -43,8 +42,7 @@ pytestmark = pytest.mark.skipif(
 
 
 _MANIFEST = Path(__file__).resolve().parents[3] / (
-    "vllm/model_executor/kernels/configs/gfx908/"
-    "hipblaslt_tuned_shapes.json"
+    "vllm/model_executor/kernels/configs/gfx908/hipblaslt_tuned_shapes.json"
 )
 
 
@@ -61,9 +59,13 @@ def _tuned_shapes() -> list[tuple[int, int, int]]:
     return out
 
 
-def _reference_w8a8(a: torch.Tensor, b: torch.Tensor,
-                    sa: torch.Tensor, sb: torch.Tensor,
-                    out_dtype: torch.dtype) -> torch.Tensor:
+def _reference_w8a8(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    sa: torch.Tensor,
+    sb: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
     """fp32 reference: cast int8 inputs to fp32, GEMM in fp32, then apply
     per-token / per-channel scales. Avoids ``torch.matmul`` int32 path
     which is unimplemented on ROCm. With both operands in [-32, 31] and
@@ -77,7 +79,8 @@ def _reference_w8a8(a: torch.Tensor, b: torch.Tensor,
 
 
 @pytest.mark.parametrize(
-    "M,N,K", _tuned_shapes() or [(32, 64, 64)],
+    "M,N,K",
+    _tuned_shapes() or [(32, 64, 64)],
     ids=lambda v: str(v),
 )
 def test_hipblaslt_matches_reference(M: int, N: int, K: int) -> None:
@@ -95,7 +98,12 @@ def test_hipblaslt_matches_reference(M: int, N: int, K: int) -> None:
     sb = (torch.rand(N, 1, device="cuda", dtype=torch.float32) * 0.05) + 0.001
 
     out = mi100_hipblaslt_scaled_mm(
-        a, b, sa, sb, out_dtype=torch.float16, bias=None,
+        a,
+        b,
+        sa,
+        sb,
+        out_dtype=torch.float16,
+        bias=None,
     )
     ref = _reference_w8a8(a, b, sa, sb, out_dtype=torch.float16)
 
@@ -108,8 +116,9 @@ def test_hipblaslt_matches_reference(M: int, N: int, K: int) -> None:
     max_rel_err = rel.max().item()
 
     # Print on failure for fast triage.
-    msg = (f"M={M} N={N} K={K} max_abs_err={max_abs_err:.3e} "
-           f"max_rel_err={max_rel_err:.3e}")
+    msg = (
+        f"M={M} N={N} K={K} max_abs_err={max_abs_err:.3e} max_rel_err={max_rel_err:.3e}"
+    )
     assert torch.allclose(out, ref, atol=1e-2, rtol=5e-2), msg
 
 
@@ -124,10 +133,20 @@ def test_bias_is_applied() -> None:
     bias = torch.full((N,), 0.5, dtype=torch.float16, device="cuda")
 
     out_no_bias = mi100_hipblaslt_scaled_mm(
-        a, b, sa, sb, out_dtype=torch.float16, bias=None,
+        a,
+        b,
+        sa,
+        sb,
+        out_dtype=torch.float16,
+        bias=None,
     )
     out_bias = mi100_hipblaslt_scaled_mm(
-        a, b, sa, sb, out_dtype=torch.float16, bias=bias,
+        a,
+        b,
+        sa,
+        sb,
+        out_dtype=torch.float16,
+        bias=bias,
     )
     diff = (out_bias.float() - out_no_bias.float() - 0.5).abs().max().item()
     assert diff < 1e-2, f"bias not applied correctly, diff={diff}"

--- a/tests/kernels/quantization/test_mi100_int8_correctness.py
+++ b/tests/kernels/quantization/test_mi100_int8_correctness.py
@@ -7,6 +7,7 @@ Sweeps the M1 hot-shape catalog at three random seeds and asserts
 emit per-shape (max_abs_err, max_rel_err) so we can diagnose specific
 shape failures.
 """
+
 from __future__ import annotations
 
 import json
@@ -46,15 +47,17 @@ def correctness_recorder():
     records: list[dict] = []
     yield records
     OUT_JSON.parent.mkdir(parents=True, exist_ok=True)
-    OUT_JSON.write_text(json.dumps(
-        {
-            "n_shapes": len(set((r["M"], r["N"], r["K"]) for r in records)),
-            "n_records": len(records),
-            "tolerance": {"atol": 1e-2, "rtol": 5e-2},
-            "records": records,
-        },
-        indent=2,
-    ))
+    OUT_JSON.write_text(
+        json.dumps(
+            {
+                "n_shapes": len(set((r["M"], r["N"], r["K"]) for r in records)),
+                "n_records": len(records),
+                "tolerance": {"atol": 1e-2, "rtol": 5e-2},
+                "records": records,
+            },
+            indent=2,
+        )
+    )
 
 
 @pytest.mark.skipif(
@@ -63,9 +66,7 @@ def correctness_recorder():
 )
 @pytest.mark.parametrize("seed", [0, 1, 2])
 @pytest.mark.parametrize("M,N,K,role", HOT_SHAPES_W8A8)
-def test_w8a8_correctness_vs_fp32(
-    M, N, K, role, seed, correctness_recorder
-):
+def test_w8a8_correctness_vs_fp32(M, N, K, role, seed, correctness_recorder):
     """torch.allclose(out_fp16, ref_fp16, atol=1e-2, rtol=5e-2)."""
     from vllm.model_executor.kernels.linear.scaled_mm.mi100_int8 import (
         mi100_int8_scaled_mm,
@@ -77,9 +78,7 @@ def test_w8a8_correctness_vs_fp32(
     scale_a = (0.01 * torch.rand((M, 1), device="cuda")).to(torch.float32)
     scale_b = (0.01 * torch.rand((N, 1), device="cuda")).to(torch.float32)
 
-    out = mi100_int8_scaled_mm(
-        a, b, scale_a, scale_b, torch.float16, bias=None
-    )
+    out = mi100_int8_scaled_mm(a, b, scale_a, scale_b, torch.float16, bias=None)
     # Chunk the FP32 reference computation along K to avoid OOM on the
     # largest shapes (down/gate_up @ M=512). The full [M,K] x [K,N] FP32
     # matmul peaks at ~2 GiB on a 32 GiB MI100; the kernel itself only
@@ -99,10 +98,17 @@ def test_w8a8_correctness_vs_fp32(
     abs_err = (out - ref).abs()
     max_abs = float(abs_err.max().item())
     max_rel = float((abs_err / (ref.abs() + 1e-3)).max().item())
-    correctness_recorder.append({
-        "M": M, "N": N, "K": K, "role": role, "seed": seed,
-        "max_abs_err": max_abs, "max_rel_err": max_rel,
-    })
+    correctness_recorder.append(
+        {
+            "M": M,
+            "N": N,
+            "K": K,
+            "role": role,
+            "seed": seed,
+            "max_abs_err": max_abs,
+            "max_rel_err": max_rel,
+        }
+    )
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=5e-2)
     del a, b, scale_a, scale_b, out, ref
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()

--- a/tests/kernels/quantization/test_mi100_int8_features.py
+++ b/tests/kernels/quantization/test_mi100_int8_features.py
@@ -8,22 +8,21 @@ Verifies VAL-TRITON-001:
   - Fuses dequant * scales + bias -> fp16 in the store epilogue (no
     separate dequant launch).
 """
+
 from __future__ import annotations
 
 import inspect
-import re
 from pathlib import Path
 
 import pytest
+import regex as re
 import torch
 
 from vllm.platforms import current_platform
 
 
 def _kernel_source() -> str:
-    path = Path(
-        "vllm/model_executor/kernels/linear/scaled_mm/mi100_int8.py"
-    )
+    path = Path("vllm/model_executor/kernels/linear/scaled_mm/mi100_int8.py")
     return path.read_text()
 
 
@@ -63,10 +62,16 @@ def test_kernel_signature_and_epilogue():
     from vllm.model_executor.kernels.linear.scaled_mm.mi100_int8 import (
         mi100_int8_scaled_mm,
     )
+
     sig = inspect.signature(mi100_int8_scaled_mm)
     params = list(sig.parameters)
     assert params[:6] == [
-        "input", "weight", "scale_a", "scale_b", "out_dtype", "bias"
+        "input",
+        "weight",
+        "scale_a",
+        "scale_b",
+        "out_dtype",
+        "bias",
     ], f"unexpected signature: {params}"
 
 
@@ -91,9 +96,7 @@ def test_w8a8_per_channel_per_token_runs_and_matches_reference():
 
     out = mi100_int8_scaled_mm(a, b, scale_a, scale_b, torch.float16, bias)
 
-    ref = (
-        scale_a * a.to(torch.float32) @ b.to(torch.float32)
-    ) * scale_b.T
+    ref = (scale_a * a.to(torch.float32) @ b.to(torch.float32)) * scale_b.T
     ref = ref + bias.to(torch.float32)
     ref = ref.to(torch.float16)
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=5e-2)

--- a/tests/kernels/quantization/test_mi100_w4a16.py
+++ b/tests/kernels/quantization/test_mi100_w4a16.py
@@ -8,22 +8,22 @@ Verifies VAL-TRITON-002:
     bitshift+mask, no global-mem hop).
   - Group-size {32, 128} correctness against an FP32 PyTorch reference.
 """
+
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
+import regex as re
 import torch
 
 from vllm.platforms import current_platform
 
 
 def _kernel_source() -> str:
-    return (
-        Path("vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16.py")
-        .read_text()
-    )
+    return Path(
+        "vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16.py"
+    ).read_text()
 
 
 def test_module_exists_with_register_unpack_pattern():
@@ -46,9 +46,9 @@ def test_module_exists_with_register_unpack_pattern():
 
 
 def _pytorch_w4a16_reference(
-    a: torch.Tensor,        # [M, K] fp16
-    b_packed: torch.Tensor, # [K, N//8] int32
-    scales: torch.Tensor,   # [K//G, N] fp16
+    a: torch.Tensor,  # [M, K] fp16
+    b_packed: torch.Tensor,  # [K, N//8] int32
+    scales: torch.Tensor,  # [K//G, N] fp16
     group_size: int,
     zp_bias: int = 8,
 ) -> torch.Tensor:
@@ -58,9 +58,7 @@ def _pytorch_w4a16_reference(
 
     shifts = torch.arange(8, device=b_packed.device, dtype=torch.int32) * 4
     # [K, N//8, 8] -> [K, N]
-    nibbles = ((b_packed.unsqueeze(-1) >> shifts) & 0xF).reshape(K, N).to(
-        torch.int32
-    )
+    nibbles = ((b_packed.unsqueeze(-1) >> shifts) & 0xF).reshape(K, N).to(torch.int32)
     nibbles_minus_z = nibbles - zp_bias
     # Broadcast scales [K//G, N] -> [K, N] by repeating each group.
     scales_full = scales.repeat_interleave(group_size, dim=0)
@@ -90,16 +88,19 @@ def test_groupwise_unpack(group_size: int):
     from vllm.model_executor.kernels.linear.scaled_mm.mi100_w4a16 import (
         mi100_w4a16_gemm,
     )
+
     M, K, N = 16, 256, 64
     torch.manual_seed(group_size)
-    a = (torch.randn((M, K), device="cuda", dtype=torch.float16) * 0.1)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16) * 0.1
     b_packed = _make_packed_b(K, N, seed=group_size)
-    scales = (
-        0.01 * torch.rand((K // group_size, N), device="cuda")
-    ).to(torch.float16)
+    scales = (0.01 * torch.rand((K // group_size, N), device="cuda")).to(torch.float16)
 
     out = mi100_w4a16_gemm(
-        a, b_packed, scales, qzeros=None, group_size=group_size,
+        a,
+        b_packed,
+        scales,
+        qzeros=None,
+        group_size=group_size,
         zp_bias=8,
     )
     ref = _pytorch_w4a16_reference(a, b_packed, scales, group_size, zp_bias=8)

--- a/tests/kernels/quantization/test_mi100_w4a16_correctness.py
+++ b/tests/kernels/quantization/test_mi100_w4a16_correctness.py
@@ -5,6 +5,7 @@
 Sweeps the M1 hot-shape catalog × group sizes {32, 128} × 3 seeds and
 asserts ``torch.allclose(out_fp16, ref_fp16, atol=1e-2, rtol=5e-2)``.
 """
+
 from __future__ import annotations
 
 import json
@@ -51,8 +52,11 @@ def _make_packed_b(K: int, N: int, seed: int) -> torch.Tensor:
 
 
 def _pytorch_w4a16_reference(
-    a: torch.Tensor, b_packed: torch.Tensor, scales: torch.Tensor,
-    group_size: int, zp_bias: int = 8,
+    a: torch.Tensor,
+    b_packed: torch.Tensor,
+    scales: torch.Tensor,
+    group_size: int,
+    zp_bias: int = 8,
 ) -> torch.Tensor:
     """FP32 reference computed in K-chunks to keep peak memory bounded."""
     K, N_packed = b_packed.shape
@@ -65,12 +69,12 @@ def _pytorch_w4a16_reference(
     for k0 in range(0, K, K_chunk):
         k1 = min(K, k0 + K_chunk)
         b_chunk = b_packed[k0:k1]  # [k1-k0, N//8] int32
-        nibbles = ((b_chunk.unsqueeze(-1) >> shifts) & 0xF).reshape(
-            k1 - k0, N
-        ).to(torch.int32) - zp_bias
+        nibbles = ((b_chunk.unsqueeze(-1) >> shifts) & 0xF).reshape(k1 - k0, N).to(
+            torch.int32
+        ) - zp_bias
         # Per-row scales for this chunk: row k -> g_idx = k // group_size.
-        g_idx = (torch.arange(k0, k1, device=a.device) // group_size)
-        scales_chunk = scales[g_idx]                                 # [k1-k0, N]
+        g_idx = torch.arange(k0, k1, device=a.device) // group_size
+        scales_chunk = scales[g_idx]  # [k1-k0, N]
         b_fp = nibbles.to(torch.float32) * scales_chunk.to(torch.float32)
         out_f32 += a[:, k0:k1].to(torch.float32) @ b_fp
         del b_chunk, nibbles, scales_chunk, b_fp
@@ -82,16 +86,17 @@ def correctness_recorder():
     records: list[dict] = []
     yield records
     OUT_JSON.parent.mkdir(parents=True, exist_ok=True)
-    OUT_JSON.write_text(json.dumps(
-        {
-            "n_shapes": len(set((r["M"], r["N"], r["K"], r["g"])
-                                for r in records)),
-            "n_records": len(records),
-            "tolerance": {"atol": 1e-2, "rtol": 5e-2},
-            "records": records,
-        },
-        indent=2,
-    ))
+    OUT_JSON.write_text(
+        json.dumps(
+            {
+                "n_shapes": len(set((r["M"], r["N"], r["K"], r["g"]) for r in records)),
+                "n_records": len(records),
+                "tolerance": {"atol": 1e-2, "rtol": 5e-2},
+                "records": records,
+            },
+            indent=2,
+        )
+    )
 
 
 @pytest.mark.skipif(
@@ -111,36 +116,43 @@ def test_w4a16_correctness_vs_fp32(
     # combat fragmentation: PyTorch's caching allocator hangs on to
     # large blocks from prior test bodies (M=512 prefill tiles), then
     # cannot satisfy a fresh ~300 MiB temporary in the next test.
-    torch.cuda.empty_cache()
-    torch.cuda.synchronize()
+    torch.accelerator.empty_cache()
+    torch.accelerator.synchronize()
 
     from vllm.model_executor.kernels.linear.scaled_mm.mi100_w4a16 import (
         mi100_w4a16_gemm,
     )
 
     torch.manual_seed(seed)
-    a = (torch.randn((M, K), device="cuda", dtype=torch.float16) * 0.1)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16) * 0.1
     b_packed = _make_packed_b(K, N, seed=seed * 31 + group_size)
-    scales = (0.01 * torch.rand(
-        (K // group_size, N), device="cuda")
-    ).to(torch.float16)
+    scales = (0.01 * torch.rand((K // group_size, N), device="cuda")).to(torch.float16)
 
     out = mi100_w4a16_gemm(
-        a, b_packed, scales, qzeros=None,
-        group_size=group_size, zp_bias=8,
+        a,
+        b_packed,
+        scales,
+        qzeros=None,
+        group_size=group_size,
+        zp_bias=8,
     )
-    ref = _pytorch_w4a16_reference(
-        a, b_packed, scales, group_size, zp_bias=8
-    )
+    ref = _pytorch_w4a16_reference(a, b_packed, scales, group_size, zp_bias=8)
 
     abs_err = (out - ref).abs()
     max_abs = float(abs_err.max().item())
     max_rel = float((abs_err / (ref.abs() + 1e-3)).max().item())
-    correctness_recorder.append({
-        "M": M, "N": N, "K": K, "g": group_size, "seed": seed,
-        "role": role,
-        "max_abs_err": max_abs, "max_rel_err": max_rel,
-    })
+    correctness_recorder.append(
+        {
+            "M": M,
+            "N": N,
+            "K": K,
+            "g": group_size,
+            "seed": seed,
+            "role": role,
+            "max_abs_err": max_abs,
+            "max_rel_err": max_rel,
+        }
+    )
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=5e-2)
     del a, b_packed, scales, out, ref
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()

--- a/tests/kernels/quantization/test_mi100_w4a16_marlin.py
+++ b/tests/kernels/quantization/test_mi100_w4a16_marlin.py
@@ -10,6 +10,7 @@ that consumes the layout is a separate feature. Two checks:
   - ``-k prefuse``: pre-fused scale/zero math equals element-wise
     ``(q - zero) * scale`` within atol=1e-2, rtol=5e-2. sym + asym.
 """
+
 from __future__ import annotations
 
 import itertools
@@ -68,9 +69,7 @@ SHAPES = [
 ]
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 @pytest.mark.parametrize("seed", [0, 1, 2])
 @pytest.mark.parametrize("group_size", [32, 128])
 @pytest.mark.parametrize("has_zp", [False, True], ids=["sym", "asym"])
@@ -84,17 +83,18 @@ def test_round_trip(K, N, has_zp, group_size, seed):
 
     w_int4_kn = torch.randint(0, 16, (K, N), device=device, dtype=torch.int32)
     b_q = _pack_int4_along_n(w_int4_kn)
-    scales = (0.05 * torch.rand(
-        (num_groups, N), device=device, dtype=torch.float32)).to(torch.float16)
+    scales = (
+        0.05 * torch.rand((num_groups, N), device=device, dtype=torch.float32)
+    ).to(torch.float16)
 
     qzeros = None
     if has_zp:
         zeros_int4 = torch.randint(
-            0, 16, (num_groups, N), device=device, dtype=torch.int32)
+            0, 16, (num_groups, N), device=device, dtype=torch.int32
+        )
         qzeros = _pack_int4_along_n(zeros_int4)
 
-    packed = marlin_repack_w4a16(
-        b_q, scales, qzeros, group_size=group_size, zp_bias=8)
+    packed = marlin_repack_w4a16(b_q, scales, qzeros, group_size=group_size, zp_bias=8)
 
     assert tuple(packed.qweight.shape) == (K // 8, N)
     assert packed.qweight.dtype == torch.int32
@@ -104,9 +104,7 @@ def test_round_trip(K, N, has_zp, group_size, seed):
     assert max_abs == 0, f"round-trip nibble mismatch: max abs diff={max_abs}"
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 @pytest.mark.parametrize("seed", [0, 1, 2])
 @pytest.mark.parametrize("group_size", [32, 128])
 @pytest.mark.parametrize("has_zp", [False, True], ids=["sym", "asym"])
@@ -121,37 +119,40 @@ def test_prefuse(K, N, has_zp, group_size, seed):
 
     w_int4_kn = torch.randint(0, 16, (K, N), device=device, dtype=torch.int32)
     b_q = _pack_int4_along_n(w_int4_kn)
-    scales = (0.05 * torch.rand(
-        (num_groups, N), device=device, dtype=torch.float32)).to(torch.float16)
+    scales = (
+        0.05 * torch.rand((num_groups, N), device=device, dtype=torch.float32)
+    ).to(torch.float16)
 
     qzeros = None
     if has_zp:
         zeros_int4 = torch.randint(
-            0, 16, (num_groups, N), device=device, dtype=torch.int32)
+            0, 16, (num_groups, N), device=device, dtype=torch.int32
+        )
         qzeros = _pack_int4_along_n(zeros_int4)
         zero_raw = zeros_int4.to(torch.float32)  # [K//G, N]
     else:
         zero_raw = torch.full(
-            (num_groups, N), float(zp_bias),
-            device=device, dtype=torch.float32)
+            (num_groups, N), float(zp_bias), device=device, dtype=torch.float32
+        )
 
     packed = marlin_repack_w4a16(
-        b_q, scales, qzeros, group_size=group_size, zp_bias=zp_bias)
+        b_q, scales, qzeros, group_size=group_size, zp_bias=zp_bias
+    )
 
     assert tuple(packed.scale.shape) == (num_groups, N)
     assert tuple(packed.zero.shape) == (num_groups, N)
 
     # Per-element nibble grid (full [K, N]) and its group index.
-    q = w_int4_kn.to(torch.float32)                                  # [K, N]
-    g_idx = torch.arange(K, device=device) // group_size            # [K]
-    scale_full = packed.scale.to(torch.float32)[g_idx]              # [K, N]
-    zero_fused_full = packed.zero.to(torch.float32)[g_idx]         # [K, N]
+    q = w_int4_kn.to(torch.float32)  # [K, N]
+    g_idx = torch.arange(K, device=device) // group_size  # [K]
+    scale_full = packed.scale.to(torch.float32)[g_idx]  # [K, N]
+    zero_fused_full = packed.zero.to(torch.float32)[g_idx]  # [K, N]
 
     # Pre-fused form:  q*scale - zero_fused  (zero_fused == zero_raw*scale)
     got = q * scale_full - zero_fused_full
 
     # Canonical reference:  (q - zero_raw) * scale
-    zero_raw_full = zero_raw[g_idx]                                  # [K, N]
+    zero_raw_full = zero_raw[g_idx]  # [K, N]
     ref = (q - zero_raw_full) * scales.to(torch.float32)[g_idx]
 
     torch.testing.assert_close(got, ref, atol=1e-2, rtol=5e-2)
@@ -170,8 +171,9 @@ GEMM_SHAPES = [
 ]
 
 
-def _make_w4a16_case(M, K, N, group_size, has_zp, seed, scales_override=None,
-                     zeros_override=None):
+def _make_w4a16_case(
+    M, K, N, group_size, has_zp, seed, scales_override=None, zeros_override=None
+):
     """Build a random W4A16 case + its pure-FP32 dequant->matmul reference.
 
     Returns ``(a, b_q, scales, qzeros, ref_c)`` where ``ref_c`` is computed
@@ -187,8 +189,8 @@ def _make_w4a16_case(M, K, N, group_size, has_zp, seed, scales_override=None,
     if scales_override is not None:
         scales = scales_override
     else:
-        scales = (0.05 * torch.rand(
-            (num_groups, N), device=device, dtype=torch.float32)
+        scales = (
+            0.05 * torch.rand((num_groups, N), device=device, dtype=torch.float32)
         ).to(torch.float16)
 
     qzeros = None
@@ -197,102 +199,92 @@ def _make_w4a16_case(M, K, N, group_size, has_zp, seed, scales_override=None,
             zeros_int4 = zeros_override
         else:
             zeros_int4 = torch.randint(
-                0, 16, (num_groups, N), device=device, dtype=torch.int32)
+                0, 16, (num_groups, N), device=device, dtype=torch.int32
+            )
         qzeros = _pack_int4_along_n(zeros_int4)
         zero_raw = zeros_int4.to(torch.float32)
     else:
         zero_raw = torch.full(
-            (num_groups, N), float(zp_bias),
-            device=device, dtype=torch.float32)
+            (num_groups, N), float(zp_bias), device=device, dtype=torch.float32
+        )
 
     a = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
 
     # Pure-FP32 reference: dequant then matmul.
     g_idx = torch.arange(K, device=device) // group_size  # [K]
-    scale_full = scales.to(torch.float32)[g_idx]          # [K, N]
-    zero_raw_full = zero_raw[g_idx]                        # [K, N]
+    scale_full = scales.to(torch.float32)[g_idx]  # [K, N]
+    zero_raw_full = zero_raw[g_idx]  # [K, N]
     w_fp = (w_int4_kn.to(torch.float32) - zero_raw_full) * scale_full
-    ref_c = a.to(torch.float32) @ w_fp                    # [M, N]
+    ref_c = a.to(torch.float32) @ w_fp  # [M, N]
 
     return a, b_q, scales, qzeros, ref_c
 
 
 def _run_gemm(a, b_q, scales, qzeros, group_size):
-    packed = marlin_repack_w4a16(
-        b_q, scales, qzeros, group_size=group_size, zp_bias=8)
+    packed = marlin_repack_w4a16(b_q, scales, qzeros, group_size=group_size, zp_bias=8)
     return mi100_w4a16_marlin_gemm(
-        a, packed.qweight, packed.scale, packed.zero, group_size)
+        a, packed.qweight, packed.scale, packed.zero, group_size
+    )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 @pytest.mark.parametrize("seed", [0, 1, 2])
 @pytest.mark.parametrize("group_size", [32, 128])
 @pytest.mark.parametrize("M,K,N", GEMM_SHAPES)
 def test_symmetric(M, K, N, group_size, seed):
     a, b_q, scales, qzeros, ref_c = _make_w4a16_case(
-        M, K, N, group_size, has_zp=False, seed=seed)
+        M, K, N, group_size, has_zp=False, seed=seed
+    )
     c = _run_gemm(a, b_q, scales, qzeros, group_size)
-    torch.testing.assert_close(
-        c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
+    torch.testing.assert_close(c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 @pytest.mark.parametrize("seed", [0, 1, 2])
 @pytest.mark.parametrize("group_size", [32, 128])
 @pytest.mark.parametrize("M,K,N", GEMM_SHAPES)
 def test_asymmetric(M, K, N, group_size, seed):
     # PRODUCTION-CRITICAL: qzeros present, full asymmetric dequant.
     a, b_q, scales, qzeros, ref_c = _make_w4a16_case(
-        M, K, N, group_size, has_zp=True, seed=seed)
+        M, K, N, group_size, has_zp=True, seed=seed
+    )
     c = _run_gemm(a, b_q, scales, qzeros, group_size)
-    torch.testing.assert_close(
-        c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
+    torch.testing.assert_close(c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 @pytest.mark.parametrize("group_size", [32, 128])
 def test_group(group_size):
     # Both supported group sizes produce correct results.
     a, b_q, scales, qzeros, ref_c = _make_w4a16_case(
-        32, 256, 256, group_size, has_zp=True, seed=0)
+        32, 256, 256, group_size, has_zp=True, seed=0
+    )
     c = _run_gemm(a, b_q, scales, qzeros, group_size)
-    torch.testing.assert_close(
-        c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
+    torch.testing.assert_close(c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 def test_group_unsupported_rejected():
     # Unsupported group_size must raise in both repack and GEMM.
     num_groups = 256 // 48 if 256 % 48 == 0 else 4
     with pytest.raises(ValueError):
         # repack rejects unsupported group_size
         b_q = torch.zeros((256, 256 // 8), device=device, dtype=torch.int32)
-        scales = torch.ones((num_groups, 256), device=device,
-                            dtype=torch.float16)
+        scales = torch.ones((num_groups, 256), device=device, dtype=torch.float16)
         marlin_repack_w4a16(b_q, scales, None, group_size=48)
 
     with pytest.raises(ValueError):
         # GEMM also rejects unsupported group_size
         a = torch.zeros((16, 256), device=device, dtype=torch.float16)
-        qweight = torch.zeros((256 // 8, 256), device=device,
-                              dtype=torch.int32)
+        qweight = torch.zeros((256 // 8, 256), device=device, dtype=torch.int32)
         scale = torch.ones((4, 256), device=device, dtype=torch.float16)
         zero = torch.zeros((4, 256), device=device, dtype=torch.float16)
         mi100_w4a16_marlin_gemm(a, qweight, scale, zero, group_size=48)
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
 def test_boundary():
     # g=32 with sharply DISTINCT per-group scales+zeros: a cross-group scale
     # leak would corrupt the result at group boundaries. K spans 8 groups.
@@ -300,38 +292,61 @@ def test_boundary():
     num_groups = K // group_size  # 8
 
     # Distinct, well-separated scale per group (one row per group).
-    scales = (torch.arange(1, num_groups + 1, device=device,
-                           dtype=torch.float32).reshape(num_groups, 1)
-              * 0.01).expand(num_groups, N).contiguous().to(torch.float16)
+    scales = (
+        (
+            torch.arange(1, num_groups + 1, device=device, dtype=torch.float32).reshape(
+                num_groups, 1
+            )
+            * 0.01
+        )
+        .expand(num_groups, N)
+        .contiguous()
+        .to(torch.float16)
+    )
     # Distinct zero per group: 0,2,4,... (mod 16).
-    zeros_int4 = ((torch.arange(num_groups, device=device, dtype=torch.int32)
-                   * 2) % 16).reshape(num_groups, 1).expand(
-                       num_groups, N).contiguous()
+    zeros_int4 = (
+        ((torch.arange(num_groups, device=device, dtype=torch.int32) * 2) % 16)
+        .reshape(num_groups, 1)
+        .expand(num_groups, N)
+        .contiguous()
+    )
 
     a, b_q, scales, qzeros, ref_c = _make_w4a16_case(
-        M, K, N, group_size, has_zp=True, seed=7,
-        scales_override=scales, zeros_override=zeros_int4)
+        M,
+        K,
+        N,
+        group_size,
+        has_zp=True,
+        seed=7,
+        scales_override=scales,
+        zeros_override=zeros_int4,
+    )
     c = _run_gemm(a, b_q, scales, qzeros, group_size)
-    torch.testing.assert_close(
-        c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
+    torch.testing.assert_close(c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
 
 
 # --- Source-pattern tests: enforce shift-only / no-interleave discipline. ---
 
+
 def test_source_no_interleave():
     import inspect
+
     src = inspect.getsource(marlin_mod)
     assert "tl.interleave" not in src, (
-        "kernel must be shift-only: tl.interleave is forbidden")
+        "kernel must be shift-only: tl.interleave is forbidden"
+    )
 
 
 def test_source_only_output_store():
     import inspect
-    import re
+
+    import regex as re
+
     src = inspect.getsource(marlin_mod)
     targets = re.findall(r"tl\.store\(\s*([A-Za-z_][A-Za-z0-9_]*)", src)
     assert targets == ["c_ptrs"], (
-        f"the only tl.store target must be the output (c_ptrs); got {targets}")
+        f"the only tl.store target must be the output (c_ptrs); got {targets}"
+    )
 
 
 # ===========================================================================
@@ -345,8 +360,7 @@ F_M2_MS = [1, 32, 128, 512]
 F_M2_NS = [4096, 10240, 24576]
 F_M2_KS = [4096, 12288]
 F_M2_GS = [32, 128]
-F_M2_SHAPES = list(
-    itertools.product(F_M2_MS, F_M2_NS, F_M2_KS, F_M2_GS))
+F_M2_SHAPES = list(itertools.product(F_M2_MS, F_M2_NS, F_M2_KS, F_M2_GS))
 
 MARLIN_KERNEL_KEY = "mi100_w4a16_marlin"
 _LDS_A_BYTES = 2  # fp16/bf16 activation tile element size
@@ -356,8 +370,8 @@ _LDS_BUDGET = 64 * 1024  # gfx908 LDS budget
 def _marlin_lds_bytes(bm: int, bn: int, bk: int, ns: int) -> int:
     """Conservative gfx908 LDS estimate; matches autotune-marlin.md.
 
-        bytes = ns * BLOCK_K * (BLOCK_M + BLOCK_N) * 2      # fp16 act term
-              + ns * (BLOCK_K // 8) * BLOCK_N * 4           # packed int4 B
+    bytes = ns * BLOCK_K * (BLOCK_M + BLOCK_N) * 2      # fp16 act term
+          + ns * (BLOCK_K // 8) * BLOCK_N * 4           # packed int4 B
     """
     return ns * bk * (bm + bn) * _LDS_A_BYTES + ns * (bk // 8) * bn * 4
 
@@ -365,14 +379,11 @@ def _marlin_lds_bytes(bm: int, bn: int, bk: int, ns: int) -> int:
 def test_seeded_configs_load_for_all_hot_shapes():
     """All 48 (M, N, K, g) resolve to a seeded JSON via the real loader and
     every selected tile is within the 64 KiB LDS budget (CPU-only)."""
-    assert len(F_M2_SHAPES) == 48, (
-        f"expected 48 hot shapes, got {len(F_M2_SHAPES)}")
+    assert len(F_M2_SHAPES) == 48, f"expected 48 hot shapes, got {len(F_M2_SHAPES)}"
     config_loader.reset_cache()
     for m, n, k, g in F_M2_SHAPES:
-        cfg = config_loader.load_config(
-            MARLIN_KERNEL_KEY, M=m, N=n, K=k, group_size=g)
-        assert cfg is not None, (
-            f"no seeded config for (M={m}, N={n}, K={k}, g={g})")
+        cfg = config_loader.load_config(MARLIN_KERNEL_KEY, M=m, N=n, K=k, group_size=g)
+        assert cfg is not None, f"no seeded config for (M={m}, N={n}, K={k}, g={g})"
         bm = int(cfg["BLOCK_M"])
         bn = int(cfg["BLOCK_N"])
         bk = int(cfg["BLOCK_K"])
@@ -382,28 +393,30 @@ def test_seeded_configs_load_for_all_hot_shapes():
         assert ns <= 2, f"num_stages={ns} > 2 on gfx908"
         est = _marlin_lds_bytes(bm, bn, bk, ns)
         assert est <= _LDS_BUDGET, (
-            f"over-budget tile for (M={m}, N={n}, K={k}, g={g}): "
-            f"{est} > {_LDS_BUDGET}")
+            f"over-budget tile for (M={m}, N={n}, K={k}, g={g}): {est} > {_LDS_BUDGET}"
+        )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm GPU required"
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
+@pytest.mark.parametrize(
+    "M,N,K,group_size",
+    [
+        (1, 4096, 4096, 128),  # decode
+        (32, 4096, 4096, 32),  # prefill-ish small
+    ],
 )
-@pytest.mark.parametrize("M,N,K,group_size", [
-    (1, 4096, 4096, 128),   # decode
-    (32, 4096, 4096, 32),   # prefill-ish small
-])
 def test_marlin_gemm_correct_with_seeded_config_active(M, N, K, group_size):
     """End-to-end correctness with the seeded config ACTIVE: repack -> GEMM
     matches the pure-FP32 dequant->matmul reference (symmetric path)."""
     # Confirm the seeded config is the one that will be selected.
     config_loader.reset_cache()
     cfg = config_loader.load_config(
-        MARLIN_KERNEL_KEY, M=M, N=N, K=K, group_size=group_size)
+        MARLIN_KERNEL_KEY, M=M, N=N, K=K, group_size=group_size
+    )
     assert cfg is not None, "seeded config must be active for this shape"
 
     a, b_q, scales, qzeros, ref_c = _make_w4a16_case(
-        M, K, N, group_size, has_zp=False, seed=0)
+        M, K, N, group_size, has_zp=False, seed=0
+    )
     c = _run_gemm(a, b_q, scales, qzeros, group_size)
-    torch.testing.assert_close(
-        c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)
+    torch.testing.assert_close(c.to(torch.float32), ref_c, atol=1e-2, rtol=5e-2)

--- a/tests/kernels/quantization/test_mi100_w8a8_dispatch.py
+++ b/tests/kernels/quantization/test_mi100_w8a8_dispatch.py
@@ -8,19 +8,19 @@ Focuses on dispatch behaviour rather than absolute speed. Numerical
 correctness of the hipBLASLt path is covered separately by
 ``test_hipblaslt_int8_correctness.py``.
 """
+
 from __future__ import annotations
 
 import json
 import os
+from collections.abc import Generator
 from pathlib import Path
 from unittest import mock
 
 import pytest
 import torch
 
-pytest.importorskip(
-    "vllm.model_executor.kernels.linear.scaled_mm.mi100_int8"
-)
+pytest.importorskip("vllm.model_executor.kernels.linear.scaled_mm.mi100_int8")
 
 from vllm.model_executor.kernels.linear.scaled_mm import (  # noqa: E402
     mi100_hipblaslt,
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def tmp_tuned_shapes(tmp_path: Path) -> Path:
+def tmp_tuned_shapes(tmp_path: Path) -> Generator[Path, None, None]:
     manifest = {
         "schema_version": 1,
         "rocm_version": "7.12",
@@ -55,9 +55,12 @@ def tmp_tuned_shapes(tmp_path: Path) -> Path:
     p = tmp_path / "tuned.json"
     p.write_text(json.dumps(manifest))
     mi100_hipblaslt.reset_tuned_shape_cache()
-    with mock.patch.dict(os.environ, {
-        "VLLM_HIPBLASLT_TUNED_SHAPES": str(p),
-    }):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VLLM_HIPBLASLT_TUNED_SHAPES": str(p),
+        },
+    ):
         yield p
     mi100_hipblaslt.reset_tuned_shape_cache()
 
@@ -102,12 +105,16 @@ def test_dispatcher_prefers_hipblaslt_for_tuned_shape(tmp_tuned_shapes):
     def kernel_spy(*args, **kwargs):
         called["triton"] += 1
 
-    with mock.patch.object(mi100_int8, "mi100_hipblaslt_scaled_mm",
-                           hipblaslt_spy), \
-         mock.patch.object(mi100_int8, "mi100_int8_scaled_mm_kernel",
-                           kernel_spy):
+    with (
+        mock.patch.object(mi100_int8, "mi100_hipblaslt_scaled_mm", hipblaslt_spy),
+        mock.patch.object(mi100_int8, "mi100_int8_scaled_mm_kernel", kernel_spy),
+    ):
         out = mi100_int8.mi100_int8_scaled_mm(
-            a, b, sa, sb, out_dtype=torch.float16,
+            a,
+            b,
+            sa,
+            sb,
+            out_dtype=torch.float16,
         )
     assert called["hipblaslt"] == 1
     assert called["triton"] == 0
@@ -125,10 +132,13 @@ def test_dispatcher_falls_back_to_triton_for_untuned(tmp_tuned_shapes):
     def hipblaslt_spy(*args, **kwargs):
         called_hipblaslt.append(1)
 
-    with mock.patch.object(mi100_int8, "mi100_hipblaslt_scaled_mm",
-                           hipblaslt_spy):
+    with mock.patch.object(mi100_int8, "mi100_hipblaslt_scaled_mm", hipblaslt_spy):
         out = mi100_int8.mi100_int8_scaled_mm(
-            a, b, sa, sb, out_dtype=torch.float16,
+            a,
+            b,
+            sa,
+            sb,
+            out_dtype=torch.float16,
         )
     assert called_hipblaslt == []
     assert out.shape == (M, N)
@@ -144,11 +154,16 @@ def test_disable_env_forces_triton_even_for_tuned_shape(tmp_tuned_shapes):
     def hipblaslt_spy(*args, **kwargs):
         hits.append(1)
 
-    with mock.patch.dict(os.environ, {"VLLM_DISABLE_HIPBLASLT": "1"}), \
-         mock.patch.object(mi100_int8, "mi100_hipblaslt_scaled_mm",
-                           hipblaslt_spy):
+    with (
+        mock.patch.dict(os.environ, {"VLLM_DISABLE_HIPBLASLT": "1"}),
+        mock.patch.object(mi100_int8, "mi100_hipblaslt_scaled_mm", hipblaslt_spy),
+    ):
         out = mi100_int8.mi100_int8_scaled_mm(
-            a, b, sa, sb, out_dtype=torch.float16,
+            a,
+            b,
+            sa,
+            sb,
+            out_dtype=torch.float16,
         )
     assert hits == []
     assert out.shape == (M, N)
@@ -161,11 +176,19 @@ def test_disable_env_output_matches_default_triton(tmp_tuned_shapes):
     a, b, sa, sb = _make_w8a8_tensors(M, N, K)
 
     out_default = mi100_int8.mi100_int8_scaled_mm(
-        a, b, sa, sb, out_dtype=torch.float16,
+        a,
+        b,
+        sa,
+        sb,
+        out_dtype=torch.float16,
     )
     with mock.patch.dict(os.environ, {"VLLM_DISABLE_HIPBLASLT": "1"}):
         out_disabled = mi100_int8.mi100_int8_scaled_mm(
-            a, b, sa, sb, out_dtype=torch.float16,
+            a,
+            b,
+            sa,
+            sb,
+            out_dtype=torch.float16,
         )
     assert torch.equal(out_default, out_disabled)
 

--- a/tests/kernels/quantization/test_w4a16_marlin_dispatch.py
+++ b/tests/kernels/quantization/test_w4a16_marlin_dispatch.py
@@ -15,6 +15,7 @@ hook in ``process_weights_after_loading``, and the selection order in
 The flag is toggled via env (monkeypatch); ``on_mi100`` is mocked where the
 selection is being exercised. Module-level skip on non-ROCm.
 """
+
 from __future__ import annotations
 
 import importlib
@@ -46,10 +47,10 @@ mi100_legacy_mod = importlib.import_module(
 )
 rocm_platform_mod = importlib.import_module("vllm.platforms.rocm")
 
-from vllm.model_executor.kernels.linear.mixed_precision.MPLinearKernel import (  # noqa: E501
+from vllm.model_executor.kernels.linear.mixed_precision.MPLinearKernel import (  # noqa: E402,E501
     MPLinearLayerConfig,
 )
-from vllm.scalar_type import scalar_types
+from vllm.scalar_type import scalar_types  # noqa: E402
 
 MARLIN_FLAG = "VLLM_MI100_W4A16_USE_MARLIN_REPACK"
 DISABLE_FLAG = "VLLM_DISABLE_MI100_W4A16"
@@ -95,8 +96,7 @@ def _make_spy(M: int, N: int, dtype: torch.dtype):
 def _install_spies(monkeypatch, M, N, dtype):
     marlin_spy, marlin_calls = _make_spy(M, N, dtype)
     legacy_spy, legacy_calls = _make_spy(M, N, dtype)
-    monkeypatch.setattr(
-        mi100_marlin_mod, "mi100_w4a16_marlin_gemm", marlin_spy)
+    monkeypatch.setattr(mi100_marlin_mod, "mi100_w4a16_marlin_gemm", marlin_spy)
     monkeypatch.setattr(mi100_legacy_mod, "mi100_w4a16_gemm", legacy_spy)
     return marlin_calls, legacy_calls
 
@@ -115,8 +115,9 @@ def _make_legacy_layer(K, N, G, has_zp, seed=0):
     num_groups = K // G
     w_int4_kn = torch.randint(0, 16, (K, N), device=device, dtype=torch.int32)
     w_q = _pack_int4_along_n(w_int4_kn)
-    w_s = (0.05 * torch.rand(
-        (num_groups, N), device=device, dtype=torch.float32)).to(torch.float16)
+    w_s = (0.05 * torch.rand((num_groups, N), device=device, dtype=torch.float32)).to(
+        torch.float16
+    )
 
     weight_type = scalar_types.uint4 if has_zp else scalar_types.uint4b8
     config = MPLinearLayerConfig(
@@ -144,7 +145,8 @@ def _make_legacy_layer(K, N, G, has_zp, seed=0):
     layer.w_s = w_s
     if has_zp:
         zeros_int4 = torch.randint(
-            0, 16, (num_groups, N), device=device, dtype=torch.int32)
+            0, 16, (num_groups, N), device=device, dtype=torch.int32
+        )
         layer.w_zp = _pack_int4_along_n(zeros_int4)
     return layer, kernel
 
@@ -158,6 +160,7 @@ def _tp_initialized() -> bool:
     from vllm.distributed.parallel_state import (
         get_tensor_model_parallel_rank,
     )
+
     try:
         get_tensor_model_parallel_rank()
         return True
@@ -173,10 +176,13 @@ def _ensure_distributed():
         ensure_model_parallel_initialized,
         init_distributed_environment,
     )
+
     with set_current_vllm_config(VllmConfig()):
         init_distributed_environment(
-            world_size=1, rank=0,
-            distributed_init_method="tcp://127.0.0.1:0", local_rank=0,
+            world_size=1,
+            rank=0,
+            distributed_init_method="tcp://127.0.0.1:0",
+            local_rank=0,
         )
         ensure_model_parallel_initialized(1, 1)
 
@@ -193,8 +199,7 @@ def _build_checkpoint_layer(K, N, G, has_zp, seed=0):
     torch.manual_seed(seed)
     w_int4_kn = torch.randint(0, 16, (K, N), device=device, dtype=torch.int32)
     w_ckpt_nk8 = _pack_int4_along_k_to_ckpt(w_int4_kn)  # [N, K//8]
-    scales_ckpt_nkg = 0.05 * torch.rand(
-        (N, K // G), device=device, dtype=torch.float16)
+    scales_ckpt_nkg = 0.05 * torch.rand((N, K // G), device=device, dtype=torch.float16)
 
     weight_type = scalar_types.uint4 if has_zp else scalar_types.uint4b8
     config = MPLinearLayerConfig(
@@ -223,26 +228,36 @@ def _build_checkpoint_layer(K, N, G, has_zp, seed=0):
     layer.register_parameter(
         "weight_packed",
         PackedvLLMParameter(
-            data=w_ckpt_nk8, weight_loader=weight_loader,
-            input_dim=1, output_dim=0, packed_factor=8, packed_dim=1,
+            data=w_ckpt_nk8,
+            weight_loader=weight_loader,
+            input_dim=1,
+            output_dim=0,
+            packed_factor=8,
+            packed_dim=1,
         ),
     )
     layer.register_parameter(
         "weight_scale",
         GroupQuantScaleParameter(
-            data=scales_ckpt_nkg, weight_loader=weight_loader,
-            input_dim=1, output_dim=0,
+            data=scales_ckpt_nkg,
+            weight_loader=weight_loader,
+            input_dim=1,
+            output_dim=0,
         ),
     )
     if has_zp:
         zeros_int4_gn = torch.randint(
-            0, 16, (K // G, N), device=device, dtype=torch.int32)
+            0, 16, (K // G, N), device=device, dtype=torch.int32
+        )
         zeros_ckpt_n8kg = _pack_int4_along_n(zeros_int4_gn).t().contiguous()
         layer.register_parameter(
             "weight_zero_point",
             PackedColumnParameter(
-                data=zeros_ckpt_n8kg, weight_loader=weight_loader,
-                output_dim=0, packed_factor=8, packed_dim=0,
+                data=zeros_ckpt_n8kg,
+                weight_loader=weight_loader,
+                output_dim=0,
+                packed_factor=8,
+                packed_dim=0,
             ),
         )
     return layer, kernel
@@ -275,7 +290,8 @@ def test_default_off_selects_legacy(monkeypatch, has_zp):
     marlin_calls, legacy_calls = _install_spies(monkeypatch, M, N, torch.float16)
 
     x = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
     kernel.apply_weights(layer, x)
 
     assert len(marlin_calls) == 0, "marlin must NOT be invoked when flag off"
@@ -299,7 +315,8 @@ def test_flag_on_selects_marlin(monkeypatch, has_zp, group_size):
 
     marlin_calls, legacy_calls = _install_spies(monkeypatch, M, N, torch.float16)
     x = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
     kernel.apply_weights(layer, x)
 
     assert len(marlin_calls) == 1, "marlin gemm must be selected"
@@ -321,7 +338,8 @@ def test_disable_precedence_over_marlin(monkeypatch):
 
     marlin_calls, legacy_calls = _install_spies(monkeypatch, M, N, torch.float16)
     x = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
     kernel.apply_weights(layer, x)
 
     assert len(marlin_calls) == 0, "DISABLE must prevent marlin invocation"
@@ -343,7 +361,8 @@ def test_group_gate(monkeypatch):
     assert _has_marlin_attrs(layer32)
     marlin_calls, _ = _install_spies(monkeypatch, M, N, torch.float16)
     x = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
     kernel32.apply_weights(layer32, x)
     assert len(marlin_calls) == 1, "g=32 must select marlin"
 
@@ -371,7 +390,8 @@ def test_non_mi100_preserves_legacy(monkeypatch):
 
     marlin_calls, _ = _install_spies(monkeypatch, M, N, torch.float16)
     x = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
     kernel.apply_weights(layer, x)
     assert len(marlin_calls) == 0, "marlin must NOT be invoked on non-MI100"
 
@@ -410,8 +430,7 @@ def test_repack_hook(monkeypatch, has_zp, group_size):
     assert torch.equal(layer_off.weight_packed, layer_on.weight_packed)
     assert torch.equal(layer_off.weight_scale, layer_on.weight_scale)
     if has_zp:
-        assert torch.equal(
-            layer_off.weight_zero_point, layer_on.weight_zero_point)
+        assert torch.equal(layer_off.weight_zero_point, layer_on.weight_zero_point)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="ROCm GPU required")
@@ -431,7 +450,8 @@ def test_byte_identical_disable_path(monkeypatch, has_zp):
     M = 16
     torch.manual_seed(123)
     x = (0.1 * torch.randn((M, K), device=device, dtype=torch.float32)).to(
-        torch.float16)
+        torch.float16
+    )
 
     out = kernel.apply_weights(layer, x)
 

--- a/tests/quantization/test_turboquant.py
+++ b/tests/quantization/test_turboquant.py
@@ -851,23 +851,40 @@ class TestRotorQuantRoundTrip:
         slot_mapping = torch.tensor([0], device=device, dtype=torch.int32)
 
         triton_turboquant_store(
-            key, value, kv_cache, slot_mapping, PiT, midpoints,
-            mse_bits=cfg.key_mse_bits, key_packed_size=cfg.key_packed_size,
-            value_quant_bits=cfg.effective_value_quant_bits, key_fp8=cfg.key_fp8,
-            rot_params=rot_params, value_rotation=cfg.value_rotation,
+            key,
+            value,
+            kv_cache,
+            slot_mapping,
+            PiT,
+            midpoints,
+            mse_bits=cfg.key_mse_bits,
+            key_packed_size=cfg.key_packed_size,
+            value_quant_bits=cfg.effective_value_quant_bits,
+            key_fp8=cfg.key_fp8,
+            rot_params=rot_params,
+            value_rotation=cfg.value_rotation,
         )
 
         query = key.expand(B, Hq, D).contiguous().to(torch.float16)
         block_table = torch.tensor([[0]], device=device, dtype=torch.int32)
         seq_lens = torch.tensor([1], device=device, dtype=torch.int32)
         output = triton_turboquant_decode_attention(
-            query=query, kv_cache=kv_cache, block_table=block_table,
-            seq_lens=seq_lens, Pi=Pi, centroids=centroids,
-            scale=1.0 / math.sqrt(D), mse_bits=cfg.key_mse_bits,
+            query=query,
+            kv_cache=kv_cache,
+            block_table=block_table,
+            seq_lens=seq_lens,
+            Pi=Pi,
+            centroids=centroids,
+            scale=1.0 / math.sqrt(D),
+            mse_bits=cfg.key_mse_bits,
             key_packed_size=cfg.key_packed_size,
-            value_quant_bits=cfg.effective_value_quant_bits, key_fp8=cfg.key_fp8,
-            norm_correction=cfg.norm_correction, PiT=PiT, rot_params=rot_params,
-            value_rotation=cfg.value_rotation, max_num_kv_splits=4,
+            value_quant_bits=cfg.effective_value_quant_bits,
+            key_fp8=cfg.key_fp8,
+            norm_correction=cfg.norm_correction,
+            PiT=PiT,
+            rot_params=rot_params,
+            value_rotation=cfg.value_rotation,
+            max_num_kv_splits=4,
         )
 
         out_fp32 = output.float()
@@ -912,12 +929,22 @@ class TestRotorQuantRoundTrip:
 
         def run(use_fused):
             kv = torch.zeros(
-                num_blocks, block_size, Hk, cfg.slot_size_aligned,
-                device=device, dtype=torch.uint8,
+                num_blocks,
+                block_size,
+                Hk,
+                cfg.slot_size_aligned,
+                device=device,
+                dtype=torch.uint8,
             )
             triton_turboquant_store(
-                key, value, kv, slot_mapping, PiT, midpoints,
-                mse_bits=cfg.key_mse_bits, key_packed_size=cfg.key_packed_size,
+                key,
+                value,
+                kv,
+                slot_mapping,
+                PiT,
+                midpoints,
+                mse_bits=cfg.key_mse_bits,
+                key_packed_size=cfg.key_packed_size,
                 value_quant_bits=cfg.effective_value_quant_bits,
                 key_fp8=cfg.key_fp8,
                 rot_params=rot_params if use_fused else None,

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -50,6 +50,7 @@ class CustomAllreduce:
     def _detect_gfx908() -> bool:
         try:
             from vllm.platforms.rocm import on_mi100
+
             return on_mi100()
         except ImportError:
             return False
@@ -76,8 +77,7 @@ class CustomAllreduce:
         self.disabled = True
         # gfx908: skip custom AR during graph capture (barrier NaN on replay)
         self._gfx908_skip_graph_ar = (
-            current_platform.is_rocm()
-            and self._detect_gfx908()
+            current_platform.is_rocm() and self._detect_gfx908()
         )
 
         if not custom_ar:

--- a/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
@@ -255,13 +255,19 @@ def triton_w4a16_gemm(
     # disabled-via-env case falls back to the generic Triton path below.
     if current_platform.is_rocm() and not _mi100_w4a16_disabled():
         from vllm.platforms.rocm import on_mi100
+
         if on_mi100() and group_size in (32, 128):
             from vllm.model_executor.kernels.linear.scaled_mm.mi100_w4a16 import (
                 mi100_w4a16_gemm as _mi100_w4a16_gemm,
             )
+
             return _mi100_w4a16_gemm(
-                a=a, b_q=b_q, scales=scales,
-                qzeros=qzeros, group_size=group_size, zp_bias=zp_bias,
+                a=a,
+                b_q=b_q,
+                scales=scales,
+                qzeros=qzeros,
+                group_size=group_size,
+                zp_bias=zp_bias,
             )
 
     c = torch.empty((M, N), dtype=a.dtype, device=a.device)
@@ -505,6 +511,7 @@ class TritonW4A16LinearKernel(MPLinearKernel):
         if not current_platform.is_rocm():
             return
         from vllm.platforms.rocm import on_mi100
+
         if not on_mi100():
             return
 
@@ -522,8 +529,11 @@ class TritonW4A16LinearKernel(MPLinearKernel):
         )
 
         packed = marlin_repack_w4a16(
-            b_q=w_q, scales=w_s, qzeros=w_zp,
-            group_size=group_size, zp_bias=zp_bias,
+            b_q=w_q,
+            scales=w_s,
+            qzeros=w_zp,
+            group_size=group_size,
+            zp_bias=zp_bias,
         )
         setattr(layer, _MARLIN_QWEIGHT_ATTR, packed.qweight)
         setattr(layer, _MARLIN_SCALE_ATTR, packed.scale)
@@ -560,12 +570,14 @@ class TritonW4A16LinearKernel(MPLinearKernel):
         )
         if use_marlin:
             from vllm.platforms.rocm import on_mi100
+
             use_marlin = on_mi100()
 
         if use_marlin:
             from vllm.model_executor.kernels.linear.scaled_mm.mi100_w4a16_marlin import (  # noqa: E501
                 mi100_w4a16_marlin_gemm,
             )
+
             output = mi100_w4a16_marlin_gemm(
                 x_2d,
                 marlin_qweight,

--- a/vllm/model_executor/kernels/linear/scaled_mm/mi100_hipblaslt.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/mi100_hipblaslt.py
@@ -21,6 +21,7 @@ This module is intentionally small: the per-shape decision lives in
 ``mi100_hipblaslt_scaled_mm``. The Triton kernel remains the fallback
 for everything else (and for the ``VLLM_DISABLE_HIPBLASLT=1`` override).
 """
+
 from __future__ import annotations
 
 import json

--- a/vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16.py
@@ -33,6 +33,7 @@ Tuning knobs and their gfx908 implications (per user M3 brief):
 Per-shape autotune configs are read from
 ``vllm/model_executor/kernels/configs/gfx908/mi100_w4a16_M*_N*_K*_g*.json``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -51,18 +52,23 @@ _SUPPORTED_GROUP_SIZES = (32, 64, 128)
 
 @triton.jit
 def mi100_w4a16_gemm_kernel(
-    a_ptr,            # [M, K] fp16/bf16
-    b_ptr,            # [K, N//8] int32 (GPTQ sequential-packed N)
-    scales_ptr,       # [K//G, N] same dtype as a
-    zeros_ptr,        # [K//G, N//8] int32 (only used when HAS_ZP)
-    c_ptr,            # [M, N] fp16/bf16
-    M, N, K,
-    stride_am, stride_ak,
-    stride_bk, stride_bn,
-    stride_cm, stride_cn,
+    a_ptr,  # [M, K] fp16/bf16
+    b_ptr,  # [K, N//8] int32 (GPTQ sequential-packed N)
+    scales_ptr,  # [K//G, N] same dtype as a
+    zeros_ptr,  # [K//G, N//8] int32 (only used when HAS_ZP)
+    c_ptr,  # [M, N] fp16/bf16
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
     group_size,
     HAS_ZP: tl.constexpr,
-    ZP_BIAS: tl.constexpr,   # 8 for uint4b8 (symmetric), 0 for asymmetric
+    ZP_BIAS: tl.constexpr,  # 8 for uint4b8 (symmetric), 0 for asymmetric
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -85,12 +91,12 @@ def mi100_w4a16_gemm_kernel(
     # Per-column shift table for the GPTQ sequential nibble layout.
     # Column j gets shift (j % 8) * 4. Build via broadcast+reshape so
     # Triton's compile-time shape inference is happy.
-    shifts_row = tl.arange(0, 8) * 4                       # [8]
-    shifts_2d = tl.broadcast_to(shifts_row[None, :],
-                                (BLOCK_N // 8, 8))         # [N//8, 8]
-    shifts_1d = tl.reshape(shifts_2d, (BLOCK_N,))          # [BLOCK_N]
-    shifts = tl.broadcast_to(shifts_1d[None, :],
-                             (BLOCK_K, BLOCK_N))           # [BLOCK_K, BLOCK_N]
+    shifts_row = tl.arange(0, 8) * 4  # [8]
+    shifts_2d = tl.broadcast_to(shifts_row[None, :], (BLOCK_N // 8, 8))  # [N//8, 8]
+    shifts_1d = tl.reshape(shifts_2d, (BLOCK_N,))  # [BLOCK_N]
+    shifts = tl.broadcast_to(
+        shifts_1d[None, :], (BLOCK_K, BLOCK_N)
+    )  # [BLOCK_K, BLOCK_N]
 
     # Scales column offsets (one scalar per output column per group).
     offs_sn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -103,14 +109,12 @@ def mi100_w4a16_gemm_kernel(
         mask_k = offs_k < K
 
         # ---- Activations: [BLOCK_M, BLOCK_K] fp16/bf16 ----
-        a_ptrs = (a_ptr + offs_m[:, None] * stride_am
-                  + offs_k[None, :] * stride_ak)
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
         mask_a = (offs_m[:, None] < M) & mask_k[None, :]
         a = tl.load(a_ptrs, mask=mask_a, other=0.0)
 
         # ---- Packed-int4 weights: [BLOCK_K, BLOCK_N//8] int32 ----
-        b_ptrs = (b_ptr + offs_k[:, None] * stride_bk
-                  + offs_bn[None, :] * stride_bn)
+        b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
         mask_b = mask_k[:, None] & (offs_bn[None, :] < N // 8)
         b_packed = tl.load(b_ptrs, mask=mask_b, other=0)
 
@@ -127,15 +131,13 @@ def mi100_w4a16_gemm_kernel(
 
         scale_offset = g_idx * N + offs_sn
         scale_mask = offs_sn < N
-        scales = tl.load(scales_ptr + scale_offset,
-                         mask=scale_mask, other=1.0)
+        scales = tl.load(scales_ptr + scale_offset, mask=scale_mask, other=1.0)
         scales = tl.broadcast_to(scales[None, :], (BLOCK_K, BLOCK_N))
 
         if HAS_ZP:
             zero_offset = g_idx * (N // 8) + offs_bn
             zero_mask = offs_bn < N // 8
-            z_packed = tl.load(zeros_ptr + zero_offset,
-                               mask=zero_mask, other=0)
+            z_packed = tl.load(zeros_ptr + zero_offset, mask=zero_mask, other=0)
             z = tl.interleave(z_packed, z_packed)
             z = tl.interleave(z, z)
             z = tl.interleave(z, z)
@@ -151,8 +153,7 @@ def mi100_w4a16_gemm_kernel(
         accumulator += tl.dot(a, b_fp, out_dtype=tl.float32)
 
     c = accumulator.to(c_ptr.type.element_ty)
-    c_ptrs = (c_ptr + offs_m[:, None] * stride_cm
-              + offs_n[None, :] * stride_cn)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
     mask_c = (offs_m[:, None] < M) & (offs_n[None, :] < N)
     tl.store(c_ptrs, c, mask=mask_c)
 
@@ -205,8 +206,7 @@ def mi100_w4a16_gemm(
         f"b_q shape mismatch: {b_q.shape} vs ({K}, {N // 8})"
     )
     assert scales.shape == (K // group_size, N), (
-        f"scales shape mismatch: {scales.shape} vs "
-        f"({K // group_size}, {N})"
+        f"scales shape mismatch: {scales.shape} vs ({K // group_size}, {N})"
     )
     if qzeros is not None:
         assert qzeros.shape == (K // group_size, N // 8), (
@@ -230,17 +230,13 @@ def mi100_w4a16_gemm(
         num_warps = int(cfg.get("num_warps", 4))
         num_stages = int(cfg.get("num_stages", 2))
         if "matrix_instr_nonkdim" in cfg:
-            extra_launch["matrix_instr_nonkdim"] = int(
-                cfg["matrix_instr_nonkdim"]
-            )
+            extra_launch["matrix_instr_nonkdim"] = int(cfg["matrix_instr_nonkdim"])
         if "kpack" in cfg:
             extra_launch["kpack"] = int(cfg["kpack"])
         if "waves_per_eu" in cfg:
             extra_launch["waves_per_eu"] = int(cfg["waves_per_eu"])
     else:
-        BLOCK_M, BLOCK_N, BLOCK_K, num_warps, num_stages = (
-            _default_block_sizes(M)
-        )
+        BLOCK_M, BLOCK_N, BLOCK_K, num_warps, num_stages = _default_block_sizes(M)
 
     # Each tile must lie within a single quant group.
     if group_size < BLOCK_K:
@@ -249,11 +245,20 @@ def mi100_w4a16_gemm(
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
 
     mi100_w4a16_gemm_kernel[grid](
-        a, b_q, scales, zeros_ptr_arg, c,
-        M, N, K,
-        a.stride(0), a.stride(1),
-        b_q.stride(0), b_q.stride(1),
-        c.stride(0), c.stride(1),
+        a,
+        b_q,
+        scales,
+        zeros_ptr_arg,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b_q.stride(0),
+        b_q.stride(1),
+        c.stride(0),
+        c.stride(1),
         group_size=group_size,
         HAS_ZP=has_zp,
         ZP_BIAS=zp_bias,

--- a/vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16_marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/mi100_w4a16_marlin.py
@@ -46,6 +46,7 @@ Nibble ordering summary (3 lines):
   - dequant: w_fp[k, n] = q[k, n] * scale[g, n] - zero[g, n], g = k // G.
 ===============================================================================
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -69,8 +70,8 @@ class MarlinRepackedW4A16:
     """
 
     qweight: torch.Tensor  # [K//8, N] int32, K-packed, N-lane-adjacent
-    scale: torch.Tensor    # [K//G, N] scales dtype
-    zero: torch.Tensor     # [K//G, N] scales dtype, pre-fused (zero_raw*scale)
+    scale: torch.Tensor  # [K//G, N] scales dtype
+    zero: torch.Tensor  # [K//G, N] scales dtype, pre-fused (zero_raw*scale)
     group_size: int
     K: int
     N: int
@@ -125,7 +126,7 @@ def unpack_repacked_to_kn(qweight_kb_n: torch.Tensor) -> torch.Tensor:
     shifts = _shifts(qweight_kb_n.device)
     # [K//8, N, 8] nibbles -> [K//8, 8, N] -> [K, N]
     nibbles = (qweight_kb_n.unsqueeze(-1) >> shifts) & 0xF  # [kb, N, 8]
-    nibbles = nibbles.permute(0, 2, 1).contiguous()          # [kb, 8, N]
+    nibbles = nibbles.permute(0, 2, 1).contiguous()  # [kb, 8, N]
     return nibbles.reshape(kb * 8, N)
 
 
@@ -164,9 +165,7 @@ def marlin_repack_w4a16(
             f"marlin_repack_w4a16: unsupported group_size={group_size}; "
             f"supported: {_SUPPORTED_GROUP_SIZES}"
         )
-    assert K % group_size == 0, (
-        f"K={K} not divisible by group_size={group_size}"
-    )
+    assert K % group_size == 0, f"K={K} not divisible by group_size={group_size}"
     assert K % 8 == 0, f"K={K} must be divisible by 8 for K-packing"
 
     num_groups = K // group_size
@@ -177,22 +176,23 @@ def marlin_repack_w4a16(
     has_zp = qzeros is not None
 
     # ---- Weight: unpack N-packing, repack along K ----
-    w_int4_kn = _unpack_int4_along_n(b_q)          # [K, N] int32
-    qweight = _pack_int4_along_k(w_int4_kn)        # [K//8, N] int32
+    w_int4_kn = _unpack_int4_along_n(b_q)  # [K, N] int32
+    qweight = _pack_int4_along_k(w_int4_kn)  # [K//8, N] int32
 
     # ---- Pre-fuse scales / zeros: w_fp = q*scale - (zero_raw*scale) ----
     scale_f32 = scales.to(torch.float32)
-    if has_zp:
+    if qzeros is not None:
         assert qzeros.dtype == torch.int32, "qzeros must be int32"
         assert qzeros.shape == (num_groups, N // 8), (
-            f"qzeros shape mismatch: {qzeros.shape} vs "
-            f"({num_groups}, {N // 8})"
+            f"qzeros shape mismatch: {qzeros.shape} vs ({num_groups}, {N // 8})"
         )
         zero_raw = _unpack_int4_along_n(qzeros).to(torch.float32)  # [K//G, N]
     else:
         zero_raw = torch.full(
-            (num_groups, N), float(zp_bias),
-            dtype=torch.float32, device=scales.device,
+            (num_groups, N),
+            float(zp_bias),
+            dtype=torch.float32,
+            device=scales.device,
         )
 
     zero_fused = (zero_raw * scale_f32).to(scales.dtype).contiguous()
@@ -233,15 +233,28 @@ def marlin_repack_w4a16(
 
 @triton.jit
 def _mi100_w4a16_marlin_gemm_kernel(
-    a_ptr, b_ptr, c_ptr, scales_ptr, zeros_ptr,
-    M, N, K,
-    stride_am, stride_ak,
-    stride_bk, stride_bn,
-    stride_cm, stride_cn,
-    stride_scales_g, stride_scales_n,
-    stride_zeros_g, stride_zeros_n,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    scales_ptr,
+    zeros_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_scales_g,
+    stride_scales_n,
+    stride_zeros_g,
+    stride_zeros_n,
     group_size,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -258,18 +271,16 @@ def _mi100_w4a16_marlin_gemm_kernel(
     offs_bn = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
     offs_k = tl.arange(0, BLOCK_K)
 
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am +
-                      offs_k[None, :] * stride_ak)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
 
     # qweight is [K//8, N] int32, K-packed. Within a BLOCK_K tile the int32 row
     # for local k is ``k // 8`` and the int4 lives at bit offset ``(k % 8)*4``.
     # SHIFT-ONLY extraction: load the packed int32 (reused for its 8 K-rows),
     # then right-shift + mask. No nibble-replication intrinsic; no weight
     # store (only the output is stored).
-    k_pack = offs_k // 8                       # [BLOCK_K] packed-row offset
-    k_shift = (offs_k % 8) * 4                 # [BLOCK_K] nibble bit shift
-    b_ptrs = b_ptr + (k_pack[:, None] * stride_bk +
-                      offs_bn[None, :] * stride_bn)
+    k_pack = offs_k // 8  # [BLOCK_K] packed-row offset
+    k_shift = (offs_k % 8) * 4  # [BLOCK_K] nibble bit shift
+    b_ptrs = b_ptr + (k_pack[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
@@ -284,14 +295,13 @@ def _mi100_w4a16_marlin_gemm_kernel(
 
         # One group per BLOCK_K tile (BLOCK_K divides group_size).
         g = (k * BLOCK_K) // group_size
-        scales = tl.load(scales_ptr + g * stride_scales_g +
-                         offs_bn * stride_scales_n)
-        zeros = tl.load(zeros_ptr + g * stride_zeros_g +
-                        offs_bn * stride_zeros_n)
+        scales = tl.load(scales_ptr + g * stride_scales_g + offs_bn * stride_scales_n)
+        zeros = tl.load(zeros_ptr + g * stride_zeros_g + offs_bn * stride_zeros_n)
 
         # Pre-fused dequant: w_fp = q * scale - zero  (zero == zero_raw*scale).
-        b_fp = b_nibble.to(tl.float32) * scales[None, :].to(tl.float32) - \
-            zeros[None, :].to(tl.float32)
+        b_fp = b_nibble.to(tl.float32) * scales[None, :].to(tl.float32) - zeros[
+            None, :
+        ].to(tl.float32)
 
         accumulator += tl.dot(a.to(tl.float32), b_fp)
 
@@ -313,13 +323,31 @@ def _default_marlin_config(M: int) -> dict:
     ``num_stages`` is kept <= 2 (gfx908 has no async-LDS pipelining).
     """
     if M <= 16:
-        return {"BLOCK_M": 16, "BLOCK_N": 64, "BLOCK_K": 32,
-                "GROUP_M": 8, "num_warps": 4, "num_stages": 2}
+        return {
+            "BLOCK_M": 16,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_M": 8,
+            "num_warps": 4,
+            "num_stages": 2,
+        }
     if M <= 64:
-        return {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 32,
-                "GROUP_M": 8, "num_warps": 4, "num_stages": 2}
-    return {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32,
-            "GROUP_M": 8, "num_warps": 4, "num_stages": 2}
+        return {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_M": 8,
+            "num_warps": 4,
+            "num_stages": 2,
+        }
+    return {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "GROUP_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+    }
 
 
 def _select_marlin_config(M: int, N: int, K: int, group_size: int) -> dict:
@@ -330,7 +358,8 @@ def _select_marlin_config(M: int, N: int, K: int, group_size: int) -> dict:
     when no JSON is pinned for the shape.
     """
     cfg = _load_mi100_autotune_config(
-        "mi100_w4a16_marlin", M=M, N=N, K=K, group_size=group_size)
+        "mi100_w4a16_marlin", M=M, N=N, K=K, group_size=group_size
+    )
     if cfg is None:
         return _default_marlin_config(M)
     out = _default_marlin_config(M)
@@ -392,9 +421,7 @@ def mi100_w4a16_marlin_gemm(
     assert qweight.shape == (K // 8, N), (
         f"qweight shape {tuple(qweight.shape)} != ({K // 8}, {N})"
     )
-    assert K % group_size == 0, (
-        f"K={K} not divisible by group_size={group_size}"
-    )
+    assert K % group_size == 0, f"K={K} not divisible by group_size={group_size}"
 
     out_dtype = out_dtype or a.dtype
     c = torch.empty((M, N), device=a.device, dtype=out_dtype)
@@ -407,17 +434,31 @@ def mi100_w4a16_marlin_gemm(
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
     )
     _mi100_w4a16_marlin_gemm_kernel[grid](
-        a, qweight, c, scale, zero,
-        M, N, K,
-        a.stride(0), a.stride(1),
-        qweight.stride(0), qweight.stride(1),
-        c.stride(0), c.stride(1),
-        scale.stride(0), scale.stride(1),
-        zero.stride(0), zero.stride(1),
+        a,
+        qweight,
+        c,
+        scale,
+        zero,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        qweight.stride(0),
+        qweight.stride(1),
+        c.stride(0),
+        c.stride(1),
+        scale.stride(0),
+        scale.stride(1),
+        zero.stride(0),
+        zero.stride(1),
         group_size,
-        BLOCK_M=cfg["BLOCK_M"], BLOCK_N=cfg["BLOCK_N"], BLOCK_K=block_k,
+        BLOCK_M=cfg["BLOCK_M"],
+        BLOCK_N=cfg["BLOCK_N"],
+        BLOCK_K=block_k,
         GROUP_M=cfg["GROUP_M"],
-        num_warps=cfg["num_warps"], num_stages=num_stages,
+        num_warps=cfg["num_warps"],
+        num_stages=num_stages,
     )
     return c
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1078,7 +1078,7 @@ class FusedMoE(PluggableLayer):
             # Block-alignment check: if we're splitting the packed-byte
             # inner dim of a GGUF k-quant / i-quant tensor, the per-rank
             # byte count MUST be an integer multiple of the GGUF block's
-            # type_size. Otherwise the dequant kernel reads mis-aligned
+            # type_size. Otherwise the dequant kernel reads misaligned
             # blocks and produces NaN (silent corruption observed with
             # MiniMax-M2 IQ3_XXS at TP=4: intermediate_size=1536 with
             # QK_K=256 gives 1536/256 = 6 blocks per expert row; TP=4

--- a/vllm/model_executor/layers/quantization/turboquant/config.py
+++ b/vllm/model_executor/layers/quantization/turboquant/config.py
@@ -9,15 +9,15 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from vllm.config import ModelConfig
-
-logger = logging.getLogger(__name__)
-
 from vllm.model_executor.layers.quantization.turboquant.rotations import (
     ROTATION_HADAMARD,
     ROTATION_KINDS,
 )
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+
+logger = logging.getLogger(__name__)
 
 # Named TQ presets: each maps to frozen config parameters.
 # key_quant_bits: 8 = FP8 keys, 3-4 = MSE (Lloyd-Max) quantized keys.

--- a/vllm/model_executor/layers/quantization/turboquant/rotations.py
+++ b/vllm/model_executor/layers/quantization/turboquant/rotations.py
@@ -198,6 +198,7 @@ def block_rotate(x: torch.Tensor, params: RotationParams) -> torch.Tensor:
         *lead, d = x.shape
         xp = x.reshape(*lead, d // 2, 2)
         x0, x1 = xp[..., 0], xp[..., 1]
+        assert params.cos is not None and params.sin is not None
         c, s = params.cos, params.sin
         y0 = c * x0 + s * x1
         y1 = -s * x0 + c * x1
@@ -206,6 +207,7 @@ def block_rotate(x: torch.Tensor, params: RotationParams) -> torch.Tensor:
         *lead, d = x.shape
         xq = x.reshape(*lead, d // 4, 4)
         # Forward map applies m on the left of each 4-vector: y = m @ x.
+        assert params.quat is not None
         w = params.quat[:, 0]
         xx = params.quat[:, 1]
         yy = params.quat[:, 2]

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -139,20 +139,16 @@ class GGUFModelLoader(BaseModelLoader):
             # block_sparse_moe.experts.X.{w1,w2,w3} naming
             for idx in range(config.num_hidden_layers):
                 gguf_to_hf_name_map[f"blk.{idx}.exp_probs_b.bias"] = (
-                    f"model.layers.{idx}.block_sparse_moe"
-                    f".e_score_correction_bias"
+                    f"model.layers.{idx}.block_sparse_moe.e_score_correction_bias"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
-                    f"model.layers.{idx}.block_sparse_moe"
-                    f".experts.0.w2.weight"
+                    f"model.layers.{idx}.block_sparse_moe.experts.0.w2.weight"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
-                    f"model.layers.{idx}.block_sparse_moe"
-                    f".experts.0.w1.weight"
+                    f"model.layers.{idx}.block_sparse_moe.experts.0.w1.weight"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
-                    f"model.layers.{idx}.block_sparse_moe"
-                    f".experts.0.w3.weight"
+                    f"model.layers.{idx}.block_sparse_moe.experts.0.w3.weight"
                 )
                 sideload_params.append(
                     re.compile(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1254,9 +1254,11 @@ def multi_thread_pt_weights_iterator(
             del state
 
 
-def _get_gguf_shard_files(gguf_file: str) -> list[str]:
+def _get_gguf_shard_files(gguf_file: str | Path) -> list[str]:
     """Get all shard files for a split GGUF, or just [gguf_file] if not split."""
     import glob as _glob
+
+    gguf_file = str(gguf_file)
     basename = os.path.basename(gguf_file)
     # Match pattern like *-00001-of-00003.gguf
     m = re.search(r"-\d+-of-(\d+)\.gguf$", basename)
@@ -1265,9 +1267,7 @@ def _get_gguf_shard_files(gguf_file: str) -> list[str]:
         # Build glob pattern to find all shards
         prefix = re.sub(r"-\d+-of-\d+\.gguf$", "", basename)
         parent = os.path.dirname(gguf_file)
-        shard_files = sorted(
-            _glob.glob(os.path.join(parent, f"{prefix}-*-of-*.gguf"))
-        )
+        shard_files = sorted(_glob.glob(os.path.join(parent, f"{prefix}-*-of-*.gguf")))
         if len(shard_files) == n_shards:
             return shard_files
     return [gguf_file]
@@ -1294,11 +1294,13 @@ def get_gguf_weight_type_map(
     result: dict[str, str] = {}
     for shard in _get_gguf_shard_files(gguf_file):
         reader = gguf.GGUFReader(shard)
-        result.update({
-            gguf_to_hf_name_map[tensor.name]: tensor.tensor_type.name
-            for tensor in reader.tensors
-            if tensor.name in gguf_to_hf_name_map
-        })
+        result.update(
+            {
+                gguf_to_hf_name_map[tensor.name]: tensor.tensor_type.name
+                for tensor in reader.tensors
+                if tensor.name in gguf_to_hf_name_map
+            }
+        )
     return result
 
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -291,7 +291,7 @@ class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
             "last": "LAST",
         }
 
-        pooling_type = pooling_type_map.get(hf_config.pooling, None)
+        pooling_type = pooling_type_map.get(hf_config.pooling)
         if pooling_type is None:
             raise ValueError(f"pool_type {hf_config.pooling!r} not supported")
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -776,9 +776,7 @@ class RocmPlatform(Platform):
         # torch.compile adds overhead without benefit. Disable by
         # default; set VLLM_MI100_TORCH_COMPILE=1 to re-enable.
         if _ON_MI100:
-            mi100_compile = os.environ.get(
-                "VLLM_MI100_TORCH_COMPILE", "0"
-            ) == "1"
+            mi100_compile = os.environ.get("VLLM_MI100_TORCH_COMPILE", "0") == "1"
             if not mi100_compile and (
                 compilation_config.mode is None
                 or compilation_config.mode != CompilationMode.NONE
@@ -799,9 +797,7 @@ class RocmPlatform(Platform):
             # Keep FULL_DECODE_ONLY as the default. Set
             # VLLM_MI100_ALLOW_PIECEWISE=1 to opt in when re-testing or when
             # upstream graph-piece fusion improves.
-            allow_piecewise = os.environ.get(
-                "VLLM_MI100_ALLOW_PIECEWISE", "0"
-            ) == "1"
+            allow_piecewise = os.environ.get("VLLM_MI100_ALLOW_PIECEWISE", "0") == "1"
             if not allow_piecewise and (
                 compilation_config.cudagraph_mode is None
                 or compilation_config.cudagraph_mode
@@ -816,9 +812,7 @@ class RocmPlatform(Platform):
                     "needs lower max_model_len to fit KV cache). "
                     "Set VLLM_MI100_ALLOW_PIECEWISE=1 to override."
                 )
-                compilation_config.cudagraph_mode = (
-                    CUDAGraphMode.FULL_DECODE_ONLY
-                )
+                compilation_config.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
         use_aiter_fused_moe = rocm_aiter_ops.is_fused_moe_enabled()
         use_aiter_fp8_linear = rocm_aiter_ops.is_linear_fp8_enabled()
         use_aiter_fused_se = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -254,6 +254,7 @@ def get_tokenizer(
         model_type in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS
     )
     if use_tokenizers_backend_override:
+        assert model_type is not None
         concrete_qualname = _MODEL_TYPE_TO_TOKENIZER_CLASS_OVERRIDE.get(model_type)
         if concrete_qualname is not None:
             # Load the specific fast tokenizer class this model's processor
@@ -270,14 +271,19 @@ def get_tokenizer(
             # attributes (e.g., max_chars_per_token).
             try:
                 from transformers.tokenization_utils_tokenizers import (
-                    TokenizersBackend as _Tk,
+                    TokenizersBackend,
                 )
+
+                _Tk = TokenizersBackend
             except ImportError:
-                from transformers import PreTrainedTokenizerFast as _Tk
+                from transformers import PreTrainedTokenizerFast
+
+                _Tk = PreTrainedTokenizerFast
 
         logger.debug(
             "Overriding tokenizer_class to %s for model_type=%r",
-            _Tk.__name__, model_type,
+            _Tk.__name__,
+            model_type,
         )
         tokenizer_cls_ = _Tk
     elif tokenizer_cls == TokenizerLike:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -227,9 +227,7 @@ class HFConfigParser(ConfigParserBase):
             # (e.g. minimax-m2). Load config.json from the GGUF directory
             # directly; vLLM has its own GGUF loader that reads tensors.
             if "is not supported yet" in str(e) and "gguf_file" in kwargs:
-                gguf_kwargs = {
-                    k: v for k, v in kwargs.items() if k != "gguf_file"
-                }
+                gguf_kwargs = {k: v for k, v in kwargs.items() if k != "gguf_file"}
                 config_dict, _ = PretrainedConfig.get_config_dict(
                     model,
                     revision=revision,
@@ -318,9 +316,7 @@ class HFConfigParser(ConfigParserBase):
                     # architectures (e.g. minimax-m2). Fall back to loading
                     # config.json from the GGUF directory; vLLM has its own
                     # GGUF loader that reads tensors from the .gguf file.
-                    gguf_kwargs = {
-                        k: v for k, v in kwargs.items() if k != "gguf_file"
-                    }
+                    gguf_kwargs = {k: v for k, v in kwargs.items() if k != "gguf_file"}
                     config = AutoConfig.from_pretrained(
                         model,
                         trust_remote_code=trust_remote_code,
@@ -701,9 +697,7 @@ def maybe_override_with_speculators(
         # (e.g. minimax-m2). Skip speculator detection in that case;
         # vLLM's own GGUF loader handles the model separately.
         if "is not supported yet" in str(e) and gguf_model_repo is not None:
-            logger.info(
-                "Skipping speculator detection for GGUF model: %s", e
-            )
+            logger.info("Skipping speculator detection for GGUF model: %s", e)
             return model, tokenizer, vllm_speculative_config
         raise
     speculators_config = config_dict.get("speculators_config")

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -22,7 +22,6 @@ from vllm.v1.attention.backend import (
     AttentionLayer,
     AttentionType,
     MultipleOf,
-    is_quantized_kv_cache,  # noqa: F811
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
 

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -54,9 +54,7 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     ROCM_AITER_FA = (
         "vllm.v1.attention.backends.rocm_aiter_fa.AiterFlashAttentionBackend"
     )
-    ROCM_CK_FA = (
-        "vllm.v1.attention.backends.rocm_ck_fa.RocmCKFlashAttentionBackend"
-    )
+    ROCM_CK_FA = "vllm.v1.attention.backends.rocm_ck_fa.RocmCKFlashAttentionBackend"
     ROCM_AITER_MLA_SPARSE = (
         "vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse.ROCMAiterMLASparseBackend"
     )

--- a/vllm/v1/attention/backends/rocm_ck_fa.py
+++ b/vllm/v1/attention/backends/rocm_ck_fa.py
@@ -113,7 +113,12 @@ class RocmCKFlashAttentionBackend(AttentionBackend):
         return (num_blocks, 2, block_size, num_kv_heads, head_size)
 
     @staticmethod
-    def get_kv_cache_stride_order() -> tuple[int, ...]:
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        if include_num_layers_dimension:
+            # (num_blocks, num_layers, 2, block_size, num_kv_heads, head_size)
+            return (1, 0, 2, 3, 4, 5)
         return (0, 1, 2, 3, 4)
 
     @staticmethod
@@ -190,9 +195,13 @@ class RocmCKFlashAttentionImpl(AttentionImpl):
             if alibi_slopes is not None
             else None
         )
-        self.sliding_window = (-1, -1) if sliding_window is None else (
-            sliding_window - 1,
-            0,
+        self.sliding_window = (
+            (-1, -1)
+            if sliding_window is None
+            else (
+                sliding_window - 1,
+                0,
+            )
         )
         self.kv_cache_dtype = kv_cache_dtype
         self.logits_soft_cap = logits_soft_cap or 0.0

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -52,9 +52,11 @@ logger = init_logger(__name__)
 def _get_mi100_tuned_constants():
     if current_platform.is_rocm():
         from vllm.platforms.rocm import on_mi100
+
         if on_mi100():
             return 64, 8
     return 128, 16
+
 
 MIN_LAUNCH_GRID_SIZE_2D, NUM_PAR_SOFTMAX_SEGMENTS = _get_mi100_tuned_constants()
 
@@ -128,7 +130,6 @@ def _compute_flash_decoding_splits(
             return split_count
 
     return FLASH_DECODING_SPLIT_COUNTS[-1]
-
 
 
 @dataclass
@@ -274,14 +275,12 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q,
-             self.max_flash_decoding_splits),
+            (self.seq_threshold_3D, self.num_heads_q, self.max_flash_decoding_splits),
             dtype=torch.float32,
             device=device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q,
-             self.max_flash_decoding_splits),
+            (self.seq_threshold_3D, self.num_heads_q, self.max_flash_decoding_splits),
             dtype=torch.float32,
             device=device,
         )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -182,13 +182,12 @@ def get_block_size(dtype: torch.dtype) -> int:
         return 32
     if current_platform.is_rocm():
         from vllm.platforms.rocm import on_mi100
+
         if on_mi100():
             # MI100 has 64KB LDS per CU. With head_dim=256, block=128
             # requires 128*256*2=64KB for Q alone, exceeding LDS budget.
             return 64
-    if current_platform.is_cuda_alike() and current_platform.has_device_capability(
-        80
-    ):
+    if current_platform.is_cuda_alike() and current_platform.has_device_capability(80):
         return 128
     return 64
 

--- a/vllm/v1/attention/ops/triton_turboquant_decode.py
+++ b/vllm/v1/attention/ops/triton_turboquant_decode.py
@@ -651,7 +651,7 @@ def triton_turboquant_decode_attention(
         # for every token, the stage2 output equals out_orig @ PiT. Recover the
         # original-space output with the inverse rotation out @ Pi (= out @ PiT.T).
         # Output rows = B×Hq is small at decode, so the dense GEMM is cheapest.
-        inv = Pi if Pi is not None else PiT.T.contiguous()
+        inv = Pi
         rotated = (output.float() @ inv).to(output.dtype)
         output.copy_(rotated)
 

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -759,6 +759,7 @@ def _get_tile_size(
 
     if current_platform.is_rocm():
         from vllm.platforms.rocm import on_mi100
+
         if on_mi100():
             return 32
 
@@ -971,6 +972,7 @@ def unified_attention(
         from vllm.v1.attention.backends.triton_attn import (
             _compute_flash_decoding_splits,
         )
+
         num_segments = _compute_flash_decoding_splits(
             max_seq_len=max_seqlen_k,
             num_seqs=num_seqs,
@@ -1083,4 +1085,3 @@ def unified_attention(
             NUM_SEGMENTS_PER_SEQ=num_segments,
             USE_FP8=output_scale is not None,
         )
-


### PR DESCRIPTION
## Problem

The CI `pre-commit` job runs hooks with `--all-files` (`.github/workflows/pre-commit.yml`), so **accumulated lint/type debt on the `mi100-fixes` base branch failed every PR**, regardless of what that PR changed — even a docs-only PR (#76). The base was never gated this way (the `push` trigger only runs on `main`, which this fork doesn't use), so debt piled up unchecked. This clears all 13 failing hooks so PRs can start going green.

## What changed

**ruff-check / ruff-format**
- Fixed B023 (lambda loop-var binding), E501, E402, and F-codes.
- Formatted the tree with the **pinned ruff 0.14.0** (CI's version).
- Excluded vendored `vllm/third_party/**` from ruff (lint-ignored already, but format still rewrote the 4490-line `pynvml.py`).

**mypy (3.10–3.13)** — 19 real type errors in `vllm/` source:
- None-narrowing asserts (turboquant rotations / marlin / turboquant decode)
- `str | Path` widening in `weight_utils._get_gguf_shard_files`
- `_Tk` redefinition + dict-key narrowing in `tokenizers/registry.py`
- removed a bad duplicate `is_quantized_kv_cache` import in `flashinfer_mla.py`
- fixed `get_kv_cache_stride_order` override signature in `rocm_ck_fa.py`
- generator fixture return type in a test

**markdownlint** — added code-fence languages (MD040), fixed MD036/MD025/MD028/MD024/MD051, removed one verbatim-duplicated block; disabled cosmetic **MD060** (1402 table-spacing hits) in `.markdownlint.yaml`, consistent with the already-disabled MD013/MD033/MD046/MD052/MD059.

**typos** — fixed real typos (`satifactory`, `mis-aligned`); allowlisted false positives in `pyproject.toml` (code identifiers `relm`/`DELT`, test token `abd`, two hex-hash fragments) and excluded captured `*.log` files.

**check-forbidden-imports** — `import re` → `import regex as re`; `import triton` → `from vllm.triton_utils import ...`.

**check-torch-cuda-call** — `torch.cuda.{empty_cache,synchronize,device_count}` → `torch.accelerator.*` (per RFC #30679).

**Auto-fixers** — SPDX headers, clang-format (10 C++ files), attention-backend-docs regeneration.

## Why this is not a duplicate

This addresses the fork's own CI debt on `mi100-fixes`; it does not overlap any upstream PR.

## Tests run

```
pre-commit run --all-files --hook-stage manual
```

All 29 hooks pass (verified locally with pinned hook versions via `uvx pre-commit`, including the LTS-node markdownlint and ruff 0.14.0).

## Note on scope

138 files changed; the bulk is docs/markdown plus the SPDX/clang-format auto-fixes. The substantive code changes are the ~21 `vllm/` files (mypy) and the import/API rewrites in tests/scripts/benchmarks.

AI assistance (Claude) was used for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ROCm CK Flash Attention backend support.
  * Backend KV-cache stride ordering now optionally includes a per-layer dimension.

* **Bug Fixes**
  * Added runtime validation for rotation parameters.
  * Fixed inverse-rotation fallback behavior for turboquant decode.

* **Documentation**
  * Numerous architecture, integration, benchmarking, and validation docs reformatted and clarified.

* **Testing & Infrastructure**
  * Benchmark and test scripts updated for broader accelerator compatibility and improved formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->